### PR TITLE
Reprocess blob endpoint

### DIFF
--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -11,6 +11,7 @@ DELETE        /api/collections/:collection/:ingestion                       cont
 POST          /api/collections/:collection/:ingestion/verifyFiles           controllers.api.Collections.verifyFiles(collection, ingestion)
 
 GET           /api/blobs                                                    controllers.api.Blobs.getBlobs
+POST          /api/blobs/:id/reprocess                                      controllers.api.Blobs.reprocess(id, rerunSuccessfulParam: Option[Boolean])
 DELETE        /api/blobs/:id                                                controllers.api.Blobs.delete(id)
 
 GET           /api/filters                                                  controllers.api.Filters.getFilters


### PR DESCRIPTION
We have an endpoint to reprocess everything in a workspace but sometimes it's better to just reprocess a single blob, especially if OCR is involved which can be quite slow.

The new endpoint has a query parameter `rerunSuccessful` which can be set to false to only re-run failed extractors. The default is true though to match how the existing reprocess workspace endpoint works.

To be consistent with the delete blobs API, this endpoint requires you have administrator access. Currently there is no UI so you must trigger it manually, through cURL with a token or through the `pfi-cli`:

```
pfi-cli api --verb POST /api/blobs/<blob id>/reprocess
```