### PR TITLE
Move giant to Java 11

### DIFF
--- a/backend/app/extraction/email/msg/MsgEmailExtractor.scala
+++ b/backend/app/extraction/email/msg/MsgEmailExtractor.scala
@@ -3,7 +3,6 @@ package extraction.email.msg
 import java.io.{ByteArrayInputStream, InputStream}
 import java.nio.file.{Files, StandardCopyOption}
 import java.security.DigestInputStream
-
 import cats.syntax.either._
 import com.auxilii.msgparser.OutlookMessageParser
 import com.auxilii.msgparser.model.{OutlookFileAttachment, OutlookMessage, OutlookMsgAttachment}
@@ -17,6 +16,7 @@ import services.{FingerprintServices, ScratchSpace, Tika}
 import utils.attempt.{Failure, UnknownFailure}
 import utils.{DateTimeUtils, Logging}
 
+import java.util.stream.Collectors
 import scala.collection.JavaConverters._
 
 class MsgEmailExtractor(scratch: ScratchSpace, ingestionServices: IngestionServices, tika: Tika) extends Extractor with Logging {
@@ -30,7 +30,7 @@ class MsgEmailExtractor(scratch: ScratchSpace, ingestionServices: IngestionServi
   override def priority = 4
 
   private def getHeaderValue(message: OutlookMessage, header: String): Option[String] = Option(message.getHeaders)
-    .flatMap(_.lines.find(_.startsWith(s"$header:")))
+    .flatMap(_.lines.collect(Collectors.toList[String]).asScala.find(_.startsWith(s"$header:")))
     .map(_.stripPrefix(s"$header:").trim)
     .filter(!_.isEmpty)
 

--- a/backend/app/model/Email.scala
+++ b/backend/app/model/Email.scala
@@ -4,7 +4,6 @@ import java.io.InputStream
 import java.security.MessageDigest
 import java.util
 import java.util.{Base64, Locale}
-
 import com.pff._
 import enumeratum.EnumEntry.Snakecase
 import enumeratum.{EnumEntry, PlayEnum}
@@ -13,6 +12,9 @@ import model.index.IndexedResource
 import org.apache.commons.io.IOUtils
 import play.api.libs.json._
 import utils.{DateTimeUtils, Logging, UriCleaner}
+
+import java.util.stream.Collectors
+import scala.collection.JavaConverters.asScalaBufferConverter
 
 object Priority {
   val NotUrgent = "not_urgent"
@@ -180,9 +182,9 @@ object Email extends Logging {
     val inReplyTo = message.getInReplyToId.hasTextOrNone().toList.flatMap(Email.cleanInReplyTo)
 
     val headers = message.getTransportMessageHeaders
-    val references = headers.lines.find(_.startsWith("References:")).map(_.stripPrefix("References:")).toList.flatMap(Email.cleanInReplyTo)
+    val references = headers.lines.collect(Collectors.toList[String]).asScala.find(_.startsWith("References:")).map(_.stripPrefix("References:")).toList.flatMap(Email.cleanInReplyTo)
 
-    val date = headers.lines.find(_.startsWith("Date:")).flatMap { date =>
+    val date = headers.lines.collect(Collectors.toList[String]).asScala.find(_.startsWith("Date:")).flatMap { date =>
       DateTimeUtils.rfc1123ToIsoDateString(date.stripPrefix("Date: ").trim())
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -174,8 +174,7 @@ lazy val backend = (project in file("backend"))
       "-J-XX:InitialRAMFraction=2",
       "-J-XX:MaxMetaspaceSize=500m",
       "-J-XX:+UseConcMarkSweepGC",
-      "-J-XX:+PrintGCDetails",
-      "-J-XX:+PrintGCDateStamps",
+      "-J-Xlog:gc*",
       "-J-XX:+HeapDumpOnOutOfMemoryError",
       s"-J-Xloggc:/var/log/${name.value}/gc.log",
       s"-J-Dhttp.port=$port"

--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,7 @@ lazy val backend = (project in file("backend"))
     RoutesKeys.routesImport += "utils.Binders._",
     playDefaultPort := port,
 
-    debianPackageDependencies := Seq("openjdk-8-jre-headless"),
+    debianPackageDependencies := Seq("java-11-amazon-corretto-jdk"),
     maintainer in Linux := "Guardian Developers <dig.dev.software@theguardian.com>",
     packageSummary in Linux := description.value,
     packageDescription := description.value,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "giant"
 description := "Tool for journalists to search, analyse and categorise unstructured data, often during an investigation"
 version := "0.1.0"
 
-scalaVersion in ThisBuild := "2.12.5"
+scalaVersion in ThisBuild := "2.12.6"
 
 import com.gu.riffraff.artifact.BuildInfo
 import play.sbt.PlayImport.PlayKeys._

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,10 +10,10 @@ deployments:
     parameters:
       amiEncrypted: true
       amiTags:
-        Recipe: investigations-app
+        Recipe: investigations-giant-app-java11
         AmigoStage: PROD
         Encrypted: pfi-playground
-  
+
   pfi-neo4j-ami-update:
     type: ami-cloudformation-parameter
     app: neo4j
@@ -23,7 +23,7 @@ deployments:
         Recipe: investigations-neo4j
         AmigoStage: PROD
         Encrypted: pfi-playground
-  
+
   pfi-elasticsearch-ami-update:
     type: ami-cloudformation-parameter
     app: elasticsearch
@@ -33,7 +33,7 @@ deployments:
         Recipe: investigations-elasticsearch-7
         AmigoStage: PROD
         Encrypted: pfi-playground
-  
+
   pfi:
     type: autoscaling
     parameters:

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -25,7 +25,7 @@ export CI=true
 
 #Use java 11
 export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
-export PATH=$PATH:$JAVA_HOME
+PATH=$PATH:$JAVA_HOME
 echo $JAVA_HOME
 java -version
 

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -4,9 +4,6 @@ set -e
 # Make Create React App treat warnings as errors
 export CI=true
 
-#Use java 11
-export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
-
 export NVM_DIR="$HOME/.nvm"
 [[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads nvm
 
@@ -25,6 +22,11 @@ cp -r frontend/build/* backend/public
 # Replace the symbolic link we use in dev with the actual file.
 # On Teamcity the JDeb build doesn't seem to follow the symbolic link while packaging, weirdly
 cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/pdf.worker.min.js
+
+#Use java 11
+export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
+echo $JAVA_HOME
+java -version
 
 # Do a full build of PFI including all tests and upload it to Riff-Raff under the playground stack
 sbt -DPFI_STACK=pfi-playground clean riffRaffUploadWithIntegrationTests

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -25,6 +25,7 @@ export CI=true
 
 #Use java 11
 export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
+export PATH=$PATH:$JAVA_HOME
 echo $JAVA_HOME
 java -version
 

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -25,7 +25,7 @@ export CI=true
 
 #Use java 11
 export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
-PATH=$PATH:$JAVA_HOME
+export PATH=$JAVA_HOME/bin:$PATH
 echo $JAVA_HOME
 java -version
 

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -4,6 +4,9 @@ set -e
 # Make Create React App treat warnings as errors
 export CI=true
 
+#Use java 11
+export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
+
 export NVM_DIR="$HOME/.nvm"
 [[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads nvm
 

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -4,24 +4,24 @@ set -e
 # Make Create React App treat warnings as errors
 export CI=true
 
-export NVM_DIR="$HOME/.nvm"
-[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads nvm
-
-nvm install
-nvm use
-
-pushd frontend
-
-npm install
-npm run build
-CI=true npm run test
-
-popd
-
-cp -r frontend/build/* backend/public
-# Replace the symbolic link we use in dev with the actual file.
-# On Teamcity the JDeb build doesn't seem to follow the symbolic link while packaging, weirdly
-cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/pdf.worker.min.js
+#export NVM_DIR="$HOME/.nvm"
+#[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads nvm
+#
+#nvm install
+#nvm use
+#
+#pushd frontend
+#
+#npm install
+#npm run build
+#CI=true npm run test
+#
+#popd
+#
+#cp -r frontend/build/* backend/public
+## Replace the symbolic link we use in dev with the actual file.
+## On Teamcity the JDeb build doesn't seem to follow the symbolic link while packaging, weirdly
+#cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/pdf.worker.min.js
 
 #Use java 11
 export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -4,30 +4,28 @@ set -e
 # Make Create React App treat warnings as errors
 export CI=true
 
-#export NVM_DIR="$HOME/.nvm"
-#[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads nvm
-#
-#nvm install
-#nvm use
-#
-#pushd frontend
-#
-#npm install
-#npm run build
-#CI=true npm run test
-#
-#popd
-#
-#cp -r frontend/build/* backend/public
-## Replace the symbolic link we use in dev with the actual file.
-## On Teamcity the JDeb build doesn't seem to follow the symbolic link while packaging, weirdly
-#cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/pdf.worker.min.js
+export NVM_DIR="$HOME/.nvm"
+[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads nvm
+
+nvm install
+nvm use
+
+pushd frontend
+
+npm install
+npm run build
+CI=true npm run test
+
+popd
+
+cp -r frontend/build/* backend/public
+# Replace the symbolic link we use in dev with the actual file.
+# On Teamcity the JDeb build doesn't seem to follow the symbolic link while packaging, weirdly
+cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/pdf.worker.min.js
 
 #Use java 11
 export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
 export PATH=$JAVA_HOME/bin:$PATH
-echo $JAVA_HOME
-java -version
 
 # Do a full build of PFI including all tests and upload it to Riff-Raff under the playground stack
 sbt -DPFI_STACK=pfi-playground clean riffRaffUploadWithIntegrationTests


### PR DESCRIPTION
## What does this change?
This was originally part of work to get giant onto graviton. I'm not sure we'll achieve that but might as well make use of this work. This moves giant onto Java 11, with the various errors I encountered fixed by the age old method of 'google copy paste'

Upgrade to scala 2.12.6: https://stackoverflow.com/questions/50034684/simulacrum-macro-implementation-not-found
`.lines` now returns a stream https://stackoverflow.com/questions/68864659/problem-rewriting-scala-method-post-upgrade-to-scala-2-12-from-2-11 (I used a different solution to convert from the stream to a list)

## How to test
This is currently live on playground https://playground.pfi.gutools.co.uk/workspaces/56b36105-498f-45a2-a7bb-ddf3a34c0c6c I've tested search and file upload

## How can we measure success?
Newer better faster shinier onwards and upwards
![ooooh](https://c.tenor.com/y4ENtAY68wcAAAAC/oooooh-wonder.gif)