### PR TITLE
Fix icij/datashare url that was 404ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to `pfi` in the code. Under development since 2017, it's written in Scala and Ty
 is maintained by the Investigations & Reporting team.
 
 If Giant doesn't fit your needs, check out [Aleph](https://github.com/alephdata/aleph/) from
-the OCCRP and [Datashare](github.com/icij/datashare) from the ICIJ.
+the OCCRP and [Datashare](https://github.com/icij/datashare) from the ICIJ.
 
 ## (Users) Getting started
 


### PR DESCRIPTION
Was previously relative, this makes it absolute so it goes to the right place..

![image](https://user-images.githubusercontent.com/638051/119158904-9f6f0280-ba4e-11eb-92e8-43f3e60692be.png)