### PR TITLE
Fix Snyk workflow: Remove rogue package-lock.json file in root

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,7 +15,7 @@ jobs:
   security:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
-      SKIP_NODE: false
       ORG: guardian-investigations
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
## What does this change?
We had a rogue package-lock file which was causing snyk to think that there should be a package.json file in the root of the project, rather than where it lives in `frontend/`. Removing this file fixes the snyk job. 

I've also dropped the `SKIP_NODE=false` line, because that's the default setting
