### PR TITLE
Specify publicReadAcl in riffraff.yaml

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -63,4 +63,4 @@ deployments:
       bucket: investigations-public-dist
       cacheControl: private
       # This is the default but if you specify it explictly Riff-Raff issues a warning
-      # publicReadAcl: true
+      publicReadAcl: true


### PR DESCRIPTION
## What does this change?
This Pr sets the publicReadAcl in giants riffraff.yaml file now that this is a [required property](https://github.com/guardian/riff-raff/pull/665)