### PR TITLE
Use specific version of minio, update docker-compose to support this …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,19 +40,20 @@ services:
       - ${PWD}/util/local-cerebro.conf:/opt/cerebro/conf/cerebro.conf
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2022-03-05T06-32-39Z
     container_name: pfi-minio
     environment:
-      MINIO_ACCESS_KEY: minio-user
-      MINIO_SECRET_KEY: reallyverysecret
+      MINIO_ROOT_USER: minio-user
+      MINIO_ROOT_PASSWORD: reallyverysecret
     volumes:
       - minio:/export
     ports:
       - 9090:9000
+      - 9092:9001
     entrypoint:
       sh
     command:
-      -c 'mkdir -p /export/ingest-data && mkdir -p /export/data && mkdir -p /export/preview && /usr/bin/minio server /export'
+      -c 'mkdir -p /export/ingest-data && mkdir -p /export/data && mkdir -p /export/preview && minio server --console-address ":9001" /export'
 
 volumes:
   neo4j:


### PR DESCRIPTION
Giant doesn't currently work locally if you check it out and try to run it. I think this is because the new version of minio is different and requires updates to the docker-compose file. This change fixes the version of minio so this won't happen again, and updates the minio command and environment variables to be compatible with the latest version