### PR TITLE
Correct es link in dev tools

### DIFF
--- a/frontend/src/js/components/viewer/DocumentMetadata.js
+++ b/frontend/src/js/components/viewer/DocumentMetadata.js
@@ -78,10 +78,10 @@ export class DocumentMetadata extends React.Component {
                 <li className='sidebar__list-item'>
                     <div className='sidebar__list-title'>elasticsearch</div>
                     <div className='sidebar__list-value'>
-                        <a target='_blank' rel='noopener noreferrer' href={`http://localhost:9200/pfi/documents/${this.props.resource.uri}`}>dev</a>
+                        <a target='_blank' rel='noopener noreferrer' href={`http://localhost:9200/pfi/_doc/${this.props.resource.uri}`}>dev</a>
                     </div>
                     <div className='sidebar__list-value'>
-                        <a target='_blank' rel='noopener noreferrer' href={`http://localhost:19200/pfi/documents/${this.props.resource.uri}`}>prod</a>
+                        <a target='_blank' rel='noopener noreferrer' href={`http://localhost:19200/pfi/_doc/${this.props.resource.uri}`}>prod</a>
                     </div>
                 </li>
                 <li className='sidebar__list-item'>


### PR DESCRIPTION
I *think* these links should've changed when we upgraded to ES 7

https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html

> **Elasticsearch 7.x**
> Specifying types in requests is deprecated. For instance, indexing a document no longer requires a document type. 
> The new index APIs are PUT {index}/_doc/{id} in case of explicit ids and POST {index}/_doc for auto-generated ids. : > Note that in 7.0, _doc is a permanent part of the path, and represents the endpoint name rather than the document type.*