### PR TITLE
Bump Log4j Version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val compilerFlags = Seq(
 )
 
 val awsVersion = "1.11.566"
-val log4jVersion = "2.11.1"
+val log4jVersion = "2.15.0"
 // To match what the main app gets from scalatestplus-play transitively
 val scalatestVersion = "3.1.1"
 


### PR DESCRIPTION
Welcome to the JVM!

Doing a quick dependency tree check it looks like the only non-2.15.0 versions of log4j are excluded.

```
user@ubuntu:~/code/pfi/giant$ sbt coursierDependencyTree | grep log4j
├─ org.apache.logging.log4j:log4j-api:2.15.0
├─ org.apache.logging.log4j:log4j-core:2.15.0
│  └─ org.apache.logging.log4j:log4j-api:2.15.0
├─ org.apache.logging.log4j:log4j-to-slf4j:2.15.0
│  ├─ org.apache.logging.log4j:log4j-api:2.15.0
│  │  ├─ (excluded) log4j:log4j:1.2.17
│  │  └─ (excluded) org.slf4j:slf4j-log4j12:1.7.21
```