### PR TITLE
move datasets to be above workspaces in sidebar

### DIFF
--- a/frontend/src/js/components/SearchSidebar/SearchSidebar.js
+++ b/frontend/src/js/components/SearchSidebar/SearchSidebar.js
@@ -44,8 +44,10 @@ export class SearchSidebarUnconnected extends React.Component {
     sortFilters = (filters) => {
         // Hard-coded to pull up workspace and dataset (collection  and ingestion) filters
         // as we expect these to be immediately useful as the number of workspaces grow
-        const hardcodedTopLevelFilters = ['workspace', 'ingestion'];
-        const topLevelFilters = filters.filter(({ key }) => hardcodedTopLevelFilters.includes(key));
+        const hardcodedTopLevelFilters = ['ingestion', 'workspace'];
+
+        // Map the hardcoded filters to be the actual filter structure to preserve ordering
+        const topLevelFilters = hardcodedTopLevelFilters.map(key => filters.find(f => f.key === key)).filter(f => f !== undefined);
         const theRest = filters.filter(({ key }) => !hardcodedTopLevelFilters.includes(key)).sort(this.sortByDisplay);
 
         return [...topLevelFilters, ...theRest];


### PR DESCRIPTION
Small quality of life change. 

I've noticed people tend to have a *lot* of workspaces and comparatively few datasets. This is usually caused by public workspaces which take up a lot of vertical screen real estate.

I just swapped them around to make it so datasets appear at the top, which for on going investigations is more useful.