### PR TITLE
EmlParserImprovements

### DIFF
--- a/backend/app/extraction/email/eml/EmlParser.scala
+++ b/backend/app/extraction/email/eml/EmlParser.scala
@@ -15,7 +15,7 @@ import model.manifest.{Blob, MimeType}
 import org.apache.commons.io.FileUtils
 import services.ingestion.IngestionServices
 import services.{FingerprintServices, ScratchSpace}
-import utils.{DateTimeUtils, Logging}
+import utils.{HtmlToPlainText, DateTimeUtils, Logging}
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
@@ -49,8 +49,16 @@ class EmlParser(val scratch: ScratchSpace, val ingestionServices: IngestionServi
         val attachments = parts.filter(p => p.getEncoding == "base64" && getFilename(p).nonEmpty)
         val nonAttachments = parts.filter(p => getFilename(p).isEmpty)
 
-        val body: String = nonAttachments.find(_.getContentType.startsWith("text/plain")).map(_.getContent.asInstanceOf[String]).getOrElse("")
-        val html: Option[String] = nonAttachments.find(_.getContentType.startsWith("text/html"))
+        val bodyPart = nonAttachments.find(_.getContentType.toLowerCase().startsWith("text/plain"))
+        val htmlPart = nonAttachments.find(_.getContentType.toLowerCase().startsWith("text/html"))
+
+        val body = (bodyPart, htmlPart) match {
+          case (Some(body), _) => body.getContent.asInstanceOf[String]
+          case (None, Some(html)) => HtmlToPlainText.convert(html.getContent.asInstanceOf[String])
+          case _ => ""
+        }
+
+        val html: Option[String] = htmlPart
           .map(_.getContent.asInstanceOf[String])
           .map(Email.inlineAttachmentsIntoHtml(_, attachments.iterator)(a =>
             Option(a.getContentID).map { id =>

--- a/backend/app/extraction/email/eml/EmlParser.scala
+++ b/backend/app/extraction/email/eml/EmlParser.scala
@@ -46,7 +46,7 @@ class EmlParser(val scratch: ScratchSpace, val ingestionServices: IngestionServi
           .collect { case p: MimeBodyPart => p }
           .flatMap(flattenMultipart)
 
-        val attachments = parts.filter(p => p.getEncoding == "base64" && getFilename(p).nonEmpty)
+        val attachments = parts.filter(p => p.getEncoding.toLowerCase() == "base64" && getFilename(p).nonEmpty)
         val nonAttachments = parts.filter(p => getFilename(p).isEmpty)
 
         val bodyPart = nonAttachments.find(_.getContentType.toLowerCase().startsWith("text/plain"))


### PR DESCRIPTION
make eml parser case insensitive with the multipart mimetypes and use the html block if there is no plain text
