### PR TITLE
--skip-text not --redo-ocr

### DIFF
--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -72,7 +72,7 @@ object Ocr {
   // OCRmyPDF is a wrapper for Tesseract that we use to overlay the OCR as a text layer in the resulting PDF
   def invokeOcrMyPdf(lang: String, inputFilePath: Path, dpi: Option[Int], stderr: OcrStderrLogger, tmpDir: Path): Path = {
     val tempFile = tmpDir.resolve(s"${inputFilePath.getFileName}.ocr.pdf")
-    val cmd = s"ocrmypdf --redo-ocr -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${inputFilePath.toAbsolutePath} ${tempFile.toAbsolutePath}"
+    val cmd = s"ocrmypdf --skip-text -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${inputFilePath.toAbsolutePath} ${tempFile.toAbsolutePath}"
 
     val stdout = mutable.Buffer.empty[String]
     val process = Process(cmd, cwd = None, extraEnv = "TMPDIR" -> tmpDir.toAbsolutePath.toString)


### PR DESCRIPTION
We started using `--redo-ocr` in order to preserve original machine-readable text in a documents that contained it (rather than re-OCR-ing everything).  See https://github.com/guardian/pfi/pull/929, https://github.com/guardian/pfi/pull/893

However, here is https://ocrmypdf.readthedocs.io/en/latest/errors.html?highlight=redo-ocr#page-already-has-text:

> - `ocrmypdf --force-ocr` to rasterize all vector content and run OCR on the images. This is useful if a previous OCR program failed, or if the document contains a text watermark.
> - **`ocrmypdf --skip-text` to skip OCR and other processing on any pages that contain text. Text pages will be copied into the output PDF without modification.**
> - `ocrmypdf --redo-ocr` to scan the file for any existing OCR (non-printing text), remove it, and do OCR again. This is one way to take advantage of improvements in OCR accuracy. Printable vector text is excluded from OCR, so this can be used on files that contain a mix of digital and scanned files.

It looks like `--skip-text` achieves the same effect, except for individual pages that contain a mix of OCR & text (which are rare).

It looks like it is potentially faster because it can skip entire pages that have text in.

It also might avoid the `AttributeError: 'NoneType' object has no attribute 'userunit'` bug which affected 115 files in the legislation ingestion and is apparently [connected to use of `--redo-ocr`](https://github.com/jbarlow83/OCRmyPDF/issues/700). (See [full doc](https://docs.google.com/document/d/1E7ZME6bx4_DuZG3gkZY0fYc3jBd2ExOMeUmhfWGmd24/edit#heading=h.3e3cfzrdop5l) for more details).

So let's give `--skip-text` a chance!

