### PR TITLE
Add rotate buttons to pdf viewer

### DIFF
--- a/frontend/src/js/components/viewer/EmbeddedPdfViewer.tsx
+++ b/frontend/src/js/components/viewer/EmbeddedPdfViewer.tsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 const viewerLocation = '/third-party/pdfjs-2.4.456-dist/web/viewer.html';
 
+
+
 export function EmbeddedPdfViewer({ doc }: { doc: string }) {
     const url = `${viewerLocation}?file=${doc}`;
 
@@ -14,6 +16,20 @@ export function EmbeddedPdfViewer({ doc }: { doc: string }) {
                 // the configuration. We'd need a release with https://github.com/mozilla/pdf.js/pull/11837.
                 const iframeDocument = iframe.contentDocument!;
                 const toolbarToHide = iframeDocument.querySelector("#toolbarViewerRight");
+                const rotatebuttons = [
+                    iframeDocument.getElementById("pageRotateCcw"),
+                    iframeDocument.getElementById("pageRotateCw")
+                ]
+                rotatebuttons.forEach(elem => {
+                    if (elem) {
+                        // allow to be squashed onto the toolbar
+                        elem.style.minWidth = "0px";
+                        // get rid of descriptor text as there's no space in the toolbar
+                        elem.innerHTML = "";
+                        iframeDocument.getElementById("toolbarViewerLeft")?.append(elem)
+                    }
+                })
+
 
                 if(toolbarToHide) {
                     toolbarToHide.setAttribute('style', 'visibility: hidden');


### PR DESCRIPTION
## What does this change?
This adds rotate clockwise/anticlockwise buttons to giant. It's pretty nasty dom manipulation, but is what's recommended in the pdfjs docs https://pdfjs.express/blog/how-to-build-pdf-viewer-jquery-pdfjs

The rotate buttons normally live in the secondary menu, which we hide in order to get rid of the download button. It might be worth changing our approach there and just hiding download rather than the entire right hand menu. I think even if we do that though it's a good idea to promote the rotate buttons to the main toolbar so they are easy to find.

<img width="305" alt="Screenshot 2022-05-31 at 16 19 15" src="https://user-images.githubusercontent.com/3606555/171209551-326fa5c3-1c8c-4203-b8dc-e990821bb14e.png">

