### PR TITLE
JDeb packaging symlink fix

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -228,7 +228,8 @@ class AppComponents(context: Context, config: Config)
       usersController,
       authController,
       appController,
-      genesisController
+      genesisController,
+      assets
     )
   } catch {
     case NonFatal(e) =>

--- a/backend/app/controllers/frontend/App.scala
+++ b/backend/app/controllers/frontend/App.scala
@@ -18,10 +18,6 @@ class App (components: ControllerComponents, assets: Assets, config: Config,
     assets.at("index.html")
   }
 
-  def thirdPartyAssets(path: String) = Action.async { implicit req: Request[AnyContent] =>
-    assets.at(s"third-party/$path").apply(req)
-  }
-
   def assetOrBundle(path: String) = Action.async { implicit req: Request[AnyContent] =>
     // Try assets first. If not then it is a route in the SPA so serve the app bundle
     assets.at(path)(req).flatMap { result =>

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -96,5 +96,5 @@ PUT           /setup                                                        cont
 
 # === Web Client ===
 GET           /                                                             controllers.frontend.App.index
-GET           /third-party/*file                                            controllers.Assets.at(path="/public", file)
+GET           /third-party/*file                                            controllers.Assets.at(path="/public/third-party", file)
 GET           /*path                                                        controllers.frontend.App.assetOrBundle(path)

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -96,5 +96,5 @@ PUT           /setup                                                        cont
 
 # === Web Client ===
 GET           /                                                             controllers.frontend.App.index
-GET           /third-party/*path                                            controllers.frontend.App.thirdPartyAssets(path)
+GET           /third-party/*file                                            controllers.Assets.at(path="/public", file)
 GET           /*path                                                        controllers.frontend.App.assetOrBundle(path)

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ scalaVersion in ThisBuild := "2.12.5"
 
 import com.gu.riffraff.artifact.BuildInfo
 import play.sbt.PlayImport.PlayKeys._
+import com.typesafe.sbt.packager.MappingsHelper._
 
 val compilerFlags = Seq(
   "-unchecked",
@@ -166,6 +167,7 @@ lazy val backend = (project in file("backend"))
     packageDescription := description.value,
 
     mappings in Universal ~= { _.filterNot { case (_, fileName) => fileName == "conf/site.conf" }},
+    mappings in Universal ++= directory(baseDirectory.value / "public"),
 
     javaOptions in Universal ++= Seq(
       "-Dpidfile.path=/dev/null",

--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,6 @@ lazy val backend = (project in file("backend"))
     packageDescription := description.value,
 
     mappings in Universal ~= { _.filterNot { case (_, fileName) => fileName == "conf/site.conf" }},
-    mappings in Universal ++= directory(baseDirectory.value / "public"),
 
     javaOptions in Universal ++= Seq(
       "-Dpidfile.path=/dev/null",

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -21,10 +21,10 @@ popd
 cp -r frontend/build/* backend/public
 # Replace the symbolic link we use in dev with the actual file.
 # On Teamcity the JDeb build doesn't seem to follow the symbolic link while packaging, weirdly
-cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/.
+cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/pdf.worker.min.js
 
 # Do a full build of PFI including all tests and upload it to Riff-Raff under the playground stack
-sbt -DPFI_STACK=pfi-playground clean riffRaffUpload # WithIntegrationTests
+sbt -DPFI_STACK=pfi-playground clean riffRaffUploadWithIntegrationTests
 
 # Do another build limited to just the binaries and upload under the Giant stack
 # To achieve this we unfortunately need to edit riff-raff.yaml directly.

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -19,9 +19,12 @@ CI=true npm run test
 popd
 
 cp -r frontend/build/* backend/public
+# Replace the symbolic link we use in dev with the actual file.
+# On Teamcity the JDeb build doesn't seem to follow the symbolic link while packaging, weirdly
+cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/.
 
 # Do a full build of PFI including all tests and upload it to Riff-Raff under the playground stack
-sbt -DPFI_STACK=pfi-playground clean riffRaffUploadWithIntegrationTests
+sbt -DPFI_STACK=pfi-playground clean riffRaffUpload # WithIntegrationTests
 
 # Do another build limited to just the binaries and upload under the Giant stack
 # To achieve this we unfortunately need to edit riff-raff.yaml directly.


### PR DESCRIPTION
Ronseal.

~We weren't including the public folder in the build.~

It looks like teamcity wasn't resolving the symlink correctly in the JDeb build - so manually `cp` it instead.