### PR TITLE
Do close the streams

### DIFF
--- a/backend/app/commands/GetPages.scala
+++ b/backend/app/commands/GetPages.scala
@@ -37,6 +37,7 @@ class GetPages(uri: Uri, top: Double, bottom: Double, query: Option[String], use
         highlights <- if(metadata.hasHighlights) {
           addSearchHighlightsToPageResponse(pageNumber, pagePreviewPdf, metadata.pageText)
         } else {
+          pagePreviewPdf.close()
           Attempt.Right(List.empty)
         }
       } yield {


### PR DESCRIPTION
The hunt is over.

There was a stream which we were opening and, on a certain branch later on, not closing.

This was manifesting in prod as a totally different part of the application running out of streams which lead me on a wild goose chase into Akka HTTPs streaming result implementation - bit of a waste of time but I learnt a lot.

Honestly this entire bit of code could do with a rewrite, we get the preview from storage and then at the end decide to return `List.empty` if the metadata has no highlights. But for now I'll do this and we can restructure later.