### PR TITLE
Upgrade log4j version to 2.17.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val compilerFlags = Seq(
 )
 
 val awsVersion = "1.11.566"
-val log4jVersion = "2.16.0"
+val log4jVersion = "2.17.0"
 // To match what the main app gets from scalatestplus-play transitively
 val scalatestVersion = "3.1.1"
 


### PR DESCRIPTION
Another log4j vulnerability has been identified - this one is high severity (instead of critical) but we should still upgrade within 14 days.

The version we're on (2.16) doesn't protect us from infinite recursion in lookup evaluation, meaning intentional recursive lookups could cause stack overflow errors that would lead to a crashing app (DOS attack).

More info here: https://logging.apache.org/log4j/2.x/index.html