### PR TITLE
OCR temp folder fixes

### DIFF
--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -47,7 +47,7 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
 
     try {
       pdDocuments = params.languages.map { lang =>
-        val pdfPath = Ocr.invokeOcrMyPdf(lang.ocr, file.getAbsolutePath, None, stderr, tmpDir)
+        val pdfPath = Ocr.invokeOcrMyPdf(lang.ocr, file.toPath, None, stderr, tmpDir)
         val pdfDoc = PDDocument.load(pdfPath.toFile)
 
         lang -> (pdfPath, pdfDoc)

--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -40,7 +40,7 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
       throw new IllegalStateException("Image OCR Extractor requires a language")
     }
 
-    val tmpDir = scratch.createWorkingDir(s"ocrmypdf-tmp-${blob.uri}")
+    val tmpDir = scratch.createWorkingDir(s"ocrmypdf-tmp-${blob.uri.value}")
 
     val stderr = mutable.Buffer.empty[String]
     var pdDocuments: Map[Language, (Path, PDDocument)] = Map.empty

--- a/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
@@ -40,7 +40,7 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
       throw new IllegalStateException("Image OCR Extractor requires a language")
     }
 
-    val tmpDir = scratch.createWorkingDir(s"ocrmypdf-tmp-${blob.uri}")
+    val tmpDir = scratch.createWorkingDir(s"ocrmypdf-tmp-${blob.uri.value}")
     val stderr = mutable.Buffer.empty[String]
 
     try {

--- a/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
@@ -65,7 +65,7 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
   }
 
   private def invokeOcrMyPdf(blobUri: Uri, lang: Language, file: File, config: OcrConfig, stderr: mutable.Buffer[String], tmpDir: Path): String = {
-    val pdfFile = Ocr.invokeOcrMyPdf(lang.ocr, file.getAbsolutePath, Some(config.dpi), stderr, tmpDir)
+    val pdfFile = Ocr.invokeOcrMyPdf(lang.ocr, file.toPath, Some(config.dpi), stderr, tmpDir)
     var document: PDDocument = null
 
     try {

--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -47,9 +47,9 @@ object Ocr {
 
   // TODO MRB: allow OcrMyPdf to read DPI if set in metadata
   // OCRmyPDF is a wrapper for Tesseract that we use to overlay the OCR as a text layer in the resulting PDF
-  def invokeOcrMyPdf(lang: String, inputFileName: String, dpi: Option[Int], stderr: mutable.Buffer[String], tmpDir: Path): Path = {
-    val tempFile = Files.createTempFile("ocrmypdf", ".pdf")
-    val cmd = s"ocrmypdf --redo-ocr -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${inputFileName} ${tempFile.toAbsolutePath}"
+  def invokeOcrMyPdf(lang: String, inputFilePath: Path, dpi: Option[Int], stderr: mutable.Buffer[String], tmpDir: Path): Path = {
+    val tempFile = tmpDir.resolve(s"${inputFilePath.getFileName}.ocr.pdf")
+    val cmd = s"ocrmypdf --redo-ocr -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${inputFilePath.toAbsolutePath} ${tempFile.toAbsolutePath}"
 
     val stdout = mutable.Buffer.empty[String]
     val process = Process(cmd, cwd = None, extraEnv = "TMPDIR" -> tmpDir.toAbsolutePath.toString)


### PR DESCRIPTION
Follow up to #3 which set `TMPDIR` for OCRmyPDF:

- Remove `Uri( )` toString wrapper from temporary file name
- Write the output PDF to the same scratch directory we pass as `TMPDIR`