### PR TITLE
Always close s3 client in putObjectSync

### DIFF
--- a/backend/app/utils/aws/S3Client.scala
+++ b/backend/app/utils/aws/S3Client.scala
@@ -40,7 +40,11 @@ class S3Client(config: S3Config)(implicit executionContext: ExecutionContext) {
     val metadata = createMetadata(contentType, Some(contentLength))
     val request = new PutObjectRequest(bucket, key, is, metadata)
 
-    aws.putObject(request)
+    try {
+      aws.putObject(request)
+    } finally {
+      is.close()
+    }
   }
 
   def putObjectSync(bucket: String, key: String, contentType: Option[String], file: Path): PutObjectResult = {


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/pfi/pull/924 and a recent error on PROD when trying to upload a file to giant, this makes sure that post putObject the input stream for the object gets closed.

UPDATE: Sadly, this function is never actually called so can't be responsible for the issue. Probably worth fixing though in case we use it in future

Here's the stacktrace from earlier today

```
AWS Sdk Failure: com.amazonaws.SdkClientException: Unable to execute HTTP request: Timeout waiting for connection from pool
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleRetryableException(AmazonHttpClient.java:1175)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1121)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:770)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:744)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:726)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:686)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:668)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:532)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:512)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4920)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4866)
	at com.amazonaws.services.s3.AmazonS3Client.access$300(AmazonS3Client.java:389)
	at com.amazonaws.services.s3.AmazonS3Client$PutObjectStrategy.invokeServiceCall(AmazonS3Client.java:5800)
	at com.amazonaws.services.s3.AmazonS3Client.uploadObject(AmazonS3Client.java:1789)
	at com.amazonaws.services.s3.AmazonS3Client.putObject(AmazonS3Client.java:1749)
	at com.amazonaws.services.s3.transfer.internal.UploadCallable.uploadInOneChunk(UploadCallable.java:131)
	at com.amazonaws.services.s3.transfer.internal.UploadCallable.call(UploadCallable.java:123)
	at com.amazonaws.services.s3.transfer.internal.UploadMonitor.call(UploadMonitor.java:143)
	at com.amazonaws.services.s3.transfer.internal.UploadMonitor.call(UploadMonitor.java:48)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.http.conn.ConnectionPoolTimeoutException: Timeout waiting for connection from pool
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.leaseConnection(PoolingHttpClientConnectionManager.java:316)
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager$1.get(PoolingHttpClientConnectionManager.java:282)
	at sun.reflect.GeneratedMethodAccessor14.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.amazonaws.http.conn.ClientConnectionRequestFactory$Handler.invoke(ClientConnectionRequestFactory.java:70)
	at com.amazonaws.http.conn.$Proxy9.get(Unknown Source)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:190)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
	at com.amazonaws.http.apache.client.impl.SdkHttpClient.execute(SdkHttpClient.java:72)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1297)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1113)
	... 21 more
```