### PR TITLE
Use same worker thread for all pages

### DIFF
--- a/frontend/src/js/components/PageViewer/PdfHelpers.ts
+++ b/frontend/src/js/components/PageViewer/PdfHelpers.ts
@@ -2,9 +2,15 @@ import * as pdfjs from "pdfjs-dist";
 import { CachedPreview, CONTAINER_SIZE, PdfText } from "./model";
 
 export const renderPdfPreview = async (
-  buffer: ArrayBuffer
+  buffer: ArrayBuffer,
+  pdfWorker: typeof pdfjs.PDFWorker
 ): Promise<CachedPreview> => {
-  const doc = await pdfjs.getDocument(new Uint8Array(buffer)).promise;
+  const doc = await pdfjs.getDocument({
+    data: new Uint8Array(buffer),
+    // Use the same web worker for all pages
+    worker: pdfWorker
+  }).promise;
+
   const pdfPage = await doc.getPage(1);
 
   const canvas = document.createElement("canvas");


### PR DESCRIPTION
If we don't pass a `worker` to `pdfjs.getDocument()`, pdf.js creates a new worker on every call:

https://github.com/mozilla/pdf.js/blob/5cf116a958548f6596674bf8d5ca0fe64aa2df3c/src/display/api.js#L331-L342

This causes a request to fetch `third-party/pdf.worker.min.js` and a new web worker thread per page loaded. When dragging across many pages, this thread leak crashes the browser when it hits about 30 or 40 threads.

Instead, we can create a worker (via pdf.js's wrapper) when we instantiate the page cache, and pass this in to `getDocument`