### PR TITLE
Do not alarm on failure to parse token

### DIFF
--- a/backend/app/utils/auth/AuthActionBuilder.scala
+++ b/backend/app/utils/auth/AuthActionBuilder.scala
@@ -1,5 +1,7 @@
 package utils.auth
 
+import pdi.jwt.JwtSession
+
 import java.time.{Clock, Instant, LocalDateTime, ZoneId, ZoneOffset}
 import pdi.jwt.JwtSession._
 import play.api.Configuration
@@ -74,37 +76,29 @@ class DefaultAuthActionBuilder(val controllerComponents: ControllerComponents, f
   private[auth] def invokeBlockWithTime[A](request: Request[A], block: (UserIdentityRequest[A]) => Future[Result],
                                            now: Long): Future[Either[Failure, Result]] = {
     implicit val implicitReq = request
-    val claimData = request.jwtSession.claimData
 
-    val maybeToken = claimData.validate[Token]
-    maybeToken match {
-      case (JsSuccess(token, _)) if token.loginExpiry > now =>
-        handleValidUnexpiredToken(token, request, block, now)
+    // Why can't we do request.jwtSession.isEmpty?
+    // Because request.jwtSession gets initialised with some default properties if there's no
+    // actual JWT token in the request. This seems a little odd to me, but it's in the pdi.jwt
+    // library so we can't control this behaviour.
+    if (request.headers.get(JwtSession.REQUEST_HEADER_NAME).isEmpty) {
+      val msg = s"No token in request"
+      logger.warn(msg)
+      Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
+    } else {
+      val claimData = request.jwtSession.claimData
+      val maybeToken = claimData.validate[Token]
+      maybeToken match {
+        case (JsSuccess(token, _)) if token.loginExpiry > now =>
+          handleValidUnexpiredToken(token, request, block, now)
 
-      case JsSuccess(token, _) => {
-        val msg = s"Token is older than $maxLoginAge"
-        logger.info(token.user.asLogMarker, msg)
-        Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
-      }
-
-      case JsError(errors) => {
-        // It would be nice to just call request.jwtSession.isEmpty right at the top,
-        // instead of all this. But request.jwtSession gets initialised with some default
-        // properties if there's no actual JWT token in the request (which seems a little
-        // odd to me, but it's in the pdi.jwt library so we can't control this behaviour).
-        val isTokenMissing = errors.forall {
-          case (_, pathErrors) =>
-            pathErrors.forall {
-              case JsonValidationError(messages) => messages.forall(_ == "error.path.missing")
-              case _ => false
-            }
-          case _ => false
-        }
-        if (isTokenMissing) {
-          val msg = s"No token in request"
-          logger.warn(msg)
+        case JsSuccess(token, _) => {
+          val msg = s"Token is older than $maxLoginAge"
+          logger.info(token.user.asLogMarker, msg)
           Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
-        } else {
+        }
+
+        case JsError(errors) => {
           val msg = s"Failed to parse token: $errors"
           logger.warn(msg)
           Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = true)))

--- a/backend/app/utils/auth/AuthActionBuilder.scala
+++ b/backend/app/utils/auth/AuthActionBuilder.scala
@@ -37,62 +37,56 @@ class DefaultAuthActionBuilder(val controllerComponents: ControllerComponents, f
                                            now: Long): Future[Either[Failure, Result]] = {
     implicit val implicitReq = request
     val claimData = request.jwtSession.claimData
-    if (request.jwtSession.isEmpty) {
-      val msg = "No token in request"
-      logger.warn(msg)
-      Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
-    } else {
-      val maybeToken = claimData.validate[Token]
-      maybeToken match {
-        case (JsSuccess(token, _)) if token.loginExpiry > now =>
-          val isVerificationExpired = token.verificationExpiry <= now
-          for {
-            maybeDbUser <- if (isVerificationExpired) getUser(token.user.username).asFuture else Future.successful(Left(AuthenticationFailure("Verification hasn't expired", reportAsFailure = true)))
-            result <- block(new AuthenticatedRequest(token.user, request))
-          } yield {
-            if (isVerificationExpired) {
-              maybeDbUser match {
-                case Right(user) if user.invalidationTime.exists(token.issuedAt < _) =>
-                  // The user has logged out
-                  val msg = s"Authenticated failed because token was issued before database invalidation time"
-                  logger.warn(token.user.asLogMarker, msg)
-                  Left(AuthenticationFailure(msg, reportAsFailure = true))
-                case Left(failure) =>
-                  logger.error(token.user.asLogMarker, "Authentication failed because user was not found in DB", failure.toThrowable)
-                  Left(failure)
-                case Right(_) =>
-                  val verificationExpiry = now + maxVerificationAge.toMillis
-                  val expiryDateTime = LocalDateTime.ofInstant(
-                    Instant.ofEpochMilli(verificationExpiry),
-                    ZoneId.systemDefault()
-                  )
-                  logger.info(token.user.asLogMarker, s"Authentication succeeded, verification expired but token renewed. New verification expiry: ${expiryDateTime}")
-                  Right(result
-                    .refreshJwtSession
-                    .addingToJwtSession(Token.VERIFICATION_EXPIRY_KEY, verificationExpiry)
-                    .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
-                  )
-              }
-            } else {
-              logger.info(token.user.asLogMarker, s"Authentication succeeded")
-              Right(result
-                .refreshJwtSession
-                .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
-              )
+    val maybeToken = claimData.validate[Token]
+    maybeToken match {
+      case (JsSuccess(token, _)) if token.loginExpiry > now =>
+        val isVerificationExpired = token.verificationExpiry <= now
+        for {
+          maybeDbUser <- if (isVerificationExpired) getUser(token.user.username).asFuture else Future.successful(Left(AuthenticationFailure("Verification hasn't expired", reportAsFailure = true)))
+          result <- block(new AuthenticatedRequest(token.user, request))
+        } yield {
+          if (isVerificationExpired) {
+            maybeDbUser match {
+              case Right(user) if user.invalidationTime.exists(token.issuedAt < _) =>
+                // The user has logged out
+                val msg = s"Authenticated failed because token was issued before database invalidation time"
+                logger.warn(token.user.asLogMarker, msg)
+                Left(AuthenticationFailure(msg, reportAsFailure = true))
+              case Left(failure) =>
+                logger.error(token.user.asLogMarker, "Authentication failed because user was not found in DB", failure.toThrowable)
+                Left(failure)
+              case Right(_) =>
+                val verificationExpiry = now + maxVerificationAge.toMillis
+                val expiryDateTime = LocalDateTime.ofInstant(
+                  Instant.ofEpochMilli(verificationExpiry),
+                  ZoneId.systemDefault()
+                )
+                logger.info(token.user.asLogMarker, s"Authentication succeeded, verification expired but token renewed. New verification expiry: ${expiryDateTime}")
+                Right(result
+                  .refreshJwtSession
+                  .addingToJwtSession(Token.VERIFICATION_EXPIRY_KEY, verificationExpiry)
+                  .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
+                )
             }
+          } else {
+            logger.info(token.user.asLogMarker, s"Authentication succeeded")
+            Right(result
+              .refreshJwtSession
+              .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
+            )
           }
-
-        case JsSuccess(token, _) => {
-          val msg = s"Token is older than $maxLoginAge"
-          logger.info(token.user.asLogMarker, msg)
-          Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
         }
 
-        case JsError(errors) => {
-          val msg = s"Failed to parse token: $errors"
-          logger.warn(msg)
-          Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = true)))
-        }
+      case JsSuccess(token, _) => {
+        val msg = s"Token is older than $maxLoginAge"
+        logger.info(token.user.asLogMarker, msg)
+        Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
+      }
+
+      case JsError(errors) => {
+        val msg = s"Failed to parse token: $errors"
+        logger.warn(msg)
+        Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = true)))
       }
     }
   }

--- a/backend/app/utils/auth/AuthActionBuilder.scala
+++ b/backend/app/utils/auth/AuthActionBuilder.scala
@@ -1,9 +1,10 @@
 package utils.auth
 
 import java.time.{Clock, Instant, LocalDateTime, ZoneId, ZoneOffset}
+
 import pdi.jwt.JwtSession._
 import play.api.Configuration
-import play.api.libs.json.{JsError, JsSuccess, JsonValidationError}
+import play.api.libs.json.{JsError, JsSuccess}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 import services.users.UserManagement
@@ -32,79 +33,62 @@ class DefaultAuthActionBuilder(val controllerComponents: ControllerComponents, f
       case Left(err) => failureToResultMapper.failureToResult(err)
     }
 
-  private def handleValidUnexpiredToken[A](token: Token, request: Request[A], block: (UserIdentityRequest[A]) => Future[Result], now: Long)(implicit requestHeader: RequestHeader): Future[Either[Failure, Result]] = {
-    val isVerificationExpired = token.verificationExpiry <= now
-    for {
-      maybeDbUser <- if (isVerificationExpired) getUser(token.user.username).asFuture else Future.successful(Left(AuthenticationFailure("Verification hasn't expired", reportAsFailure = true)))
-      result <- block(new AuthenticatedRequest(token.user, request))
-    } yield {
-      if (isVerificationExpired) {
-        maybeDbUser match {
-          case Right(user) if user.invalidationTime.exists(token.issuedAt < _) =>
-            // The user has logged out
-            val msg = s"Authenticated failed because token was issued before database invalidation time"
-            logger.warn(token.user.asLogMarker, msg)
-            Left(AuthenticationFailure(msg, reportAsFailure = true))
-          case Left(failure) =>
-            logger.error(token.user.asLogMarker, "Authentication failed because user was not found in DB", failure.toThrowable)
-            Left(failure)
-          case Right(_) =>
-            val verificationExpiry = now + maxVerificationAge.toMillis
-            val expiryDateTime = LocalDateTime.ofInstant(
-              Instant.ofEpochMilli(verificationExpiry),
-              ZoneId.systemDefault()
-            )
-            logger.info(token.user.asLogMarker, s"Authentication succeeded, verification expired but token renewed. New verification expiry: ${expiryDateTime}")
-            Right(result
-              .refreshJwtSession
-              .addingToJwtSession(Token.VERIFICATION_EXPIRY_KEY, verificationExpiry)
-              .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
-            )
-        }
-      } else {
-        logger.info(token.user.asLogMarker, s"Authentication succeeded")
-        Right(result
-          .refreshJwtSession
-          .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
-        )
-      }
-    }
-  }
-
   private[auth] def invokeBlockWithTime[A](request: Request[A], block: (UserIdentityRequest[A]) => Future[Result],
                                            now: Long): Future[Either[Failure, Result]] = {
     implicit val implicitReq = request
     val claimData = request.jwtSession.claimData
-
-    val maybeToken = claimData.validate[Token]
-    maybeToken match {
-      case (JsSuccess(token, _)) if token.loginExpiry > now =>
-        handleValidUnexpiredToken(token, request, block, now)
-
-      case JsSuccess(token, _) => {
-        val msg = s"Token is older than $maxLoginAge"
-        logger.info(token.user.asLogMarker, msg)
-        Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
-      }
-
-      case JsError(errors) => {
-        // It would be nice to just call request.jwtSession.isEmpty right at the top,
-        // instead of all this. But request.jwtSession gets initialised with some default
-        // properties if there's no actual JWT token in the request (which seems a little
-        // odd to me, but it's in the pdi.jwt library so we can't control this behaviour).
-        val isTokenMissing = errors.forall {
-          case (_, pathErrors) =>
-            pathErrors.forall {
-              case JsonValidationError(messages) => messages.forall(_ == "error.path.missing")
-              case _ => false
+    if (request.jwtSession.isEmpty) {
+      val msg = "No token in request"
+      logger.warn(msg)
+      Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
+    } else {
+      val maybeToken = claimData.validate[Token]
+      maybeToken match {
+        case (JsSuccess(token, _)) if token.loginExpiry > now =>
+          val isVerificationExpired = token.verificationExpiry <= now
+          for {
+            maybeDbUser <- if (isVerificationExpired) getUser(token.user.username).asFuture else Future.successful(Left(AuthenticationFailure("Verification hasn't expired", reportAsFailure = true)))
+            result <- block(new AuthenticatedRequest(token.user, request))
+          } yield {
+            if (isVerificationExpired) {
+              maybeDbUser match {
+                case Right(user) if user.invalidationTime.exists(token.issuedAt < _) =>
+                  // The user has logged out
+                  val msg = s"Authenticated failed because token was issued before database invalidation time"
+                  logger.warn(token.user.asLogMarker, msg)
+                  Left(AuthenticationFailure(msg, reportAsFailure = true))
+                case Left(failure) =>
+                  logger.error(token.user.asLogMarker, "Authentication failed because user was not found in DB", failure.toThrowable)
+                  Left(failure)
+                case Right(_) =>
+                  val verificationExpiry = now + maxVerificationAge.toMillis
+                  val expiryDateTime = LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(verificationExpiry),
+                    ZoneId.systemDefault()
+                  )
+                  logger.info(token.user.asLogMarker, s"Authentication succeeded, verification expired but token renewed. New verification expiry: ${expiryDateTime}")
+                  Right(result
+                    .refreshJwtSession
+                    .addingToJwtSession(Token.VERIFICATION_EXPIRY_KEY, verificationExpiry)
+                    .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
+                  )
+              }
+            } else {
+              logger.info(token.user.asLogMarker, s"Authentication succeeded")
+              Right(result
+                .refreshJwtSession
+                .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
+              )
             }
-          case _ => false
-        }
-        if (isTokenMissing) {
-          val msg = s"No token in request"
-          logger.warn(msg)
+          }
+
+        case JsSuccess(token, _) => {
+          val msg = s"Token is older than $maxLoginAge"
+          logger.info(token.user.asLogMarker, msg)
           Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
-        } else {
+        }
+
+        case JsError(errors) => {
           val msg = s"Failed to parse token: $errors"
           logger.warn(msg)
           Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = true)))

--- a/backend/app/utils/auth/AuthActionBuilder.scala
+++ b/backend/app/utils/auth/AuthActionBuilder.scala
@@ -1,10 +1,9 @@
 package utils.auth
 
 import java.time.{Clock, Instant, LocalDateTime, ZoneId, ZoneOffset}
-
 import pdi.jwt.JwtSession._
 import play.api.Configuration
-import play.api.libs.json.{JsError, JsSuccess}
+import play.api.libs.json.{JsError, JsSuccess, JsonValidationError}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 import services.users.UserManagement
@@ -33,62 +32,79 @@ class DefaultAuthActionBuilder(val controllerComponents: ControllerComponents, f
       case Left(err) => failureToResultMapper.failureToResult(err)
     }
 
+  private def handleValidUnexpiredToken[A](token: Token, request: Request[A], block: (UserIdentityRequest[A]) => Future[Result], now: Long)(implicit requestHeader: RequestHeader): Future[Either[Failure, Result]] = {
+    val isVerificationExpired = token.verificationExpiry <= now
+    for {
+      maybeDbUser <- if (isVerificationExpired) getUser(token.user.username).asFuture else Future.successful(Left(AuthenticationFailure("Verification hasn't expired", reportAsFailure = true)))
+      result <- block(new AuthenticatedRequest(token.user, request))
+    } yield {
+      if (isVerificationExpired) {
+        maybeDbUser match {
+          case Right(user) if user.invalidationTime.exists(token.issuedAt < _) =>
+            // The user has logged out
+            val msg = s"Authenticated failed because token was issued before database invalidation time"
+            logger.warn(token.user.asLogMarker, msg)
+            Left(AuthenticationFailure(msg, reportAsFailure = true))
+          case Left(failure) =>
+            logger.error(token.user.asLogMarker, "Authentication failed because user was not found in DB", failure.toThrowable)
+            Left(failure)
+          case Right(_) =>
+            val verificationExpiry = now + maxVerificationAge.toMillis
+            val expiryDateTime = LocalDateTime.ofInstant(
+              Instant.ofEpochMilli(verificationExpiry),
+              ZoneId.systemDefault()
+            )
+            logger.info(token.user.asLogMarker, s"Authentication succeeded, verification expired but token renewed. New verification expiry: ${expiryDateTime}")
+            Right(result
+              .refreshJwtSession
+              .addingToJwtSession(Token.VERIFICATION_EXPIRY_KEY, verificationExpiry)
+              .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
+            )
+        }
+      } else {
+        logger.info(token.user.asLogMarker, s"Authentication succeeded")
+        Right(result
+          .refreshJwtSession
+          .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
+        )
+      }
+    }
+  }
+
   private[auth] def invokeBlockWithTime[A](request: Request[A], block: (UserIdentityRequest[A]) => Future[Result],
                                            now: Long): Future[Either[Failure, Result]] = {
     implicit val implicitReq = request
     val claimData = request.jwtSession.claimData
-    if (request.jwtSession.isEmpty) {
-      val msg = "No token in request"
-      logger.warn(msg)
-      Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
-    } else {
-      val maybeToken = claimData.validate[Token]
-      maybeToken match {
-        case (JsSuccess(token, _)) if token.loginExpiry > now =>
-          val isVerificationExpired = token.verificationExpiry <= now
-          for {
-            maybeDbUser <- if (isVerificationExpired) getUser(token.user.username).asFuture else Future.successful(Left(AuthenticationFailure("Verification hasn't expired", reportAsFailure = true)))
-            result <- block(new AuthenticatedRequest(token.user, request))
-          } yield {
-            if (isVerificationExpired) {
-              maybeDbUser match {
-                case Right(user) if user.invalidationTime.exists(token.issuedAt < _) =>
-                  // The user has logged out
-                  val msg = s"Authenticated failed because token was issued before database invalidation time"
-                  logger.warn(token.user.asLogMarker, msg)
-                  Left(AuthenticationFailure(msg, reportAsFailure = true))
-                case Left(failure) =>
-                  logger.error(token.user.asLogMarker, "Authentication failed because user was not found in DB", failure.toThrowable)
-                  Left(failure)
-                case Right(_) =>
-                  val verificationExpiry = now + maxVerificationAge.toMillis
-                  val expiryDateTime = LocalDateTime.ofInstant(
-                    Instant.ofEpochMilli(verificationExpiry),
-                    ZoneId.systemDefault()
-                  )
-                  logger.info(token.user.asLogMarker, s"Authentication succeeded, verification expired but token renewed. New verification expiry: ${expiryDateTime}")
-                  Right(result
-                    .refreshJwtSession
-                    .addingToJwtSession(Token.VERIFICATION_EXPIRY_KEY, verificationExpiry)
-                    .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
-                  )
-              }
-            } else {
-              logger.info(token.user.asLogMarker, s"Authentication succeeded")
-              Right(result
-                .refreshJwtSession
-                .addingToJwtSession(Token.REFRESHED_AT_KEY, now)
-              )
+
+    val maybeToken = claimData.validate[Token]
+    maybeToken match {
+      case (JsSuccess(token, _)) if token.loginExpiry > now =>
+        handleValidUnexpiredToken(token, request, block, now)
+
+      case JsSuccess(token, _) => {
+        val msg = s"Token is older than $maxLoginAge"
+        logger.info(token.user.asLogMarker, msg)
+        Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
+      }
+
+      case JsError(errors) => {
+        // It would be nice to just call request.jwtSession.isEmpty right at the top,
+        // instead of all this. But request.jwtSession gets initialised with some default
+        // properties if there's no actual JWT token in the request (which seems a little
+        // odd to me, but it's in the pdi.jwt library so we can't control this behaviour).
+        val isTokenMissing = errors.forall {
+          case (_, pathErrors) =>
+            pathErrors.forall {
+              case JsonValidationError(messages) => messages.forall(_ == "error.path.missing")
+              case _ => false
             }
-          }
-
-        case JsSuccess(token, _) => {
-          val msg = s"Token is older than $maxLoginAge"
-          logger.info(token.user.asLogMarker, msg)
-          Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
+          case _ => false
         }
-
-        case JsError(errors) => {
+        if (isTokenMissing) {
+          val msg = s"No token in request"
+          logger.warn(msg)
+          Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
+        } else {
           val msg = s"Failed to parse token: $errors"
           logger.warn(msg)
           Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = true)))

--- a/backend/app/utils/auth/AuthActionBuilder.scala
+++ b/backend/app/utils/auth/AuthActionBuilder.scala
@@ -86,7 +86,11 @@ class DefaultAuthActionBuilder(val controllerComponents: ControllerComponents, f
       case JsError(errors) => {
         val msg = s"Failed to parse token: $errors"
         logger.warn(msg)
-        Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = true)))
+        // This error happens whenever the token is missing,
+        // as a result of vulnerability scanners and occasionally developer testing/debugging
+        // (e.g. just opening https://giant.pfi.gutools.co.uk/api/search in your browser will fire this alarm).
+        // For this reason we don't want to get an alarm.
+        Future.successful(Left(AuthenticationFailure(msg, reportAsFailure = false)))
       }
     }
   }

--- a/backend/test/utils/auth/AuthActionBuilderTest.scala
+++ b/backend/test/utils/auth/AuthActionBuilderTest.scala
@@ -106,7 +106,7 @@ class AuthActionBuilderTest extends AnyFreeSpec with Matchers with BaseOneAppPer
         }
         inside (result.left.value) {
           case uf: HiddenFailure =>
-            uf.actualMessage should startWith ("Failed to parse token: ")
+            uf.actualMessage should be ("No token in request")
         }
       }
 

--- a/backend/test/utils/auth/AuthActionBuilderTest.scala
+++ b/backend/test/utils/auth/AuthActionBuilderTest.scala
@@ -106,7 +106,7 @@ class AuthActionBuilderTest extends AnyFreeSpec with Matchers with BaseOneAppPer
         }
         inside (result.left.value) {
           case uf: HiddenFailure =>
-            uf.actualMessage should be ("No token in request")
+            uf.actualMessage should startWith ("Failed to parse token: ")
         }
       }
 


### PR DESCRIPTION
We shouldn't alarm on "failed to parse token", since this happens whenever the token is missing, as a result of vulnerability scanners and occasionally developer testing/debugging (e.g. just opening https://giant.pfi.gutools.co.uk/api/search in your browser will fire this alarm). We get spurious alarms most weeks because of this