### PR TITLE
Make rex the only allowed stage for giant deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,6 +2,8 @@
 # updating all references to `pfi-playground` in this file between each.
 stacks: [pfi-playground]
 regions: [eu-west-1]
+allowedStages:
+ - rex
 
 deployments:
   pfi-ami-update:


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/riff-raff/pull/692 - rex is the only stage on giant at the moment so let's tell riffraff that