### PR TITLE
Make metric dimension consistent with Lurch

### DIFF
--- a/backend/app/services/MetricsService.scala
+++ b/backend/app/services/MetricsService.scala
@@ -84,9 +84,9 @@ class CloudwatchMetricsService(config: AWSDiscoveryConfig) extends MetricsServic
   def updateMetric(metricName: String, metricValue: Double = 1): Unit =
     updateMetrics(List(MetricUpdate(metricName, metricValue)))
 
-  def recordUsageEvent(username: String): Unit = {
+  def recordUsageEvent(userEmail: String): Unit = {
     val standardisedStage = if (config.stack == "pfi-giant") "PROD" else "CODE"
-    val dimensions = List(("App", "Giant"), ("Stage", standardisedStage), ("Username", username))
+    val dimensions = List(("App", "Giant"), ("Stage", standardisedStage), ("UserEmail", userEmail))
 
     updateMetrics(List(MetricUpdate(Metrics.usageEvents, 1)), dimensions)
   }


### PR DESCRIPTION
## What does this change?

This PR changes the CloudWatch usage metric from Username to UserEmail to be consistent with Lurch's usage metric.

Initially we intented to have Giant send the username to CloudWatch (without "@guardian.co.uk"), as Giant allows login with just username and password (no email address). We had planned to [change UserEmail to Username](https://github.com/guardian/lurch/pull/437) in Lurch for consistency. However, as we are only posting the usage metric on pandomain login for Giant, this only happens when we have an email address. Conseqnetly we no longer need to strip the "@guardian.co.uk" in Lurch to form a username and can simply use the UserEmail dimension in both Lurch and Giant.

Keeping the metric dimensions consistent will enable us to view the usage of individual users across both Lurch and Giant in [Grafana](https://metrics.gutools.co.uk/d/BjGFOolnk/investigations-tools-usage?orgId=1&refresh=1d&from=now-7d&to=now).

## How to test

Has been deployed to [Playground](https://playground.pfi.gutools.co.uk) and CloudWatch is receiving events with the UserEmail dimension.
