### PR TITLE
Add new metrics for ingest failures

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -154,7 +154,7 @@ class AppComponents(context: Context, config: Config)
     extractors.foreach(mimeTypeMapper.addExtractor)
 
     // Common components
-    val failureToResultMapper = config.aws.map(new CloudWatchReportingFailureToResultMapper(_)).getOrElse(new DefaultFailureToResultMapper)
+    val failureToResultMapper = config.aws.map(c => new CloudWatchReportingFailureToResultMapper(new MetricsService(c))).getOrElse(new DefaultFailureToResultMapper)
     val authActionBuilder = new DefaultAuthActionBuilder(controllerComponents, failureToResultMapper, config.auth.timeouts.maxLoginAge, config.auth.timeouts.maxVerificationAge, users)(configuration, Clock.systemUTC())
     val authControllerComponents = new AuthControllerComponents(authActionBuilder, failureToResultMapper, users, controllerComponents)
 

--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -153,7 +153,7 @@ class AppComponents(context: Context, config: Config)
     val extractors = List(olmExtractor, zipExtractor, rarExtractor, documentBodyExtractor, pstExtractor, emlExtractor, msgExtractor, mboxExtractor, csvTableExtractor, excelTableExtractor) ++ ocrExtractors
     extractors.foreach(mimeTypeMapper.addExtractor)
 
-    val metricsService = new MetricsService(config.aws)
+    val metricsService = config.aws.map(new CloudwatchMetricsService(_)).getOrElse(new DefaultMetricsService())
 
     // Common components
     val failureToResultMapper = new CloudWatchReportingFailureToResultMapper(metricsService)

--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -153,7 +153,7 @@ class AppComponents(context: Context, config: Config)
     val extractors = List(olmExtractor, zipExtractor, rarExtractor, documentBodyExtractor, pstExtractor, emlExtractor, msgExtractor, mboxExtractor, csvTableExtractor, excelTableExtractor) ++ ocrExtractors
     extractors.foreach(mimeTypeMapper.addExtractor)
 
-    val metricsService = config.aws.map(new CloudwatchMetricsService(_)).getOrElse(new DefaultMetricsService())
+    val metricsService = config.aws.map(new CloudwatchMetricsService(_)).getOrElse(new NoOpMetricsService())
 
     // Common components
     val failureToResultMapper = new CloudWatchReportingFailureToResultMapper(metricsService)

--- a/backend/app/extraction/Worker.scala
+++ b/backend/app/extraction/Worker.scala
@@ -88,7 +88,8 @@ class Worker(
 
         case Left(failure) =>
           markAsFailure(blob, extractor, failure)
-          failureToResultMapper.failureToResult(failure)
+          metricsService.updateCloudwatchMetric(Metrics.itemsFailed)
+          logger.warn(s"Ingest batch execution failure, ${failure.msg}", failure.toThrowable)
           completed
       }
     }

--- a/backend/app/extraction/Worker.scala
+++ b/backend/app/extraction/Worker.scala
@@ -35,7 +35,7 @@ class Worker(
       completed
     }.recoverWith {
       case err =>
-        metricsService.updateCloudwatchMetric(Metrics.batchesFailed)
+        metricsService.updateMetric(Metrics.batchesFailed)
         // on failure, fetchBatch just returns the first failure
         logger.error("Error executing batch", err)
         manifest.releaseLocks(name)
@@ -88,8 +88,8 @@ class Worker(
 
         case Left(failure) =>
           markAsFailure(blob, extractor, failure)
-          metricsService.updateCloudwatchMetric(Metrics.itemsFailed)
-          logger.warn(s"Ingest batch execution failure, ${failure.msg}", failure.toThrowable)
+          metricsService.updateMetric(Metrics.itemsFailed)
+          logger.error(s"Ingest batch execution failure, ${failure.msg}", failure.toThrowable)
           completed
       }
     }

--- a/backend/app/ingestion/phase2/IngestStorePolling.scala
+++ b/backend/app/ingestion/phase2/IngestStorePolling.scala
@@ -4,12 +4,13 @@ import java.nio.file.{Files, Path}
 import java.util.UUID
 import akka.actor.{ActorSystem, Cancellable}
 import cats.syntax.either._
+import com.amazonaws.services.cloudwatch.model.MetricDatum
+import extraction.Worker
 import model.Uri
 import model.ingestion.Key
 import services.ingestion.IngestionServices
-import services.{FingerprintServices, IngestStorage, ScratchSpace}
+import services.{FingerprintServices, IngestStorage, MetricUpdate, Metrics, MetricsService, ScratchSpace}
 import utils.attempt.{Attempt, Failure, UnknownFailure}
-import utils.controller.FailureToResultMapper
 import utils.{Logging, WorkerControl}
 
 import scala.concurrent.duration._
@@ -32,7 +33,7 @@ class IngestStorePolling(
   scratchSpace: ScratchSpace,
   ingestionServices: IngestionServices,
   batchSize: Int,
-  failureToResultMapper: FailureToResultMapper) extends Logging {
+  metricsService: MetricsService) extends Logging {
   implicit val workerContext: ExecutionContext = executionContext
 
   private val minimumWait = 10.second
@@ -58,7 +59,7 @@ class IngestStorePolling(
       val pollCompleteFuture: Future[FiniteDuration] = getNextBatch.fold(
         failure => {
           logger.warn(s"Failed to poll ingestion store $failure")
-          failureToResultMapper.failureToResult(failure)
+          metricsService.updateCloudwatchMetric(Metrics.batchesFailed)
           maximumWait
         },
         batch => {
@@ -71,12 +72,15 @@ class IngestStorePolling(
               val result = processKey(key)
               result match {
                 case Left(failure) =>
-                  failureToResultMapper.failureToResult(failure)
+                  metricsService.updateCloudwatchMetric(Metrics.itemsFailed)
                   logger.warn(s"Failed to process $key: $failure")
                 case _ => ingestStorage.delete(key)
               }
               result
             }.collect { case Right(success) => success }
+            metricsService.updateCloudwatchMetrics(List(
+              MetricUpdate(Metrics.itemsIngested, results.size),
+              MetricUpdate(Metrics.batchesIngested, 1)))
             logger.info(s"Processed ${results.size}. Checking for work again in $minimumWait")
             minimumWait
           }
@@ -86,13 +90,13 @@ class IngestStorePolling(
         case Success(pollDuration) => schedulePoll(pollDuration)
         case SFailure(NonFatal(t)) =>
           logger.error("Exception whilst processing ingestion batch", t)
-          failureToResultMapper.failureToResult(UnknownFailure(t))
+          metricsService.updateCloudwatchMetric(Metrics.batchesFailed)
           schedulePoll(maximumWait)
       }
     } catch {
       case NonFatal(t) =>
         logger.error("Exception whilst getting next batch from ingestion store", t)
-        failureToResultMapper.failureToResult(UnknownFailure(t))
+        metricsService.updateCloudwatchMetric(Metrics.batchesFailed)
         schedulePoll(maximumWait)
     }
   }

--- a/backend/app/services/MetricsService.scala
+++ b/backend/app/services/MetricsService.scala
@@ -29,28 +29,30 @@ object Metrics {
   }
 }
 
-class MetricsService(configOpt: Option[AWSDiscoveryConfig]) extends  Logging {
+trait MetricsService {
+  def updateCloudwatchMetrics(metrics:List[MetricUpdate]): Unit
+  def updateCloudwatchMetric(metricName: String, metricValue: Double = 1): Unit
+}
 
-  val defaultRegion = "eu-west-1"
+class DefaultMetricsService() extends MetricsService {
+  def updateCloudwatchMetrics(metrics:List[MetricUpdate]): Unit = Unit
+  def updateCloudwatchMetric(metricName: String, metricValue: Double = 1): Unit = Unit
+}
 
-  if (configOpt.isEmpty) {
-    logger.warn(s"No AWS discovery config provided to metrics service. Initialising service in default region $defaultRegion and without Stack/Stage dimensions.")
-  }
+class CloudwatchMetricsService(config: AWSDiscoveryConfig) extends MetricsService with Logging {
 
   private val credentials: AWSCredentialsProvider = AwsCredentials()
   private val cloudwatch: AmazonCloudWatch = AmazonCloudWatchClientBuilder.standard()
     .withCredentials(credentials)
-    .withRegion(configOpt.map(_.region).getOrElse(defaultRegion))
+    .withRegion(config.region)
     .build()
 
   // These must be exactly the same as in the alarm, without any additional dimensions.
   // CloudWatch will not aggregate custom metrics
-  private val dimensions = configOpt.map{ config =>
-    List(
+  private val dimensions = List(
       new Dimension().withName("Stack").withValue(config.stack),
       new Dimension().withName("Stage").withValue(config.stage)
     )
-  }.getOrElse(List())
 
   def updateCloudwatchMetrics(metrics:List[MetricUpdate]): Unit = {
     val metricsData = metrics.map(m => Metrics.metricDatum(m.name, dimensions, m.value))

--- a/backend/app/services/MetricsService.scala
+++ b/backend/app/services/MetricsService.scala
@@ -20,7 +20,7 @@ object Metrics {
   val failureToResultMapper = "ErrorsInGiantFailureToResultMapper"
 
 
-  def metricDatum(name: String, dimensions: List[Dimension], value: Double): MetricDatum = {
+  protected def metricDatum(name: String, dimensions: List[Dimension], value: Double): MetricDatum = {
     new MetricDatum()
       .withMetricName(name)
       .withTimestamp(new Date())
@@ -30,13 +30,13 @@ object Metrics {
 }
 
 trait MetricsService {
-  def updateCloudwatchMetrics(metrics:List[MetricUpdate]): Unit
-  def updateCloudwatchMetric(metricName: String, metricValue: Double = 1): Unit
+  def updateMetrics(metrics:List[MetricUpdate]): Unit
+  def updateMetric(metricName: String, metricValue: Double = 1): Unit
 }
 
-class DefaultMetricsService() extends MetricsService {
-  def updateCloudwatchMetrics(metrics:List[MetricUpdate]): Unit = Unit
-  def updateCloudwatchMetric(metricName: String, metricValue: Double = 1): Unit = Unit
+class NoOpMetricsService() extends MetricsService {
+  def updateMetrics(metrics:List[MetricUpdate]): Unit = Unit
+  def updateMetric(metricName: String, metricValue: Double = 1): Unit = Unit
 }
 
 class CloudwatchMetricsService(config: AWSDiscoveryConfig) extends MetricsService with Logging {
@@ -54,7 +54,7 @@ class CloudwatchMetricsService(config: AWSDiscoveryConfig) extends MetricsServic
       new Dimension().withName("Stage").withValue(config.stage)
     )
 
-  def updateCloudwatchMetrics(metrics:List[MetricUpdate]): Unit = {
+  def updateMetrics(metrics:List[MetricUpdate]): Unit = {
     val metricsData = metrics.map(m => Metrics.metricDatum(m.name, dimensions, m.value))
     try {
       val request = new PutMetricDataRequest()
@@ -71,6 +71,6 @@ class CloudwatchMetricsService(config: AWSDiscoveryConfig) extends MetricsServic
     }
   }
 
-  def updateCloudwatchMetric(metricName: String, metricValue: Double = 1): Unit =
-    updateCloudwatchMetrics(List(MetricUpdate(metricName, metricValue)))
+  def updateMetric(metricName: String, metricValue: Double = 1): Unit =
+    updateMetrics(List(MetricUpdate(metricName, metricValue)))
 }

--- a/backend/app/services/MetricsService.scala
+++ b/backend/app/services/MetricsService.scala
@@ -20,7 +20,7 @@ object Metrics {
   val failureToResultMapper = "ErrorsInGiantFailureToResultMapper"
 
 
-  protected def metricDatum(name: String, dimensions: List[Dimension], value: Double): MetricDatum = {
+  def metricDatum(name: String, dimensions: List[Dimension], value: Double): MetricDatum = {
     new MetricDatum()
       .withMetricName(name)
       .withTimestamp(new Date())

--- a/backend/app/services/MetricsService.scala
+++ b/backend/app/services/MetricsService.scala
@@ -1,0 +1,62 @@
+package services
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest}
+import utils.{AwsCredentials, Logging}
+
+import java.util.Date
+import scala.util.control.NonFatal
+
+case class MetricUpdate(name: String, value: Double)
+
+object Metrics {
+  val namespace = "PFI"
+
+  val itemsIngested = "IngestedItems"
+  val itemsFailed = "IngestItemsFailed"
+  val batchesIngested = "IngestBatchesIngested"
+  val batchesFailed = "IngestBatchesFailed"
+  val failureToResultMapper = "ErrorsInGiantFailureToResultMapper"
+
+
+  def metricDatum(name: String, dimensions: List[Dimension], value: Double): MetricDatum = {
+    new MetricDatum()
+      .withMetricName(name)
+      .withTimestamp(new Date())
+      .withDimensions(dimensions: _*)
+      .withValue(value)
+  }
+}
+
+class MetricsService(config: AWSDiscoveryConfig) extends Logging {
+  private val credentials: AWSCredentialsProvider = AwsCredentials()
+  private val cloudwatch: AmazonCloudWatch = AmazonCloudWatchClientBuilder.standard().withCredentials(credentials).withRegion(config.region).build()
+
+  // These must be exactly the same as in the alarm, without any additional dimensions.
+  // CloudWatch will not aggregate custom metrics
+  private val dimensions = List(
+    new Dimension().withName("Stack").withValue(config.stack),
+    new Dimension().withName("Stage").withValue(config.stage)
+  )
+
+  def updateCloudwatchMetrics(metrics:List[MetricUpdate]): Unit = {
+    val metricsData = metrics.map(m => Metrics.metricDatum(m.name, dimensions, m.value))
+    try {
+      val request = new PutMetricDataRequest()
+        .withNamespace(Metrics.namespace)
+        .withMetricData(
+          // As above, the metric must have the same unit as the alarm, in this case no unit
+          metricsData : _*
+        )
+
+      cloudwatch.putMetricData(request)
+   } catch {
+    case NonFatal(e) =>
+      logger.warn(s"Unable to report ${metrics.map(_.name).mkString(",")} to Cloudwatch", e)
+    }
+  }
+
+  def updateCloudwatchMetric(metricName: String, metricValue: Double = 1): Unit =
+    updateCloudwatchMetrics(List(MetricUpdate(metricName, metricValue)))
+}

--- a/backend/app/utils/controller/FailureToResultMapper.scala
+++ b/backend/app/utils/controller/FailureToResultMapper.scala
@@ -135,7 +135,7 @@ class CloudWatchReportingFailureToResultMapper(metricsService: MetricsService) e
       FailureToResultMapper.failureToResult(err, user)
 
     case _ =>
-      metricsService.updateCloudwatchMetric(Metrics.failureToResultMapper)
+      metricsService.updateMetric(Metrics.failureToResultMapper)
       FailureToResultMapper.failureToResult(err, user)
   }
 }

--- a/backend/app/utils/controller/FailureToResultMapper.scala
+++ b/backend/app/utils/controller/FailureToResultMapper.scala
@@ -7,7 +7,7 @@ import net.logstash.logback.marker.Markers.{aggregate, append}
 import play.api.http.HeaderNames
 import play.api.libs.json.JsError
 import play.api.mvc.{Result, Results}
-import services.AWSDiscoveryConfig
+import services.{AWSDiscoveryConfig, Metrics, MetricsService}
 import utils.attempt._
 import utils.auth.User
 import utils.{AwsCredentials, Logging}
@@ -118,11 +118,7 @@ class DefaultFailureToResultMapper extends FailureToResultMapper with Logging {
   }
 }
 
-class CloudWatchReportingFailureToResultMapper(config: AWSDiscoveryConfig) extends FailureToResultMapper with Logging {
-  val credentials = AwsCredentials()
-  val cloudwatch = AmazonCloudWatchClientBuilder.standard().withCredentials(credentials).withRegion(config.region).build()
-
-  val instanceId = EC2MetadataUtils.getInstanceId
+class CloudWatchReportingFailureToResultMapper(metricsService: MetricsService) extends FailureToResultMapper with Logging {
 
   override def failureToResult(err: Failure, user: Option[User]): Result = err match {
     // Don't alarm on expected authentication failures such as expired tokens.
@@ -139,35 +135,7 @@ class CloudWatchReportingFailureToResultMapper(config: AWSDiscoveryConfig) exten
       FailureToResultMapper.failureToResult(err, user)
 
     case _ =>
-      tryToReportToCloudWatch()
+      metricsService.updateCloudwatchMetric(Metrics.failureToResultMapper)
       FailureToResultMapper.failureToResult(err, user)
-  }
-
-  private def tryToReportToCloudWatch(): Unit = try {
-    val namespace = "PFI"
-    val metricName = "ErrorsInGiantFailureToResultMapper"
-
-    // These must be exactly the same as in the alarm, without any additional dimensions.
-    // CloudWatch will not aggregate custom metrics
-    val dimensions = List(
-      new Dimension().withName("Stack").withValue(config.stack),
-      new Dimension().withName("Stage").withValue(config.stage)
-    )
-
-    val request = new PutMetricDataRequest()
-      .withNamespace(namespace)
-      .withMetricData(
-        // As above, the metric must have the same unit as the alarm, in this case no unit
-        new MetricDatum()
-          .withMetricName(metricName)
-          .withTimestamp(new Date())
-          .withDimensions(dimensions: _*)
-          .withValue(1d)
-      )
-
-    cloudwatch.putMetricData(request)
-  } catch {
-    case NonFatal(e) =>
-      logger.warn("Unable to report failure to Cloudwatch", e)
   }
 }

--- a/backend/test/extraction/WorkerTest.scala
+++ b/backend/test/extraction/WorkerTest.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import model.manifest.{Blob, WorkItem}
 import model.{English, ObjectMetadata, Uri}
 import org.scalatest.EitherValues
-import services.ObjectStorage
+import services.{DefaultMetricsService, ObjectStorage}
 import services.manifest.Manifest.WorkCounts
 import services.manifest.WorkerManifest
 import utils.attempt.AttemptAwait._
@@ -89,7 +89,7 @@ class WorkerTest extends AnyFlatSpec with Matchers with EitherValues {
       override def delete(key: String): Either[Failure, Unit] = ???
     }
 
-    new Worker("test", manifest, blobStorage, extractors, new DefaultFailureToResultMapper)(scala.concurrent.ExecutionContext.global)
+    new Worker("test", manifest, blobStorage, extractors, new DefaultMetricsService)(scala.concurrent.ExecutionContext.global)
   }
 }
 

--- a/backend/test/extraction/WorkerTest.scala
+++ b/backend/test/extraction/WorkerTest.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import model.manifest.{Blob, WorkItem}
 import model.{English, ObjectMetadata, Uri}
 import org.scalatest.EitherValues
-import services.{DefaultMetricsService, ObjectStorage}
+import services.{NoOpMetricsService, ObjectStorage}
 import services.manifest.Manifest.WorkCounts
 import services.manifest.WorkerManifest
 import utils.attempt.AttemptAwait._
@@ -89,7 +89,7 @@ class WorkerTest extends AnyFlatSpec with Matchers with EitherValues {
       override def delete(key: String): Either[Failure, Unit] = ???
     }
 
-    new Worker("test", manifest, blobStorage, extractors, new DefaultMetricsService)(scala.concurrent.ExecutionContext.global)
+    new Worker("test", manifest, blobStorage, extractors, new NoOpMetricsService)(scala.concurrent.ExecutionContext.global)
   }
 }
 


### PR DESCRIPTION
## What does this change?
We recently performed a large ingest on giant. This resulted in a lot of alarms. The majority of these were triggered by the failuretoresultmapper metric - which alarms whenever there's more than 1 error. The link between worker errors and failuretoresultmapper was added in https://github.com/guardian/pfi/pull/925 in order to alarm when workers fail. However, grouping frontend errors (e.g. auth failure 5xx/4xx errors) that users experience with ingest errors isn't very helpful when it comes to setting a threshold for triggering an alarm on - as we have a small number of users we want to be notified for every time a user hits an error, but we don't want an alarm when, during a 10,000 file ingest there is a single failure.

This PR disconnects the workers from failuretoresultsmapper and instead adds 4 new metrics to try and capture ingest failures:
 - itemsIngested
 - itemsFailed
 - batchesIngested
 - batchesFailed

I'm not convinced about splitting these up into batches and items, but mixing them feels like a bad idea. The motiviation for measuring success as well as failures is so that we can see at a glance what proportion of files in an ingest are failing. This could be used to e.g. alarm when > 10% of stuff in an ingest fails - or we may still want to alarm on every worker failure

## How to test
I've tested this on playground using a small ingest and a manually generated dodgy PDF file and the metrics came out [as predicted](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2:graph=~(metrics~(~(~(expression~'100*2a*28m1*2fm2*29~label~'Expression1~id~'e1))~(~'PFI~'IngestItemsFailed~'Stage~'rex~'Stack~'pfi-playground~(id~'m1))~(~'.~'IngestedItems~'.~'.~'.~'.~(id~'m2)))~view~'timeSeries~stacked~false~region~'eu-west-1~start~'-PT1H~end~'P0D~stat~'Maximum~period~300);query=~'*7bPFI*2cStack*2cStage*7d).

A new alarm will be needed to maintain the existing alarm behaviour https://github.com/guardian/investigations-platform/pull/392


![ingest problems](https://media1.giphy.com/media/xT5LMqniIEWjVWo4Pm/giphy.gif)
