### PR TITLE
Incremental OCR logging and retry OCR after deploy (again)

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -138,9 +138,9 @@ class AppComponents(context: Context, config: Config)
     val mboxExtractor = new MBoxEmailExtractor(emlParser)
 
     val tesseractPdfOcrExtractor = new TesseractPdfOcrExtractor(config.ocr, scratchSpace, esResources, esPages, ingestionServices)
-    val ocrMyPdfExtractor = new OcrMyPdfExtractor(scratchSpace, esResources, esPages, previewStorage)
-    val imageOcrExtractor = new ImageOcrExtractor(config.ocr, scratchSpace, esResources)
-    val ocrMyPdfImageExtractor = new OcrMyPdfImageExtractor(config.ocr, scratchSpace, esResources, previewStorage)
+    val ocrMyPdfExtractor = new OcrMyPdfExtractor(scratchSpace, esResources, esPages, previewStorage, ingestionServices)
+    val imageOcrExtractor = new ImageOcrExtractor(config.ocr, scratchSpace, esResources, ingestionServices)
+    val ocrMyPdfImageExtractor = new OcrMyPdfImageExtractor(config.ocr, scratchSpace, esResources, previewStorage, ingestionServices)
 
     val ocrExtractors = config.ocr.defaultEngine match {
       case OcrEngine.OcrMyPdf => List(ocrMyPdfExtractor, ocrMyPdfImageExtractor)

--- a/backend/app/extraction/ocr/BaseOcrExtractor.scala
+++ b/backend/app/extraction/ocr/BaseOcrExtractor.scala
@@ -1,0 +1,36 @@
+package extraction.ocr
+
+import extraction.{ExtractionParams, FileExtractor}
+import model.manifest.Blob
+import services.ScratchSpace
+import utils.Ocr.OcrSubprocessInterruptedException
+import utils.OcrStderrLogger
+import utils.attempt.{Failure, SubprocessInterruptedFailure}
+
+import java.io.File
+import scala.util.control.NonFatal
+
+abstract class BaseOcrExtractor(scratchSpace: ScratchSpace) extends FileExtractor(scratchSpace) {
+  def extractOcr(blob: Blob, file: File, params: ExtractionParams, stdErrLogger: OcrStderrLogger): Unit
+  def buildStdErrLogger(blob: Blob): OcrStderrLogger
+
+  final override def extract(blob: Blob, file: File, params: ExtractionParams): Either[Failure, Unit] = {
+    if (params.languages.isEmpty) {
+      throw new IllegalStateException(s"${this.name} requires a language")
+    }
+
+    val stdErrLogger = buildStdErrLogger(blob)
+
+    try {
+      extractOcr(blob, file, params, stdErrLogger)
+      Right(())
+    } catch {
+      case OcrSubprocessInterruptedException =>
+        Left(SubprocessInterruptedFailure)
+
+      case NonFatal(e) =>
+        // Throw exception here instead of returning Left to include stderr and preserve the original stack trace
+        throw new IllegalStateException(s"${this.name} error ${stdErrLogger.getOutput}", e)
+    }
+  }
+}

--- a/backend/app/extraction/ocr/ImageOcrExtractor.scala
+++ b/backend/app/extraction/ocr/ImageOcrExtractor.scala
@@ -1,23 +1,22 @@
 package extraction.ocr
 
-import extraction.{ExtractionParams, FileExtractor}
+import extraction.ExtractionParams
 import model.manifest.{Blob, MimeType}
 import services.index.Index
 import services.ingestion.IngestionServices
 import services.{OcrConfig, ScratchSpace}
-import utils.Ocr.OcrSubprocessInterruptedException
 import utils.attempt.AttemptAwait._
-import utils.attempt.{Failure, SubprocessInterruptedFailure}
 import utils.{Logging, Ocr, OcrStderrLogger}
 
 import java.io.File
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.control.NonFatal
 
 // I've avoided renaming this for compatibility reasons (the extractor name is stored in the Manifest).
 // It should now be called TesseractImageOcrExtractor
-class ImageOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends FileExtractor(scratch) with Logging {
+class ImageOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, ingestionServices: IngestionServices)
+  (implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
+
   val mimeTypes = Set(
     "image/png",
     "image/jpeg",
@@ -33,27 +32,15 @@ class ImageOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, 
     100 * size
   }
 
-  override def extract(blob: Blob, file: File, params: ExtractionParams): Either[Failure, Unit] = {
-    if (params.languages.isEmpty) {
-      throw new IllegalStateException("Image OCR Extractor requires a language")
-    }
+  override def buildStdErrLogger(blob: Blob): OcrStderrLogger = {
+    new OcrStderrLogger(Some(ingestionServices.setProgressNote(blob.uri, this, _)))
+  }
 
-    val stdErrLogger = new OcrStderrLogger(Some(ingestionServices.setProgressNote(blob.uri, this, _)))
-
-    try {
-      params.languages.foreach { lang =>
-        val text = Ocr.invokeTesseractDirectly(lang.ocr, file.getAbsolutePath, config.tesseract, stdErrLogger)
-        val optionalText = if (text.trim().isEmpty) None else Some(text)
-        index.addDocumentOcr(blob.uri, optionalText, lang).awaitEither(10.second)
-      }
-
-      Right(())
-    } catch {
-      case OcrSubprocessInterruptedException =>
-        Left(SubprocessInterruptedFailure)
-
-      case NonFatal(e) =>
-        throw e
+  override def extractOcr(blob: Blob, file: File, params: ExtractionParams, stdErrLogger: OcrStderrLogger): Unit = {
+    params.languages.foreach { lang =>
+      val text = Ocr.invokeTesseractDirectly(lang.ocr, file.getAbsolutePath, config.tesseract, stdErrLogger)
+      val optionalText = if (text.trim().isEmpty) None else Some(text)
+      index.addDocumentOcr(blob.uri, optionalText, lang).awaitEither(10.second)
     }
   }
 }

--- a/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
@@ -10,16 +10,19 @@ import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.text.PDFTextStripper
 import services.index.Index
 import services._
+import services.ingestion.IngestionServices
+import utils.Ocr.OcrSubprocessInterruptedException
 import utils.attempt.AttemptAwait._
-import utils.attempt.Failure
-import utils.{Logging, Ocr}
+import utils.attempt.{Failure, SubprocessInterruptedFailure}
+import utils.{Logging, Ocr, OcrStderrLogger}
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, previewStorage: ObjectStorage)(implicit ec: ExecutionContext) extends FileExtractor(scratch) with Logging {
+class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, previewStorage: ObjectStorage,
+  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends FileExtractor(scratch) with Logging {
   val mimeTypes = Set(
     "image/png",
     "image/jpeg",
@@ -41,7 +44,7 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
     }
 
     val tmpDir = scratch.createWorkingDir(s"ocrmypdf-tmp-${blob.uri}")
-    val stderr = mutable.Buffer.empty[String]
+    val stderr = new OcrStderrLogger(Some(ingestionServices.setProgressNote(blob.uri, this, _)))
 
     try {
       params.languages.foreach { lang =>
@@ -52,19 +55,17 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
 
       Right(())
     } catch {
+      case OcrSubprocessInterruptedException =>
+        Left(SubprocessInterruptedFailure)
+
       case NonFatal(e) =>
-        throw new IllegalStateException(s"ImageOcrExtractor error ${stderr.mkString("\n")}", e)
+        throw new IllegalStateException(s"ImageOcrExtractor error ${stderr.getOutput}", e)
     } finally {
       FileUtils.deleteDirectory(tmpDir.toFile)
-
-      if(stderr.nonEmpty) {
-        logger.info(s"OCR output for ${blob.uri}")
-        logger.info(stderr.mkString("\n"))
-      }
     }
   }
 
-  private def invokeOcrMyPdf(blobUri: Uri, lang: Language, file: File, config: OcrConfig, stderr: mutable.Buffer[String], tmpDir: Path): String = {
+  private def invokeOcrMyPdf(blobUri: Uri, lang: Language, file: File, config: OcrConfig, stderr: OcrStderrLogger, tmpDir: Path): String = {
     val pdfFile = Ocr.invokeOcrMyPdf(lang.ocr, file.getAbsolutePath, Some(config.dpi), stderr, tmpDir)
     var document: PDDocument = null
 

--- a/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
@@ -1,28 +1,24 @@
 package extraction.ocr
 
-import java.io.{File, InputStream}
-import java.nio.file.{Files, Path}
-import extraction.{ExtractionParams, Extractor, FileExtractor}
+import extraction.ExtractionParams
 import model.manifest.{Blob, MimeType}
 import model.{Language, Uri}
 import org.apache.commons.io.FileUtils
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.text.PDFTextStripper
-import services.index.Index
 import services._
+import services.index.Index
 import services.ingestion.IngestionServices
-import utils.Ocr.OcrSubprocessInterruptedException
 import utils.attempt.AttemptAwait._
-import utils.attempt.{Failure, SubprocessInterruptedFailure}
 import utils.{Logging, Ocr, OcrStderrLogger}
 
-import scala.collection.mutable
+import java.io.File
+import java.nio.file.{Files, Path}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.control.NonFatal
 
 class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, previewStorage: ObjectStorage,
-  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends FileExtractor(scratch) with Logging {
+  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
   val mimeTypes = Set(
     "image/png",
     "image/jpeg",
@@ -38,28 +34,19 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
     100 * size
   }
 
-  override def extract(blob: Blob, file: File, params: ExtractionParams): Either[Failure, Unit] = {
-    if (params.languages.isEmpty) {
-      throw new IllegalStateException("Image OCR Extractor requires a language")
-    }
+  override def buildStdErrLogger(blob: Blob): OcrStderrLogger = {
+    new OcrStderrLogger(Some(ingestionServices.setProgressNote(blob.uri, this, _)))
+  }
 
+  override def extractOcr(blob: Blob, file: File, params: ExtractionParams, stdErrLogger: OcrStderrLogger): Unit = {
     val tmpDir = scratch.createWorkingDir(s"ocrmypdf-tmp-${blob.uri}")
-    val stderr = new OcrStderrLogger(Some(ingestionServices.setProgressNote(blob.uri, this, _)))
 
     try {
       params.languages.foreach { lang =>
-        val text = invokeOcrMyPdf(blob.uri, lang, file, config, stderr, tmpDir)
+        val text = invokeOcrMyPdf(blob.uri, lang, file, config, stdErrLogger, tmpDir)
         val optionalText = if (text.trim().isEmpty) None else Some(text)
         index.addDocumentOcr(blob.uri, optionalText, lang).awaitEither(10.second)
       }
-
-      Right(())
-    } catch {
-      case OcrSubprocessInterruptedException =>
-        Left(SubprocessInterruptedFailure)
-
-      case NonFatal(e) =>
-        throw new IllegalStateException(s"ImageOcrExtractor error ${stderr.getOutput}", e)
     } finally {
       FileUtils.deleteDirectory(tmpDir.toFile)
     }

--- a/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
+++ b/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
@@ -15,7 +15,7 @@ import services.{OcrConfig, ScratchSpace}
 import utils.Ocr.OcrSubprocessInterruptedException
 import utils.attempt.AttemptAwait._
 import utils.attempt.{Failure, SubprocessInterruptedFailure}
-import utils.{Logging, Ocr}
+import utils.{Logging, Ocr, OcrStderrLogger}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -48,7 +48,7 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
       throw new IllegalStateException("Image OCR Extractor requires a language")
     }
 
-    val stderr = mutable.Buffer.empty[String]
+    val stderr = new OcrStderrLogger(None) // this extractor manually sets the progress note
     var document: PDDocument = null
 
     try {
@@ -99,11 +99,6 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
     } finally {
       Option(document).foreach(_.close())
       cleanup(file)
-
-      if(stderr.nonEmpty) {
-        logger.info(s"OCR output for ${blob.uri}")
-        logger.info(stderr.mkString("\n"))
-      }
     }
   }
 

--- a/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
+++ b/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
@@ -1,31 +1,24 @@
 package extraction.ocr
 
-import java.io.{File, InputStream}
-import java.nio.file.{Files, Paths}
-import extraction.{ExtractionParams, Extractor, FileExtractor}
+import extraction.ExtractionParams
 import model.index.{Page, PageDimensions}
 import model.manifest.{Blob, MimeType}
-import model.{Language, Uri}
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.rendering.{ImageType, PDFRenderer}
 import org.apache.pdfbox.tools.imageio.ImageIOUtil
 import services.index.{Index, Pages}
 import services.ingestion.IngestionServices
 import services.{OcrConfig, ScratchSpace}
-import utils.Ocr.OcrSubprocessInterruptedException
-import utils.attempt.AttemptAwait._
-import utils.attempt.{Failure, SubprocessInterruptedFailure}
 import utils.{Logging, Ocr, OcrStderrLogger}
 
-import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
+import java.io.File
+import java.nio.file.{Files, Paths}
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-import scala.util.control.NonFatal
 
 // We could also use this as a possible fallback option after the primary OcrMyPdfExtractor, which
 // doesn't ocr as many docs (e.g. it respects encryption of PDFs)
-class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, pageService: Pages, ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends FileExtractor(scratch) with Logging {
+class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, pageService: Pages,
+  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
   val mimeTypes = Set(
     "application/pdf"
   )
@@ -43,12 +36,11 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
     100 * size
   }
 
-  override def extract(blob: Blob, file: File, params: ExtractionParams): Either[Failure, Unit] = {
-    if (params.languages.isEmpty) {
-      throw new IllegalStateException("Image OCR Extractor requires a language")
-    }
+  override def buildStdErrLogger(blob: Blob): OcrStderrLogger = {
+    new OcrStderrLogger(None) // this extractor manually sets the progress note
+  }
 
-    val stderr = new OcrStderrLogger(None) // this extractor manually sets the progress note
+  override def extractOcr(blob: Blob, file: File, params: ExtractionParams, stdErrLogger: OcrStderrLogger): Unit = {
     var document: PDDocument = null
 
     try {
@@ -74,7 +66,7 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
 
         val pageTextByLanguage = params.languages.map { lang =>
           ingestionServices.setProgressNote(blob.uri, this, s"Page ${pageNumber + 1}/${totalPages} (${lang.key})")
-          val text = Ocr.invokeTesseractDirectly(lang.ocr, imageFileName, config.tesseract, stderr)
+          val text = Ocr.invokeTesseractDirectly(lang.ocr, imageFileName, config.tesseract, stdErrLogger)
 
           lang -> text
         }
@@ -88,14 +80,6 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
 
       pageService.addPageContents(blob.uri, pages)
       OcrMyPdfExtractor.insertFullText(blob.uri, pages, index)
-
-      Right(())
-    } catch {
-      case OcrSubprocessInterruptedException =>
-        Left(SubprocessInterruptedFailure)
-
-      case NonFatal(e) =>
-        throw e
     } finally {
       Option(document).foreach(_.close())
       cleanup(file)

--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -1,12 +1,26 @@
 package utils
 
 import java.nio.file.{Files, Path}
-
 import services.TesseractOcrConfig
+import utils.attempt.Failure
 
 import scala.collection.mutable
 import scala.sys.process._
 
+class OcrStderrLogger(setProgressNote: Option[String => Either[Failure, Unit]]) extends Logging {
+  val acc = mutable.Buffer[String]()
+
+  def append(line: String): Unit = {
+    acc.append(line)
+
+    logger.info(line)
+    setProgressNote.foreach(f => f(line))
+  }
+
+  def getOutput: String = {
+    acc.mkString("\n")
+  }
+}
 
 object Ocr {
   class OcrSubprocessCrashedException(exitCode: Int, stderr: String) extends Exception(s"Exit code: $exitCode: ${stderr}")
@@ -26,11 +40,11 @@ object Ocr {
   object OcrMyPdfOtherError extends Exception("Some other error occurred.")
   object OcrMyPdfCtrlC extends Exception("The program was interrupted by pressing Ctrl+C.")
 
-  def invokeTesseractDirectly(lang: String, imageFileName: String, config: TesseractOcrConfig, stderr: mutable.Buffer[String]): String = {
+  def invokeTesseractDirectly(lang: String, imageFileName: String, config: TesseractOcrConfig, stderr: OcrStderrLogger): String = {
     val cmd = s"tesseract $imageFileName stdout -l $lang --oem ${config.engineMode} --psm ${config.pageSegmentationMode}"
 
     val stdout = mutable.Buffer.empty[String]
-    val exitCode = Process(cmd).!(ProcessLogger(stdout.append(_), stderr.append(_)))
+    val exitCode = Process(cmd).!(ProcessLogger(stdout.append(_), stderr.append))
 
     exitCode match {
       case 143 =>
@@ -41,19 +55,19 @@ object Ocr {
         stdout.mkString("\n")
 
       case _ =>
-        throw new OcrSubprocessCrashedException(exitCode, stderr.mkString("\n"))
+        throw new OcrSubprocessCrashedException(exitCode, stderr.getOutput)
     }
   }
 
   // TODO MRB: allow OcrMyPdf to read DPI if set in metadata
   // OCRmyPDF is a wrapper for Tesseract that we use to overlay the OCR as a text layer in the resulting PDF
-  def invokeOcrMyPdf(lang: String, inputFileName: String, dpi: Option[Int], stderr: mutable.Buffer[String], tmpDir: Path): Path = {
+  def invokeOcrMyPdf(lang: String, inputFileName: String, dpi: Option[Int], stderr: OcrStderrLogger, tmpDir: Path): Path = {
     val tempFile = Files.createTempFile("ocrmypdf", ".pdf")
     val cmd = s"ocrmypdf --redo-ocr -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${inputFileName} ${tempFile.toAbsolutePath}"
 
     val stdout = mutable.Buffer.empty[String]
     val process = Process(cmd, cwd = None, extraEnv = "TMPDIR" -> tmpDir.toAbsolutePath.toString)
-    val exitCode = process.!(ProcessLogger(stdout.append(_), stderr.append(_)))
+    val exitCode = process.!(ProcessLogger(stdout.append(_), stderr.append))
 
     exitCode match {
       // 0: success


### PR DESCRIPTION
Other OCR extractors catch the subprocess dying (such as during a Riff-Raff deploy) and don't mark it as a failure so the work can be picked up by a future worker. Unfortunately we didn't include this behaviour for the OCRmyPDF extractors. This PR adds it back in a base class to try and make it less likely we regress this again. Ideally we'd have integration tests for it too but this is a decent first step.

It also adds incremental logging for stderr of the subprocess. Before we only logged once everything was complete and it was impossible to get a sense of how far through OCRing a very large PDF we were.

Bonus feature, the last stderr log line is passed through the client as a progress note:

https://user-images.githubusercontent.com/395805/119389744-ed407080-bcc3-11eb-8fe6-9413d1a0bab5.mov
