### PR TITLE
Bump tika to 1.22 to remove vulnerability

### DIFF
--- a/backend/app/utils/HtmlToPlainText.scala
+++ b/backend/app/utils/HtmlToPlainText.scala
@@ -1,7 +1,7 @@
 package utils
 
 import org.jsoup.Jsoup
-import org.jsoup.helper.StringUtil
+import org.jsoup.internal.StringUtil
 import org.jsoup.nodes.{Element, Node, TextNode}
 import org.jsoup.select.NodeFilter.FilterResult
 import org.jsoup.select.{NodeFilter, NodeTraversor}

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ lazy val backend = (project in file("backend"))
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the
       // conf/org/apache/tika/mimecustom-mimetypes.xml file
-      "org.apache.tika" % "tika-parsers" % "1.20" exclude("javax.ws.rs", "javax.ws.rs-api"),
+      "org.apache.tika" % "tika-parsers" % "1.22" exclude("javax.ws.rs", "javax.ws.rs-api"),
       // Daft workaround due to https://github.com/sbt/sbt/issues/3618#issuecomment-454528463
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.5",
       "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,


### PR DESCRIPTION
## What does this change?
[Snyk](https://app.snyk.io/org/guardian-investigations/project/a40df7ee-382f-42d9-b182-53f7f515cca4) has identified a vulnerability with Tika which can also bee seen on [maven central](https://mvnrepository.com/artifact/org.apache.tika/tika-parsers).

This bumps tika to the next version without the vulnerability. There's a comment in the code:
```
 // NOTE: When you update tika you need to check if there are any updates required to be made to the
 // conf/org/apache/tika/mimecustom-mimetypes.xml file
```

Here are the release notes for [1.2.1](https://tika.apache.org/1.21/index.html) and [1.2.2](https://tika.apache.org/1.22/index.html) - as far as I can tell there are no updates needed to this file 

## How to test
Deploy to playground and try an ingest. Something for after easter! 