### PR TITLE
Log blob URI in extractor failure

### DIFF
--- a/backend/app/extraction/Worker.scala
+++ b/backend/app/extraction/Worker.scala
@@ -110,7 +110,7 @@ class Worker(
   }
 
   private def markAsFailure(blob: Blob, extractor: Extractor, failure: Failure): Unit = {
-    logger.error(s"Error in extractor '${extractor.name}': ${failure.msg}")
+    logger.error(s"Error in '${extractor.name} processing ${blob.uri.value}': ${failure.msg}")
 
     manifest.logExtractionFailure(blob.uri, extractor.name, failure.msg).left.foreach { f =>
       logger.error(s"Failed to log extractor in manifest: ${f.msg}")


### PR DESCRIPTION
Without this you have to dig back through the logs for a particular worker instance to find the corresponding "Working on XYZ" log message. For big OCR jobs this could be hours ago.