### PR TITLE
PageViewer: Mk. III Mod. A

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -33,7 +33,7 @@ import router.Routes
 import services._
 import services.annotations.Neo4jAnnotations
 import services.events.ElasticsearchEvents
-import services.index.{ElasticsearchPages, ElasticsearchResources}
+import services.index.{ElasticsearchPages, ElasticsearchResources, Pages2}
 import services.ingestion.IngestionServices
 import services.manifest.Neo4jManifest
 import services.previewing.PreviewService
@@ -89,6 +89,7 @@ class AppComponents(context: Context, config: Config)
     val esTables = new ElasticsearchTable(esClient, config.elasticsearch.tableRowIndexName).setup().await()
     val esEvents = new ElasticsearchEvents(esClient, config.elasticsearch.eventIndexName).setup().await()
     val esPages = new ElasticsearchPages(esClient, config.elasticsearch.pageIndexNamePrefix).setup().await()
+    val pages2 = new Pages2(esClient, config.elasticsearch.pageIndexNamePrefix)
 
     val neo4jDriver = GraphDatabase.driver(config.neo4j.url, AuthTokens.basic(config.neo4j.user, config.neo4j.password))
     val manifest = Neo4jManifest.setupManifest(neo4jDriver, neo4jExecutionContext, config.neo4j.queryLogging).valueOr(failure => throw new Exception(failure.msg))
@@ -177,6 +178,7 @@ class AppComponents(context: Context, config: Config)
     val workspacesController = new Workspaces(authControllerComponents, annotations, esResources, manifest)
     val commentsController = new Comments(authControllerComponents, manifest, esResources, annotations)
     val usersController = new Users(authControllerComponents, userProvider)
+    val pagesControler = new PagesController(authControllerComponents, manifest, esResources, pages2, annotations, previewStorage)
 
     val workerControl = config.aws match {
       case Some(awsDiscoveryConfig) =>
@@ -221,6 +223,7 @@ class AppComponents(context: Context, config: Config)
       documentsController,
       commentsController,
       resourceController,
+      pagesControler,
       emailController,
       mimeTypesController,
       workspacesController,

--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -178,7 +178,7 @@ class AppComponents(context: Context, config: Config)
     val workspacesController = new Workspaces(authControllerComponents, annotations, esResources, manifest)
     val commentsController = new Comments(authControllerComponents, manifest, esResources, annotations)
     val usersController = new Users(authControllerComponents, userProvider)
-    val pagesControler = new PagesController(authControllerComponents, manifest, esResources, pages2, annotations, previewStorage)
+    val pagesController = new PagesController(authControllerComponents, manifest, esResources, pages2, annotations, previewStorage)
 
     val workerControl = config.aws match {
       case Some(awsDiscoveryConfig) =>
@@ -223,7 +223,7 @@ class AppComponents(context: Context, config: Config)
       documentsController,
       commentsController,
       resourceController,
-      pagesControler,
+      pagesController,
       emailController,
       mimeTypesController,
       workspacesController,

--- a/backend/app/commands/GetPagePreview.scala
+++ b/backend/app/commands/GetPagePreview.scala
@@ -9,7 +9,7 @@ import utils.attempt.Attempt
 
 import scala.concurrent.ExecutionContext
 
-class GetPagePreview(uri: Uri, language: Language, pageNumber: Int, query: Option[String],
+class GetPagePreview(uri: Uri, language: Language, pageNumber: Int,
                      previewStorage: ObjectStorage)(implicit ec: ExecutionContext) extends AttemptCommand[HttpEntity] {
   override def process(): Attempt[HttpEntity] = {
     val previewUri = PreviewService.getPageStoragePath(uri, language, pageNumber)

--- a/backend/app/commands/GetPages.scala
+++ b/backend/app/commands/GetPages.scala
@@ -41,6 +41,7 @@ class GetPages(uri: Uri, top: Double, bottom: Double, query: Option[String], use
           Attempt.Right(List.empty)
         }
       } yield {
+        // FIXME? Why don't we just return the PDF data here? This would save the
         FrontendPage(pageNumber, metadata.language, allLanguages, page.dimensions, highlights)
       }
     }
@@ -63,6 +64,7 @@ class GetPages(uri: Uri, top: Double, bottom: Double, query: Option[String], use
 object GetPages {
   case class PagePreviewMetadata(language: Language, pageText: String, hasHighlights: Boolean)
 
+  // TODO SC/JS: This name is a bit wrong - its not simply metadata, it's language choice and *actual* data
   def getPagePreviewMetadata(uri: Uri, page: Page, userRequestedLanguage: Option[Language]): Attempt[PagePreviewMetadata] = {
     val pageNumber = page.page.toInt
     val allLanguages = page.value.keySet

--- a/backend/app/controllers/api/PagesController.scala
+++ b/backend/app/controllers/api/PagesController.scala
@@ -25,7 +25,8 @@ class PagesController(val controllerComponents: AuthControllerComponents, manife
     pagesService.getPageCount(uri).map(count => Ok(Json.obj("pageCount" -> count)))
   }
 
-  def getPageText(uri: Uri, pageNumber: Int, q: Option[String], language: Option[Language]) = ApiAction.attempt { req =>
+  // Get language and highlight data for a given page
+  def getPageData(uri: Uri, pageNumber: Int, q: Option[String], language: Option[Language]) = ApiAction.attempt { req =>
     val query = q.map(Chips.parseQueryString)
 
     val getResource = GetResource(uri, ResourceFetchMode.Basic, req.user.username, manifest, index, annotations, controllerComponents.users).process()

--- a/backend/app/controllers/api/PagesController.scala
+++ b/backend/app/controllers/api/PagesController.scala
@@ -1,0 +1,73 @@
+package controllers.api
+
+import java.io.InputStream
+
+import commands.{GetPagePreview, GetPages, GetResource, ResourceFetchMode}
+import model.frontend.{Chips, HighlightableText}
+import model.index.{FrontendPage, PageHighlight}
+import model.{Language, Languages, Uri}
+import org.apache.pdfbox.pdmodel.PDDocument
+import play.api.libs.json.Json
+import play.api.mvc.{ResponseHeader, Result}
+import services.ObjectStorage
+import services.annotations.Annotations
+import services.manifest.Manifest
+import services.index.{Index, Pages2}
+import services.previewing.PreviewService
+import utils.PDFUtil
+import utils.attempt.Attempt
+import utils.controller.{AuthApiController, AuthControllerComponents}
+
+class PagesController(val controllerComponents: AuthControllerComponents, manifest: Manifest,
+    index: Index, pagesService: Pages2, annotations: Annotations, previewStorage: ObjectStorage) extends AuthApiController {
+
+  def getPageCount(uri: Uri) = ApiAction.attempt { req =>
+    pagesService.getPageCount(uri).map(count => Ok(Json.obj("pageCount" -> count)))
+  }
+
+  def getPageText(uri: Uri, pageNumber: Int, q: Option[String], language: Option[Language]) = ApiAction.attempt { req =>
+    val query = q.map(Chips.parseQueryString)
+
+    for {
+      // Check we have permission to see this file
+      _ <- GetResource(uri, ResourceFetchMode.Basic, req.user.username, manifest, index, annotations, controllerComponents.users).process()
+      page <- pagesService.getPage(uri, pageNumber, query)
+      allLanguages = page.value.keySet
+      // Highlighting stuff
+      metadata <- GetPages.getPagePreviewMetadata(uri, page, language)
+      previewUri = PreviewService.getPageStoragePath(uri, metadata.language, pageNumber)
+      pagePreviewPdf <- previewStorage.get(previewUri).toAttempt
+      highlights <- if(metadata.hasHighlights) {
+        addSearchHighlightsToPageResponse(pageNumber, pagePreviewPdf, metadata.pageText)
+      } else {
+        pagePreviewPdf.close()
+        Attempt.Right(List.empty)
+      }
+    } yield {
+      val response = FrontendPage(pageNumber, metadata.language, allLanguages, page.dimensions, highlights)
+      Ok(Json.toJson(response))
+    }
+  }
+
+  private def addSearchHighlightsToPageResponse(pageNumber: Int, pageData: InputStream, pageText: String): Attempt[List[PageHighlight]] = Attempt.catchNonFatalBlasé {
+    try {
+      val pagePDF = PDDocument.load(pageData)
+      val highlightableText = HighlightableText.fromString(pageText, Some(pageNumber))
+
+      PDFUtil.getSearchResultHighlights(highlightableText, pagePDF, pageNumber)
+    } finally {
+      pageData.close()
+    }
+  }
+
+  def getPagePreview(uri: Uri, pageNumber: Int) = ApiAction.attempt { req =>
+    for {
+      // Check we have permission to see this file
+      _ <- GetResource(uri, ResourceFetchMode.Basic, req.user.username, manifest, index, annotations, controllerComponents.users).process()
+      // TODO fix language stuff
+      response <- new GetPagePreview(uri, Languages.getByKeyOrThrow("english"), pageNumber, previewStorage).process()
+    } yield {
+      Result(ResponseHeader(200, Map.empty), response)
+    }
+  }
+}

--- a/backend/app/controllers/api/Resource.scala
+++ b/backend/app/controllers/api/Resource.scala
@@ -86,13 +86,11 @@ class Resource(val controllerComponents: AuthControllerComponents, manifest: Man
     }
   }
 
-  def getPagePreview(uri: Uri, language: Language, pageNumber: Int, q: Option[String]) = ApiAction.attempt { req =>
-    val query = q.map(Chips.parseQueryString)
-
+  def getPagePreview(uri: Uri, language: Language, pageNumber: Int) = ApiAction.attempt { req =>
     for {
       // Check we have permission to see this file
       _ <- GetResource(uri, ResourceFetchMode.Basic, req.user.username, manifest, index, annotations, controllerComponents.users).process()
-      response <- new GetPagePreview(uri, language, pageNumber, query, previewStorage).process()
+      response <- new GetPagePreview(uri, language, pageNumber, previewStorage).process()
     } yield {
       Result(ResponseHeader(200, Map.empty), response)
     }

--- a/backend/app/model/index/Page.scala
+++ b/backend/app/model/index/Page.scala
@@ -16,9 +16,11 @@ object PageDimensions {
   val A4_PORTRAIT = PageDimensions(595, 842, 0, 842)
 }
 
-sealed abstract class PageHighlight { def id: String }
 case class HighlightSpan(x: Double, y: Double, width: Double, height: Double, rotation: Double)
+
+sealed abstract class PageHighlight { def id: String }
 case class SearchResultPageHighlight(id: String, spans: List[HighlightSpan]) extends PageHighlight
+// Other types of highlight might include comments or Ctrl-F searches
 
 object PageHighlight {
   implicit val writes: Writes[PageHighlight] = {

--- a/backend/app/services/index/Pages2.scala
+++ b/backend/app/services/index/Pages2.scala
@@ -1,0 +1,58 @@
+package services.index
+
+import com.sksamuel.elastic4s.ElasticClient
+import com.sksamuel.elastic4s.ElasticDsl._
+import services.index.HitReaders.{PageHitReader, RichFieldMap}
+import com.sksamuel.elastic4s.requests.searches.queries.Query
+import com.sksamuel.elastic4s.requests.searches.{HighlightField, MultisearchResponseItem}
+import model.Uri
+import model.index.Page
+import services.ElasticsearchSyntax
+import utils.Logging
+import utils.attempt.{Attempt, NotFoundFailure}
+
+import scala.concurrent.ExecutionContext
+
+class Pages2(val client: ElasticClient, indexNamePrefix: String)(implicit val ex: ExecutionContext)
+  extends ElasticsearchSyntax with Logging {
+  val textIndexName = s"$indexNamePrefix-text"
+
+  def getPageCount(uri: Uri): Attempt[Long] = {
+    execute {
+      count(textIndexName).query(
+        termQuery(PagesFields.resourceId, uri.value),
+      )
+    }.map { resp =>
+      resp.count
+    }
+  }
+
+  def getPage(uri: Uri, pageNumber: Int, highlightQuery: Option[String]): Attempt[Page] = {
+    val query = highlightQuery.map(buildQuery)
+    val highlightFields = query.toList.flatMap { query =>
+      HighlightFields.languageHighlighters(PagesFields.value, query)
+        // Ensure we get the whole page, not just the highlights
+        .map(_.numberOfFragments(0))
+    }
+
+    execute {
+      search(textIndexName)
+        .termQuery("_id", s"${uri.value}-$pageNumber")
+        .highlighting(highlightFields)
+    }.flatMap { response =>
+      val pages = response.to[Page]
+
+      if(pages.isEmpty) {
+        Attempt.Left(NotFoundFailure(s"Missing page $pageNumber for $uri"))
+      } else {
+        Attempt.Right(pages.head)
+      }
+    }
+  }
+
+  private def buildQuery(q: String) =
+    queryStringQuery(q)
+    .defaultOperator("and")
+    .field(s"${PagesFields.value}.*")
+    .quoteFieldSuffix(".exact")
+}

--- a/backend/app/utils/PDFUtil.scala
+++ b/backend/app/utils/PDFUtil.scala
@@ -79,7 +79,8 @@ object PDFUtil {
       val startIdx = highlight.range.startCharacter
       val endIdx = highlight.range.endCharacter - 1
 
-      // We're going to split the existing text path
+      // Split the existing text path into lines of characters
+      // TODO SC: Make a case class for this to help readability?
       val highlightSpans: List[List[TextPosition]] = textPositions
         .slice(startIdx, endIdx + 1)
         .zipWithIndex
@@ -93,8 +94,8 @@ object PDFUtil {
       })
 
       val id = HighlightableText.searchHighlightId(ix, Some(pageNumber))
-      val spans = highlightSpans.map { span =>
 
+      val spans = highlightSpans.map { span =>
         val startCharacter = span.head
         val endCharacter = span.last
 

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -34,7 +34,7 @@ GET           /api/pages/preview/:language/:uri/:pageNumber                 cont
 
 GET           /api/pages2/:uri/pageCount                                    controllers.api.PagesController.getPageCount(uri: model.Uri)
 GET           /api/pages2/:uri/:pageNumber/preview                          controllers.api.PagesController.getPagePreview(uri: model.Uri, pageNumber: Int)
-GET           /api/pages2/:uri/:pageNumber/text                             controllers.api.PagesController.getPageText(uri: model.Uri, pageNumber: Int, q: Option[String], language: Option[model.Language])
+GET           /api/pages2/:uri/:pageNumber/text                             controllers.api.PagesController.getPageData(uri: model.Uri, pageNumber: Int, q: Option[String], language: Option[model.Language])
 
 GET           /api/extractions/failures                                     controllers.api.Resource.getExtractionFailures
 POST          /api/extractions/failures/resources                           controllers.api.Resource.getResourcesForExtractionFailure(page: Int ?= 1, pageSize: Int ?= 20)

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -30,7 +30,11 @@ GET           /api/resources/*uri                                           cont
 DELETE        /api/comments/:commentId                                      controllers.api.Comments.deleteComment(commentId: String)
 
 GET           /api/pages/text/:uri                                          controllers.api.Resource.getTextPages(uri: model.Uri, top: Double, bottom: Double, q: Option[String], language: Option[model.Language])
-GET           /api/pages/preview/:language/:uri/:pageNumber                 controllers.api.Resource.getPagePreview(uri: model.Uri, language: model.Language, pageNumber: Int, q: Option[String])
+GET           /api/pages/preview/:language/:uri/:pageNumber                 controllers.api.Resource.getPagePreview(uri: model.Uri, language: model.Language, pageNumber: Int)
+
+GET           /api/pages2/:uri/pageCount                                    controllers.api.PagesController.getPageCount(uri: model.Uri)
+GET           /api/pages2/:uri/:pageNumber/preview                          controllers.api.PagesController.getPagePreview(uri: model.Uri, pageNumber: Int)
+GET           /api/pages2/:uri/:pageNumber/text                             controllers.api.PagesController.getPageText(uri: model.Uri, pageNumber: Int, q: Option[String], language: Option[model.Language])
 
 GET           /api/extractions/failures                                     controllers.api.Resource.getExtractionFailures
 POST          /api/extractions/failures/resources                           controllers.api.Resource.getResourcesForExtractionFailure(page: Int ?= 1, pageSize: Int ?= 20)

--- a/frontend/src/js/App.js
+++ b/frontend/src/js/App.js
@@ -20,6 +20,7 @@ import {ResourceHandler} from './components/ResourceHandler/ResourceHandler';
 import Directory from './components/Directory/Directory';
 import Thread from './components/EmailBrowser/Thread';
 import Viewer from './components/viewer/Viewer';
+import {PageViewer} from './components/PageViewer/PageViewer';
 import ViewerSidebar from './components/viewer/ViewerSidebar';
 import {ErrorBar} from './components/UtilComponents/ErrorBar';
 import Login from './components/Login/Login';
@@ -75,6 +76,7 @@ class App extends React.Component {
                     <Route path='/collections/:uri' component={CurrentCollection} />
                     <Route path='/search' component={Search} />
                     <Route path='/viewer/:uri' component={Viewer} />
+                    <Route path='/viewer2/:uri' component={PageViewer} />
                     <Route path='/files/*' component={() => <Directory currentResource={getCurrentResource()} />} />
                     <Route path='/emails/thread/:uri' component={Thread} />
                     <Route path='/ingestions/*' component={() => <Directory currentResource={getCurrentResource()} />} />

--- a/frontend/src/js/components/PageViewer/Page.module.css
+++ b/frontend/src/js/components/PageViewer/Page.module.css
@@ -1,0 +1,3 @@
+.container {
+  position: relative;
+}

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -16,20 +16,23 @@ export const Page: FC<PageProps> = ({ getPagePreview, getPageText }) => {
   const [scale, setScale] = useState<number | null>(null);
   const [textOverlays, setTextOverlays] = useState<PdfText[] | null>(null);
 
-  const mountCanvas = useCallback((pageRef) => {
-    getPagePreview()
-      .then((preview) => {
-        setScale(preview.scale);
-        pageRef?.appendChild(preview.canvas);
-        return preview;
-      })
-      .then((preview) => {
-        // Begin rendering the text overlays after the PDF rendered to the DOM
-        renderTextOverlays(preview).then(setTextOverlays);
-      });
+  const mountCanvas = useCallback(
+    (pageRef) => {
+      getPagePreview()
+        .then((preview) => {
+          setScale(preview.scale);
+          pageRef?.appendChild(preview.canvas);
+          return preview;
+        })
+        .then((preview) => {
+          // Begin rendering the text overlays after the PDF rendered to the DOM
+          renderTextOverlays(preview).then(setTextOverlays);
+        });
 
-    getPageText().then(setPageText);
-  }, []);
+      getPageText().then(setPageText);
+    },
+    [getPagePreview, getPageText]
+  );
 
   return (
     <div ref={mountCanvas} className={styles.container}>

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -1,17 +1,41 @@
-import React, { FC, useCallback } from "react";
+import React, { FC, useCallback, useState } from "react";
 import { Page as PageData } from "./model";
+import { PageHighlight } from "./PageHighlight";
+import styles from "./Page.module.css";
+import { ptsToPx } from "../viewer/PageViewer/pageViewerApi";
+import { Preview } from "./PageCache";
 
 type PageProps = {
   // Pass in funcitons here so the page can handle the life cycle of it's own elements
-  getPagePreview: () => Promise<HTMLCanvasElement>;
+  getPagePreview: () => Promise<Preview>;
   getPageText: () => Promise<PageData>;
 };
 
 export const Page: FC<PageProps> = ({ getPagePreview, getPageText }) => {
+  const [pageText, setPageText] = useState<PageData | null>(null);
+  const [scale, setScale] = useState<number | null>(null);
+
   const mountCanvas = useCallback((pageRef) => {
-    getPagePreview().then((canvas) => pageRef?.appendChild(canvas));
-    getPageText();
+    getPagePreview().then((preview) => {
+      setScale(preview.scale);
+      pageRef?.appendChild(preview.canvas);
+    });
+
+    getPageText().then(setPageText);
   }, []);
 
-  return <div ref={mountCanvas} />;
+  return (
+    <div ref={mountCanvas} className={styles.container}>
+      {scale &&
+        pageText &&
+        pageText.highlights.map((hl) => (
+          <PageHighlight
+            key={hl.id}
+            highlight={hl}
+            focused={false}
+            scale={scale}
+          />
+        ))}
+    </div>
+  );
 };

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -1,0 +1,17 @@
+import React, { FC, useCallback } from "react";
+import { Page as PageData } from "./model";
+
+type PageProps = {
+  // Pass in funcitons here so the page can handle the life cycle of it's own elements
+  getPagePreview: () => Promise<HTMLCanvasElement>;
+  getPageText: () => Promise<PageData>;
+};
+
+export const Page: FC<PageProps> = ({ getPagePreview, getPageText }) => {
+  const mountCanvas = useCallback((pageRef) => {
+    getPagePreview().then((canvas) => pageRef?.appendChild(canvas));
+    getPageText();
+  }, []);
+
+  return <div ref={mountCanvas} />;
+};

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -1,31 +1,40 @@
 import React, { FC, useCallback, useState } from "react";
-import { Page as PageData } from "./model";
-import { PageHighlight } from "./PageHighlight";
+import { CachedPreview, Page as PageData, PdfText } from "./model";
 import styles from "./Page.module.css";
-import { ptsToPx } from "../viewer/PageViewer/pageViewerApi";
-import { Preview } from "./PageCache";
+import { PageHighlight } from "./PageHighlight";
+import { PageOverlayText } from "./PageOverlayText";
+import { renderTextOverlays } from "./PdfHelpers";
 
 type PageProps = {
   // Pass in funcitons here so the page can handle the life cycle of it's own elements
-  getPagePreview: () => Promise<Preview>;
+  getPagePreview: () => Promise<CachedPreview>;
   getPageText: () => Promise<PageData>;
 };
 
 export const Page: FC<PageProps> = ({ getPagePreview, getPageText }) => {
   const [pageText, setPageText] = useState<PageData | null>(null);
   const [scale, setScale] = useState<number | null>(null);
+  const [textOverlays, setTextOverlays] = useState<PdfText[] | null>(null);
 
   const mountCanvas = useCallback((pageRef) => {
-    getPagePreview().then((preview) => {
-      setScale(preview.scale);
-      pageRef?.appendChild(preview.canvas);
-    });
+    getPagePreview()
+      .then((preview) => {
+        setScale(preview.scale);
+        pageRef?.appendChild(preview.canvas);
+        return preview;
+      })
+      .then((preview) => {
+        // Begin rendering the text overlays after the PDF rendered to the DOM
+        renderTextOverlays(preview).then(setTextOverlays);
+      });
 
     getPageText().then(setPageText);
   }, []);
 
   return (
     <div ref={mountCanvas} className={styles.container}>
+      {textOverlays &&
+        textOverlays.map((to, i) => <PageOverlayText key={i} text={to} />)}
       {scale &&
         pageText &&
         pageText.highlights.map((hl) => (

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -31,7 +31,9 @@ export const Page: FC<PageProps> = ({ getPagePreview, getPageText }) => {
 
       getPageText().then(setPageText);
     },
-    [getPagePreview, getPageText]
+    // TypeScript insists that the array be there but following exhaustive-deps lint suggestion breaks behaviour
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   );
 
   return (

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -16,11 +16,14 @@ export const Page: FC<PageProps> = ({ getPagePreview, getPageData }) => {
   const [scale, setScale] = useState<number | null>(null);
   const [textOverlays, setTextOverlays] = useState<PdfText[] | null>(null);
 
-  // If the
   const [aborted, setAborted] = useState(false);
 
   const handleAbort = (err: Error) => {
     if (err.name === "AbortError") {
+      // If our fetch request gets aborted due to a cache eviction then
+      // we want to show some info to the user saying why the page isn't rendering.
+      //
+      // Since the cache is an LRU we should never get an eviction on a visible page.
       setAborted(true);
     }
   };

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -1,100 +1,58 @@
 import authFetch from "../../util/auth/authFetch";
-import { CachedPreview, Page } from "./model";
+import { LruCache } from "../../util/LruCache";
+import { CachedPreview, PageData } from "./model";
 import { renderPdfPreview } from "./PdfHelpers";
+
+export type CachedPageData = {
+  previewAbortController: AbortController;
+  preview: Promise<CachedPreview>;
+  dataAbortController: AbortController;
+  data: Promise<PageData>;
+};
 
 export class PageCache {
   uri: string;
+  query?: string;
 
   static MAX_CACHED_PAGES = 100;
 
-  // Tracking of text (Page}) and rendered previews (HTMLCanvasElement) is handled seperately incase an
-  // eviction happens to an item that is in flight
-  previews: CachedPreview[] = [];
-  cachedPreviewsLru: number[] = [];
+  private cache: LruCache<number, CachedPageData>;
 
-  pages: Page[] = [];
-  cachedPagesLru: number[] = [];
-
-  constructor(uri: string) {
+  constructor(uri: string, query?: string) {
     this.uri = uri;
+    this.query = query;
+    this.cache = new LruCache(25, this.onCacheMiss, this.onCacheEvict);
   }
 
-  //////////////
-  // Previews //
-  //////////////
+  private onCacheMiss = (pageNumber: number): CachedPageData => {
+    const previewAbortController = new AbortController();
+    const preview = authFetch(`/api/pages2/${this.uri}/${pageNumber}/preview`, {
+      signal: previewAbortController.signal,
+    })
+      .then((res) => res.arrayBuffer())
+      .then((buf) => renderPdfPreview(buf));
 
-  private addToPreviewCache = (pageNumber: number, canvas: CachedPreview) => {
-    this.previews[pageNumber] = canvas;
-    this.cachedPreviewsLru.push(pageNumber);
-    if (this.cachedPreviewsLru.length > PageCache.MAX_CACHED_PAGES) {
-      const lruPageNumber = this.cachedPreviewsLru.shift();
-      if (lruPageNumber) {
-        delete this.previews[lruPageNumber];
-      }
-    }
+    const dataAbortController = new AbortController();
+    const data = authFetch(
+      `/api/pages2/${this.uri}/${pageNumber}/text${
+        this.query ? `?q=${this.query}` : ""
+      }`,
+      { signal: dataAbortController.signal }
+    ).then((res) => res.json());
+
+    return {
+      previewAbortController,
+      preview,
+      dataAbortController,
+      data,
+    };
   };
 
-  private bumpPreviewRecency = (pageNumber: number) => {
-    const index = this.cachedPreviewsLru.findIndex((pn) => pn === pageNumber);
-    this.cachedPreviewsLru.splice(index, 1);
-    this.cachedPreviewsLru.push(pageNumber);
+  private onCacheEvict = (pageNumber: number, v: CachedPageData) => {
+    console.log('Evicting ' + pageNumber);
+    v.previewAbortController.abort();
+    v.dataAbortController.abort();
   };
 
-  // Get a cached canvas with the page rendered into it
-  getPagePreview = async (pageNumber: number): Promise<CachedPreview> => {
-    if (this.previews[pageNumber]) {
-      this.bumpPreviewRecency(pageNumber);
-
-      return Promise.resolve(this.previews[pageNumber]);
-    } else {
-      const response = await authFetch(
-        `/api/pages2/${this.uri}/${pageNumber}/preview`
-      );
-      const buffer = await response.arrayBuffer();
-
-      const preview = await renderPdfPreview(buffer);
-
-      this.addToPreviewCache(pageNumber, preview);
-
-      return preview;
-    }
-  };
-
-  ///////////////
-  // Page text //
-  ///////////////
-
-  private addToPageCache = (pageNumber: number, page: Page) => {
-    this.pages[pageNumber] = page;
-    this.cachedPagesLru.push(pageNumber);
-    if (this.cachedPagesLru.length > PageCache.MAX_CACHED_PAGES) {
-      const lruPageNumber = this.cachedPagesLru.shift();
-      if (lruPageNumber) {
-        delete this.pages[lruPageNumber];
-      }
-    }
-  };
-
-  private bumpPageRecency = (pageNumber: number) => {
-    const index = this.cachedPagesLru.findIndex((pn) => pn === pageNumber);
-    this.cachedPagesLru.splice(index, 1);
-    this.cachedPagesLru.push(pageNumber);
-  };
-
-  getPageText = async (pageNumber: number, query?: string): Promise<Page> => {
-    if (this.previews[pageNumber]) {
-      this.bumpPageRecency(pageNumber);
-      return Promise.resolve(this.pages[pageNumber]);
-    } else {
-      const response = await authFetch(
-        `/api/pages2/${this.uri}/${pageNumber}/text${
-          query ? `?q=${query}` : ""
-        }`
-      );
-
-      const json = await response.json();
-      this.addToPageCache(pageNumber, json);
-      return json;
-    }
-  };
+  getPage = (pageNumber: number) => this.cache.get(pageNumber);
 }

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -1,0 +1,129 @@
+import _ from "lodash";
+import authFetch from "../../util/auth/authFetch";
+import * as pdfjs from "pdfjs-dist";
+import { Page } from "./model";
+
+export class PageCache {
+  uri: string;
+
+  static MAX_CACHED_PAGES = 100;
+
+  // Tracking of text (Page}) and rendered previews (HTMLCanvasElement) is handled seperately incase an
+  // eviction happens to an item that is in flight
+  previews: HTMLCanvasElement[] = [];
+  cachedPreviewsLru: number[] = [];
+
+  pages: Page[] = [];
+  cachedPagesLru: number[] = [];
+
+  constructor(uri: string) {
+    this.uri = uri;
+  }
+
+  //////////////
+  // Previews //
+  //////////////
+
+  private addToPreviewCache = (
+    pageNumber: number,
+    canvas: HTMLCanvasElement
+  ) => {
+    this.previews[pageNumber] = canvas;
+    this.cachedPreviewsLru.push(pageNumber);
+    if (this.cachedPreviewsLru.length > PageCache.MAX_CACHED_PAGES) {
+      const lruPageNumber = this.cachedPreviewsLru.shift();
+      if (lruPageNumber) {
+        delete this.previews[lruPageNumber];
+      }
+    }
+  };
+
+  private bumpPreviewRecency = (pageNumber: number) => {
+    const index = this.cachedPreviewsLru.findIndex((pn) => pn === pageNumber);
+    this.cachedPreviewsLru.splice(index, 1);
+    this.cachedPreviewsLru.push(pageNumber);
+  };
+
+  // Get a cached canvas with the page rendered into it
+  getPagePreview = async (pageNumber: number): Promise<HTMLCanvasElement> => {
+    if (this.previews[pageNumber]) {
+      this.bumpPreviewRecency(pageNumber);
+
+      return Promise.resolve(this.previews[pageNumber]);
+    } else {
+      const response = await authFetch(
+        `/api/pages2/${this.uri}/${pageNumber}/preview`
+      );
+      const buffer = await response.arrayBuffer();
+
+      const doc = await pdfjs.getDocument(new Uint8Array(buffer)).promise;
+      const pdfPage = await doc.getPage(1);
+
+      const canvas = document.createElement("canvas");
+      const canvasContext = canvas.getContext("2d")!;
+
+      // Scaling
+      const unscaledViewport = pdfPage.getViewport({ scale: 1.0 });
+      const isLandscape = unscaledViewport.width > unscaledViewport.height;
+
+      const widthScale = 1000 / unscaledViewport.width;
+      const heightScale = 1000 / unscaledViewport.height;
+
+      const scale = isLandscape ? widthScale : heightScale;
+
+      const viewport = pdfPage.getViewport({ scale });
+
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+
+      // Render
+      await pdfPage.render({
+        canvasContext,
+        viewport,
+      });
+
+      // Handle caching
+      this.addToPreviewCache(pageNumber, canvas);
+
+      return canvas;
+    }
+  };
+
+  ///////////////
+  // Page text //
+  ///////////////
+
+  private addToPageCache = (pageNumber: number, page: Page) => {
+    this.pages[pageNumber] = page;
+    this.cachedPagesLru.push(pageNumber);
+    if (this.cachedPagesLru.length > PageCache.MAX_CACHED_PAGES) {
+      const lruPageNumber = this.cachedPagesLru.shift();
+      if (lruPageNumber) {
+        delete this.pages[lruPageNumber];
+      }
+    }
+  };
+
+  private bumpPageRecency = (pageNumber: number) => {
+    const index = this.cachedPagesLru.findIndex((pn) => pn === pageNumber);
+    this.cachedPagesLru.splice(index, 1);
+    this.cachedPagesLru.push(pageNumber);
+  };
+
+  getPageText = async (pageNumber: number, query?: string): Promise<Page> => {
+    if (this.previews[pageNumber]) {
+      this.bumpPageRecency(pageNumber);
+      return Promise.resolve(this.pages[pageNumber]);
+    } else {
+      const response = await authFetch(
+        `/api/pages2/${this.uri}/${pageNumber}/text${
+          query ? `?q=${query}` : ""
+        }`
+      );
+
+      const json = await response.json();
+      this.addToPageCache(pageNumber, json);
+      return json;
+    }
+  };
+}

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -14,14 +14,17 @@ export class PageCache {
   uri: string;
   query?: string;
 
-  static MAX_CACHED_PAGES = 100;
+  // Arrived at by testing with Chrome on Ubuntu.
+  // Having too many cached pages can result in having too many 
+  // in-flight requests, causing browser instability.
+  static MAX_CACHED_PAGES = 25;
 
   private cache: LruCache<number, CachedPageData>;
 
   constructor(uri: string, query?: string) {
     this.uri = uri;
     this.query = query;
-    this.cache = new LruCache(25, this.onCacheMiss, this.onCacheEvict);
+    this.cache = new LruCache(PageCache.MAX_CACHED_PAGES, this.onCacheMiss, this.onCacheEvict);
   }
 
   private onCacheMiss = (pageNumber: number): CachedPageData => {

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -48,8 +48,7 @@ export class PageCache {
     };
   };
 
-  private onCacheEvict = (pageNumber: number, v: CachedPageData) => {
-    console.log('Evicting ' + pageNumber);
+  private onCacheEvict = (_: number, v: CachedPageData) => {
     v.previewAbortController.abort();
     v.dataAbortController.abort();
   };

--- a/frontend/src/js/components/PageViewer/PageHighlight.tsx
+++ b/frontend/src/js/components/PageViewer/PageHighlight.tsx
@@ -1,0 +1,53 @@
+import React, { CSSProperties, FC } from "react";
+import { ptsToPx } from "../viewer/PageViewer/pageViewerApi";
+import { Highlight } from "./model";
+
+type PageHighlightProps = {
+  highlight: Highlight;
+  focused: boolean;
+  scale: number;
+};
+
+export const PageHighlight: FC<PageHighlightProps> = ({
+  highlight,
+  focused,
+  scale,
+}) => {
+  const { id, type } = highlight;
+  const onMountOrUnmount = () => {};
+
+  switch (type) {
+    case "SearchResultPageHighlight":
+      return (
+        <>
+          {highlight.data.map((span, i) => {
+            const style: CSSProperties = {
+              position: "absolute",
+              left: span.x * scale,
+              top: span.y * scale,
+              width: span.width * scale,
+              height: span.height * scale,
+              transformOrigin: "top left",
+              transform: `rotate(${span.rotation}rad)`,
+              pointerEvents: "none",
+            };
+
+            return (
+              <span
+                className={
+                  focused
+                    ? `pfi-page-highlight pfi-page-highlight--focused`
+                    : "pfi-page-highlight"
+                }
+                ref={onMountOrUnmount}
+                key={`${id}-${i}`}
+                style={style}
+              />
+            );
+          })}
+        </>
+      );
+    default:
+      return null;
+  }
+};

--- a/frontend/src/js/components/PageViewer/PageHighlight.tsx
+++ b/frontend/src/js/components/PageViewer/PageHighlight.tsx
@@ -1,5 +1,4 @@
 import React, { CSSProperties, FC } from "react";
-import { ptsToPx } from "../viewer/PageViewer/pageViewerApi";
 import { Highlight } from "./model";
 
 type PageHighlightProps = {

--- a/frontend/src/js/components/PageViewer/PageOverlayText.tsx
+++ b/frontend/src/js/components/PageViewer/PageOverlayText.tsx
@@ -4,10 +4,12 @@ import { PdfText } from "./model";
 type PageOverlayTextProps = {
   text: PdfText;
 };
+
 // This renders invisible text over the PDF to allow selection
 // Selection is useful for copy-paste and making comments
 export const PageOverlayText: FC<PageOverlayTextProps> = ({ text }) => {
   const { left, top, fontSize, fontFamily, transform, value } = text;
+
   return (
     <div
       className="pfi-page__pdf-text"

--- a/frontend/src/js/components/PageViewer/PageOverlayText.tsx
+++ b/frontend/src/js/components/PageViewer/PageOverlayText.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from "react";
+import { PdfText } from "./model";
+
+type PageOverlayTextProps = {
+  text: PdfText;
+};
+// This renders invisible text over the PDF to allow selection
+// Selection is useful for copy-paste and making comments
+export const PageOverlayText: FC<PageOverlayTextProps> = ({ text }) => {
+  const { left, top, fontSize, fontFamily, transform, value } = text;
+  return (
+    <div
+      className="pfi-page__pdf-text"
+      style={{ left, top, fontSize, fontFamily, transform }}
+    >
+      {value}
+    </div>
+  );
+};

--- a/frontend/src/js/components/PageViewer/PageViewer.module.css
+++ b/frontend/src/js/components/PageViewer/PageViewer.module.css
@@ -1,0 +1,5 @@
+.main {
+    height: calc(100vh - 80px);
+    flex-grow: 1;
+    display: flex;
+}

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -1,0 +1,17 @@
+import React, { FC, useState } from "react";
+import { VirtualScroll } from "./VirtualScroll";
+
+type PageViewerProps = {
+  uri: string;
+    page: number;
+};
+
+export const PageViewer: FC<PageViewerProps> = () => {
+  const [pages, setPages] = useState([]);
+
+  const renderPage = (page: number) => {
+    return <div>Page: {page}</div>
+  }
+
+  return <VirtualScroll totalPages={200} renderPage={renderPage}/>
+};

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -11,9 +11,8 @@ type PageViewerProps = {
 
 export const PageViewer: FC<PageViewerProps> = () => {
   const { uri } = useParams<{ uri: string }>();
-  const [page] = useState(
-    Number(new URLSearchParams(document.location.search).get("page"))
-  );
+  const [page, setPage] = useState<number | undefined>(undefined);
+  const [query, setQuery] = useState<string | undefined>(undefined);
 
   const [pageCache] = useState(new PageCache(uri));
   const [totalPages, setTotalPages] = useState<number | null>(null);
@@ -22,13 +21,18 @@ export const PageViewer: FC<PageViewerProps> = () => {
     authFetch(`/api/pages2/${uri}/pageCount`)
       .then((res) => res.json())
       .then((obj) => setTotalPages(obj.pageCount));
+
+    const params = new URLSearchParams(document.location.search);
+
+    setPage(Number(params.get("page")));
+    setQuery(params.get("q") ?? undefined);
   }, [uri]);
 
   const renderPage = (pageNumber: number) => {
     return (
       <Page
         getPagePreview={() => pageCache.getPagePreview(pageNumber)}
-        getPageText={() => pageCache.getPageText(pageNumber)}
+        getPageText={() => pageCache.getPageText(pageNumber, query)}
       />
     );
   };

--- a/frontend/src/js/components/PageViewer/PdfHelpers.ts
+++ b/frontend/src/js/components/PageViewer/PdfHelpers.ts
@@ -56,16 +56,12 @@ export const renderTextOverlays = async (
     textContentItemsStr,
   }).promise;
 
-  return textDivs.flatMap((textDiv) => {
-    return [
-      {
-        value: textDiv.innerHTML,
-        left: textDiv.style.left,
-        top: textDiv.style.top,
-        fontSize: textDiv.style.fontSize,
-        fontFamily: textDiv.style.fontFamily,
-        transform: textDiv.style.transform,
-      },
-    ];
-  });
+  return textDivs.map((textDiv) => ({
+    value: textDiv.innerHTML,
+    left: textDiv.style.left,
+    top: textDiv.style.top,
+    fontSize: textDiv.style.fontSize,
+    fontFamily: textDiv.style.fontFamily,
+    transform: textDiv.style.transform,
+  }));
 };

--- a/frontend/src/js/components/PageViewer/PdfHelpers.ts
+++ b/frontend/src/js/components/PageViewer/PdfHelpers.ts
@@ -1,0 +1,71 @@
+import * as pdfjs from "pdfjs-dist";
+import { CachedPreview, CONTAINER_SIZE, PdfText } from "./model";
+
+export const renderPdfPreview = async (
+  buffer: ArrayBuffer
+): Promise<CachedPreview> => {
+  const doc = await pdfjs.getDocument(new Uint8Array(buffer)).promise;
+  const pdfPage = await doc.getPage(1);
+
+  const canvas = document.createElement("canvas");
+  const canvasContext = canvas.getContext("2d")!;
+
+  // Scaling
+  const unscaledViewport = pdfPage.getViewport({ scale: 1.0 });
+  const isLandscape = unscaledViewport.width > unscaledViewport.height;
+
+  const widthScale = CONTAINER_SIZE / unscaledViewport.width;
+  const heightScale = CONTAINER_SIZE / unscaledViewport.height;
+
+  const scale = isLandscape ? widthScale : heightScale;
+
+  const viewport = pdfPage.getViewport({ scale });
+
+  canvas.width = viewport.width;
+  canvas.height = viewport.height;
+
+  // Render
+  await pdfPage.render({
+    canvasContext,
+    viewport,
+  });
+
+  return { pdfPage, canvas, scale };
+};
+
+export const renderTextOverlays = async (
+  preview: CachedPreview
+): Promise<PdfText[]> => {
+  const { pdfPage, scale } = preview;
+
+  const textContentStream = pdfPage.streamTextContent({
+    normalizeWhitespace: true,
+    disableCombineTextItems: false,
+  });
+
+  const textDivs: HTMLDivElement[] = [];
+  const textContentItemsStr: string[] = [];
+  const viewport = pdfPage.getViewport({ scale });
+
+  await pdfjs.renderTextLayer({
+    textContentStream,
+    container: document.createElement("div"),
+    viewport,
+    textDivs,
+    enhanceTextSelection: true,
+    textContentItemsStr,
+  }).promise;
+
+  return textDivs.flatMap((textDiv) => {
+    return [
+      {
+        value: textDiv.innerHTML,
+        left: textDiv.style.left,
+        top: textDiv.style.top,
+        fontSize: textDiv.style.fontSize,
+        fontFamily: textDiv.style.fontFamily,
+        transform: textDiv.style.transform,
+      },
+    ];
+  });
+};

--- a/frontend/src/js/components/PageViewer/VirtualScroll.module.css
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.module.css
@@ -1,21 +1,24 @@
 .scrollArea {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .pages {
-    position: relative;
+  position: relative;
 }
 
 .container {
-    position: absolute;
-    margin: 10px;
-    box-sizing: border-box;
-    border: 5px dashed blue;
-    background: red;
-    min-width: 400px;
-    min-height: 400px;
-    max-width: 400px;
-    max-height: 400px;
+  position: absolute;
+
+  margin: 10px;
+
+  min-width: 1000px;
+  min-height: 1000px;
+  max-width: 1000px;
+  max-height: 1000px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/frontend/src/js/components/PageViewer/VirtualScroll.module.css
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.module.css
@@ -1,0 +1,21 @@
+.scrollArea {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.pages {
+    position: relative;
+}
+
+.container {
+    position: absolute;
+    margin: 10px;
+    box-sizing: border-box;
+    border: 5px dashed blue;
+    background: red;
+    min-width: 400px;
+    min-height: 400px;
+    max-width: 400px;
+    max-height: 400px;
+}

--- a/frontend/src/js/components/PageViewer/VirtualScroll.module.css
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.module.css
@@ -1,14 +1,17 @@
-.scrollArea {
+.scrollContainer {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+.pages {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-.pages {
-  position: relative;
-}
-
-.container {
+.pageContainer {
   position: absolute;
 
   margin: 10px;

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -1,0 +1,59 @@
+import _ from "lodash";
+import React, { FC, ReactNode, useRef, useState } from "react";
+import styles from "./VirtualScroll.module.css";
+
+type VirtualScrollProps = {
+    totalPages: number;
+    renderPage: (pageNumber: number) => ReactNode,
+}
+
+export const VirtualScroll: FC<VirtualScrollProps> = ({totalPages, renderPage}) => {
+  const PRELOAD_PAGES = 3;
+
+  const pageHeight = 400;
+
+  const viewport = useRef<HTMLDivElement>(null);
+
+  const [topPage, setTopPage] = useState(1 - PRELOAD_PAGES);
+  const [midPage, setMidPage] = useState(1); // TODO - hook up to URL
+  const [botPage, setBotPage] = useState(1 + PRELOAD_PAGES);
+
+  const onScroll = () => {
+    if (viewport?.current) {
+      const v = viewport.current;
+
+      const currentMid = v.scrollTop + v.clientHeight / 2;
+      const topEdge = currentMid - PRELOAD_PAGES * pageHeight;
+      const botEdge = currentMid + PRELOAD_PAGES * pageHeight;
+
+      const topPage = Math.floor(topEdge / pageHeight);
+      const midPage = Math.floor(currentMid / pageHeight);
+      const botPage = Math.ceil(botEdge / pageHeight);
+
+      setTopPage(topPage);
+      setMidPage(midPage);
+      setBotPage(botPage);
+    }
+  };
+
+  return (
+    <div ref={viewport} className="viewer__main" onScroll={onScroll}>
+      <div
+        className={styles.scrollArea}
+        style={{ height: totalPages * pageHeight }}
+      >
+        <div className={styles.pages}>
+          {_.range(topPage, botPage).map((p) => (
+            <div
+                key={p}
+              style={{ top: p * pageHeight }}
+              className={styles.container}
+            >
+            {renderPage(p)}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import React, { FC, ReactNode, useLayoutEffect, useRef, useState } from "react";
+import { CONTAINER_AND_MARGIN_SIZE } from "./model";
 import styles from "./VirtualScroll.module.css";
 
 type VirtualScrollProps = {
@@ -13,15 +14,14 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   initialPage,
   renderPage,
 }) => {
-  const PRELOAD_PAGES = 9;
+  const PRELOAD_PAGES = 2;
 
-  // Height + margins
-  const pageHeight = 1020;
+  const pageHeight = CONTAINER_AND_MARGIN_SIZE;
 
   const viewport = useRef<HTMLDivElement>(null);
 
   const [topPage, setTopPage] = useState(1);
-  const [midPage, setMidPage] = useState(1);
+  const [midPage, setMidPage] = useState(1); // Todo hook up to URL
   const [botPage, setBotPage] = useState(1 + PRELOAD_PAGES);
 
   const onScroll = () => {

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -51,7 +51,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
       const v = viewport.current!;
 
       const scrollTo =
-        initialPage != 1 ? initialPage * pageHeight - v.clientHeight / 2 : 0;
+        initialPage !== 1 ? initialPage * pageHeight - v.clientHeight / 2 : 0;
 
       v.scrollTop = scrollTo;
     }

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -48,34 +48,28 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
 
   useLayoutEffect(() => {
     if (viewport?.current && initialPage) {
-      const v = viewport.current!;
+      const v = viewport.current;
 
-      const scrollTo =
-        initialPage !== 1 ? initialPage * pageHeight - v.clientHeight / 2 : 0;
+      const scrollTo = (initialPage - 1) * pageHeight;
 
       v.scrollTop = scrollTo;
     }
   }, [viewport, initialPage, pageHeight]);
 
   return (
-    <div ref={viewport} className="viewer__main" onScroll={onScroll}>
-      <div
-        className={styles.scrollArea}
-        style={{ height: totalPages * pageHeight }}
-      >
-        <div className={styles.pages}>
-          {_.range(topPage, botPage + 1)
-            .filter((p) => p > 0 && p <= totalPages)
-            .map((p) => (
-              <div
-                key={p}
-                style={{ top: (p - 1) * pageHeight }}
-                className={styles.container}
-              >
-                {renderPage(p)}
-              </div>
-            ))}
-        </div>
+    <div ref={viewport} className={styles.scrollContainer} onScroll={onScroll}>
+      <div className={styles.pages} style={{ height: totalPages * pageHeight }}>
+        {_.range(topPage, botPage + 1)
+          .filter((pageNumber) => pageNumber > 0 && pageNumber <= totalPages)
+          .map((pageNumber) => (
+            <div
+              key={pageNumber}
+              style={{ top: (pageNumber - 1) * pageHeight }}
+              className={styles.pageContainer}
+            >
+              {renderPage(pageNumber)}
+            </div>
+          ))}
       </div>
     </div>
   );

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -14,6 +14,9 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   initialPage,
   renderPage,
 }) => {
+  // Tweaked this and 2 seems to be a good amount on a regular monitor
+  // The fewer pages we preload the faster the initial paint will be
+  // Could possibly make it dynamic based on the visible of the container
   const PRELOAD_PAGES = 2;
 
   const pageHeight = CONTAINER_AND_MARGIN_SIZE;
@@ -29,6 +32,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
       const v = viewport.current;
 
       const currentMid = v.scrollTop + v.clientHeight / 2;
+
       const topEdge = currentMid - PRELOAD_PAGES * pageHeight;
       const botEdge = currentMid + PRELOAD_PAGES * pageHeight;
 

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -1,21 +1,27 @@
 import _ from "lodash";
-import React, { FC, ReactNode, useRef, useState } from "react";
+import React, { FC, ReactNode, useLayoutEffect, useRef, useState } from "react";
 import styles from "./VirtualScroll.module.css";
 
 type VirtualScrollProps = {
-    totalPages: number;
-    renderPage: (pageNumber: number) => ReactNode,
-}
+  totalPages: number;
+  initialPage?: number;
+  renderPage: (pageNumber: number) => ReactNode;
+};
 
-export const VirtualScroll: FC<VirtualScrollProps> = ({totalPages, renderPage}) => {
-  const PRELOAD_PAGES = 3;
+export const VirtualScroll: FC<VirtualScrollProps> = ({
+  totalPages,
+  initialPage,
+  renderPage,
+}) => {
+  const PRELOAD_PAGES = 9;
 
-  const pageHeight = 400;
+  // Height + margins
+  const pageHeight = 1020;
 
   const viewport = useRef<HTMLDivElement>(null);
 
-  const [topPage, setTopPage] = useState(1 - PRELOAD_PAGES);
-  const [midPage, setMidPage] = useState(1); // TODO - hook up to URL
+  const [topPage, setTopPage] = useState(1);
+  const [midPage, setMidPage] = useState(1);
   const [botPage, setBotPage] = useState(1 + PRELOAD_PAGES);
 
   const onScroll = () => {
@@ -26,15 +32,24 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({totalPages, renderPage}) 
       const topEdge = currentMid - PRELOAD_PAGES * pageHeight;
       const botEdge = currentMid + PRELOAD_PAGES * pageHeight;
 
-      const topPage = Math.floor(topEdge / pageHeight);
+      const topPage = Math.max(Math.floor(topEdge / pageHeight), 1);
       const midPage = Math.floor(currentMid / pageHeight);
-      const botPage = Math.ceil(botEdge / pageHeight);
+      const botPage = Math.min(Math.ceil(botEdge / pageHeight), totalPages);
 
       setTopPage(topPage);
       setMidPage(midPage);
       setBotPage(botPage);
     }
   };
+
+  useLayoutEffect(() => {
+    if (viewport?.current && initialPage) {
+      const v = viewport.current!;
+
+      const scrollTo = initialPage * pageHeight - v.clientHeight / 2;
+      v.scrollTop = scrollTo;
+    }
+  }, [viewport]);
 
   return (
     <div ref={viewport} className="viewer__main" onScroll={onScroll}>
@@ -43,15 +58,17 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({totalPages, renderPage}) 
         style={{ height: totalPages * pageHeight }}
       >
         <div className={styles.pages}>
-          {_.range(topPage, botPage).map((p) => (
-            <div
+          {_.range(topPage, botPage + 1)
+            .filter((p) => p > 0 && p <= totalPages)
+            .map((p) => (
+              <div
                 key={p}
-              style={{ top: p * pageHeight }}
-              className={styles.container}
-            >
-            {renderPage(p)}
-            </div>
-          ))}
+                style={{ top: (p - 1) * pageHeight }}
+                className={styles.container}
+              >
+                {renderPage(p)}
+              </div>
+            ))}
         </div>
       </div>
     </div>

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -24,7 +24,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   const viewport = useRef<HTMLDivElement>(null);
 
   const [topPage, setTopPage] = useState(1);
-  const [midPage, setMidPage] = useState(1); // Todo hook up to URL
+  //const [midPage, setMidPage] = useState(1); // Todo hook up to URL
   const [botPage, setBotPage] = useState(1 + PRELOAD_PAGES);
 
   const onScroll = () => {
@@ -37,11 +37,11 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
       const botEdge = currentMid + PRELOAD_PAGES * pageHeight;
 
       const topPage = Math.max(Math.floor(topEdge / pageHeight), 1);
-      const midPage = Math.floor(currentMid / pageHeight);
+      //const midPage = Math.floor(currentMid / pageHeight);
       const botPage = Math.min(Math.ceil(botEdge / pageHeight), totalPages);
 
       setTopPage(topPage);
-      setMidPage(midPage);
+      //setMidPage(midPage);
       setBotPage(botPage);
     }
   };
@@ -50,10 +50,12 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     if (viewport?.current && initialPage) {
       const v = viewport.current!;
 
-      const scrollTo = initialPage * pageHeight - v.clientHeight / 2;
+      const scrollTo =
+        initialPage != 1 ? initialPage * pageHeight - v.clientHeight / 2 : 0;
+
       v.scrollTop = scrollTo;
     }
-  }, [viewport]);
+  }, [viewport, initialPage, pageHeight]);
 
   return (
     <div ref={viewport} className="viewer__main" onScroll={onScroll}>

--- a/frontend/src/js/components/PageViewer/model.ts
+++ b/frontend/src/js/components/PageViewer/model.ts
@@ -38,7 +38,7 @@ export type PdfText = {
   transform: string;
 };
 
-export type Page = {
+export type PageData = {
   // TODO: Do we need this value wrapper? Keep getting lost looking for highlights, then remember I need to expand value
   page: number;
   dimensions: PageDimensions;

--- a/frontend/src/js/components/PageViewer/model.ts
+++ b/frontend/src/js/components/PageViewer/model.ts
@@ -1,0 +1,33 @@
+// Copy-pasta from the old reducer
+export type PageDimensions = {
+  width: number;
+  height: number;
+  top: number;
+  bottom: number;
+};
+
+export type SearchResultHighlightSpan = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+};
+
+export type SearchResultPageHighlight = {
+  type: "SearchResultPageHighlight";
+  id: string;
+  data: SearchResultHighlightSpan[];
+};
+
+export type PageHighlight = SearchResultPageHighlight; // TODO MRB: add a highlight type for comments
+
+export type Page = {
+  // TODO: Do we need this value wrapper? Keep getting lost looking for highlights, then remember I need to expand value
+  page: number;
+  dimensions: PageDimensions;
+  // The highlights as rectangles to overlay on the document
+  highlights: PageHighlight[];
+  currentLanguage: string;
+  allLanguages: string;
+};

--- a/frontend/src/js/components/PageViewer/model.ts
+++ b/frontend/src/js/components/PageViewer/model.ts
@@ -1,3 +1,7 @@
+// Hardcoded container sizes - should make these dynamic but that can wait for now...
+export const CONTAINER_SIZE = 1000;
+export const CONTAINER_AND_MARGIN_SIZE = 1020;
+
 // Copy-pasta from the old reducer
 export type PageDimensions = {
   width: number;
@@ -14,20 +18,20 @@ export type SearchResultHighlightSpan = {
   rotation: number;
 };
 
-export type SearchResultPageHighlight = {
+export type SearchResultHighlight = {
   type: "SearchResultPageHighlight";
   id: string;
   data: SearchResultHighlightSpan[];
 };
 
-export type PageHighlight = SearchResultPageHighlight; // TODO MRB: add a highlight type for comments
+export type Highlight = SearchResultHighlight; // TODO MRB: add a highlight type for comments
 
 export type Page = {
   // TODO: Do we need this value wrapper? Keep getting lost looking for highlights, then remember I need to expand value
   page: number;
   dimensions: PageDimensions;
   // The highlights as rectangles to overlay on the document
-  highlights: PageHighlight[];
+  highlights: Highlight[];
   currentLanguage: string;
   allLanguages: string;
 };

--- a/frontend/src/js/components/PageViewer/model.ts
+++ b/frontend/src/js/components/PageViewer/model.ts
@@ -1,3 +1,5 @@
+import { PDFPageProxy } from "pdfjs-dist/types/display/api";
+
 // Hardcoded container sizes - should make these dynamic but that can wait for now...
 export const CONTAINER_SIZE = 1000;
 export const CONTAINER_AND_MARGIN_SIZE = 1020;
@@ -26,6 +28,16 @@ export type SearchResultHighlight = {
 
 export type Highlight = SearchResultHighlight; // TODO MRB: add a highlight type for comments
 
+// Used for positioning overlay text
+export type PdfText = {
+  value: string;
+  left: string;
+  top: string;
+  fontSize: string;
+  fontFamily: string;
+  transform: string;
+};
+
 export type Page = {
   // TODO: Do we need this value wrapper? Keep getting lost looking for highlights, then remember I need to expand value
   page: number;
@@ -34,4 +46,12 @@ export type Page = {
   highlights: Highlight[];
   currentLanguage: string;
   allLanguages: string;
+};
+
+export type CachedPreview = {
+  canvas: HTMLCanvasElement;
+  scale: number;
+  // This is returned so that the page renderer can enqueue extracting the
+  // text overlays *after* the first paint which should imporove snappiness.
+  pdfPage: PDFPageProxy;
 };

--- a/frontend/src/js/util/LruCache.ts
+++ b/frontend/src/js/util/LruCache.ts
@@ -1,0 +1,60 @@
+type OnMissFunction<K, V> = (k: K) => V;
+type OnEvictFunction<K, V> = (k: K, v: V) => void;
+
+export class LruCache<K extends string| number, V> {
+    // We keep track of value recency using a queue data structure.
+    //
+    // Here's an tutorial on how a LRU cache can be implemented with queues:
+    //   https://www.interviewcake.com/concept/java/lru-cache
+    // 
+    // The tutorial uses a linked list which has certain performance characteristics which
+    // can be ignored for this implementation since we're using whatever data structure
+    // the browser uses for lists (e.g. https://github.com/v8/v8/blob/d5625e3/src/objects/js-array.h#L20-L24)
+
+    maxEntries: number;
+    recencyQueue: K[] = [];
+    entries: Record<K,V> = {} as Record<K, V>;
+
+    // This function tells the LRU cache how to fetch a new value
+    onMiss: OnMissFunction<K, V>;
+
+    // This function tells the LRU cache what to do when it evicts an item
+    onEvict: OnEvictFunction<K, V>;
+
+    constructor(maxEntries: number, onMiss: OnMissFunction<K, V>, onEvict: OnEvictFunction<K, V> = () => {}) {
+        this.maxEntries = maxEntries;
+        this.onMiss = onMiss;
+        this.onEvict = onEvict;
+    }
+
+  private addToCache = (key: K, value: V) => {
+    this.entries[key] = value;
+    this.recencyQueue.push(key);
+
+    if (this.recencyQueue.length > this.maxEntries) {
+      const evictedEntryKey = this.recencyQueue.shift();
+      if (evictedEntryKey) {
+        const evictedEntry = this.entries[evictedEntryKey];
+        this.onEvict(evictedEntryKey, evictedEntry)
+        delete this.entries[evictedEntryKey];
+      }
+    }
+  };
+
+  private bumpRecency = (key: K) => {
+    const index = this.recencyQueue.findIndex((k) => k === key);
+    this.recencyQueue.splice(index, 1);
+    this.recencyQueue.push(key);
+  };
+
+    get = (k: K): V => {
+        if (this.entries[k]) {
+            this.bumpRecency(k)
+            return this.entries[k];
+        } else {
+            const newValue = this.onMiss(k);
+            this.addToCache(k, newValue)
+            return newValue;
+        }
+    }
+}


### PR DESCRIPTION
Just thought I'd open a PR now because this could get pretty long. This is not production ready but has approximate feature parity with the existing page viewer.

The main intention of this rework is to remove the synchronous nature of the old API in order to give us a well performing foundation for the page viewer MVP.

Rather than modify the existing code I've added new Typescript/Scala files. The older versions can be retired in the future if we decide this is a good approach.

You can access the new version of the page viewer by changing `/viewer/:uri` to `/viewer2/:uri` in this build.

I'll try to be very descriptive in this PR for future info but will happily run through after standup or whatever.

## Previous version

https://user-images.githubusercontent.com/5560113/156780098-b6732ee0-7e95-44e6-af71-ae8fdfb450f8.mov

Previously a few queries to Elasticsearch were sent off and those got the visible pages using a pixel offset in the client's window, once we had the page numbers from ES we could then fetch the individual PDF pages from S3. The first API call did *4* separate calls to Elasticsearch - which in a production environment where ES is on the other side of a network connection produced some pretty unfortunate performance characteristics. Additionally - since the page numbers aren't known until after this call - downloading the PDF pages was blocked until this was complete. In my rough testing I've seen the time to paint a single PDF page be ~800ms in just network latency.

## New version

https://user-images.githubusercontent.com/5560113/156780154-a1eb618f-243b-4bdb-9aa9-d5b22641328b.mov

The new version does the same fundamental work, but reorganised to decrease perceived latency, which you can think of as "time to paint" an individual page to the DOM. It mainly achieves this by allowing the pages to be fetched asynchronously to the text and highlights, caching, and by prefetching results which are off page using a virtual scrolling mechanism.

Information that is only needed once, currently only total page count, is fetched individually to reduce the amount of work done per-page request.

Pages are fetched individually which is a latency/throughput trade-off, I've come down hard on the side of latency. 

Pages are fetched by their page number, which removes the synchronous API call, but at the cost of some rendering complexity. Because we don't know how big the pages dimension are until we fetch the results it's impossible to size the parent scroll area to be the correct height. To get around this we contain individual pages inside a bounding box, which is 1000x1000 pixels at the moment. This also makes having margins and whatnot between pages very easy!

Note that this bounding box approach makes it possible to link to a specific page, which previously would have been expressed as linking to a pixel offset. This would have worked fine, if a bit weird.

I've also made a cache where we render the PDFs to off-DOM canvases which are added to the containers as they scroll into view.

Highlights and text overlays are done separately to the canvas paint - right now the computation of the text overlays is not cached which is not ideal but is much more straight forward.

## Other stuff...
A side benefit of the rewrite is it uses our more modern understanding of react hooks - the original version was written as a first foray into hooks and was a bit messy (at least, according to a Señor engineer formally of this parish who shall go unnamed). I hope the code is easier to follow.

# Production performance data to come...