### PR TITLE
Do not setPagesToLoad twice on init

### DIFF
--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -33,7 +33,7 @@ export const PageViewer: FC<PageViewerProps> = () => {
   const [findSearch, setFind] = useState("");
 
   const [triggerRefresh, setTriggerRefresh] = useState(0);
-  const [preloadPages, setPreloadPages] = useState<number[]>([]);
+  const [pageNumbersToPreload, setPageNumbersToPreload] = useState<number[]>([]);
 
   const [rotation, setRotation] = useState(0);
 
@@ -98,7 +98,7 @@ export const PageViewer: FC<PageViewerProps> = () => {
       (idx) => findSearchHits[idx]
     );
 
-    setPreloadPages(newPreloadPages);
+    setPageNumbersToPreload(newPreloadPages);
   }, [findSearchHits]);
 
   const jumpToNextFindHit = useCallback(() => {
@@ -151,7 +151,7 @@ export const PageViewer: FC<PageViewerProps> = () => {
           triggerHighlightRefresh={triggerRefresh}
           totalPages={totalPages}
           jumpToPage={jumpToPage}
-          preloadPages={preloadPages}
+          pageNumbersToPreload={pageNumbersToPreload}
           onMiddlePageChange={setMiddlePage}
           rotation={rotation}
         />

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -1,9 +1,9 @@
-import _, { debounce } from 'lodash';
+import { debounce, range } from 'lodash';
 import React, { FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { CachedPreview, CONTAINER_AND_MARGIN_SIZE, PageData } from './model';
-import { Page } from "./Page";
-import { PageCache } from "./PageCache";
-import styles from "./VirtualScroll.module.css";
+import { Page } from './Page';
+import { PageCache } from './PageCache';
+import styles from './VirtualScroll.module.css';
 import throttle from 'lodash/throttle';
 
 type VirtualScrollProps = {
@@ -119,7 +119,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   }, [pageHeight, jumpToPage]);
 
   useEffect(() => {
-    const renderedPages = _.range(pageRange.top, pageRange.bottom + 1).map((pageNumber) => {
+    const renderedPages = range(pageRange.top, pageRange.bottom + 1).map((pageNumber) => {
       const cachedPage = pageCache.getPage(pageNumber);
       return {
         pageNumber,

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -53,7 +53,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     pageCache.setFindQuery(findQuery);
   }, [findQuery, pageCache]);
 
-  const [pages, setPages] = useState({bottom: 1, middle: 1, top: 1 + PRELOAD_PAGES});
+  const [pages, setPages] = useState({bottom: 1 + PRELOAD_PAGES, middle: 1, top: 1});
   const debouncedSetPages = useMemo(() => debounce(setPages, 150), [setPages]);
 
   const setPagesFromScrollPosition = useCallback(() => {

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -55,7 +55,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   const [midPage, setMidPage] = useState(1); // Todo hook up to URL
   const [botPage, setBotPage] = useState(1 + PRELOAD_PAGES);
 
-  const getPages = useCallback(() => {
+  const setPagesToLoad = useCallback(() => {
     if (viewport?.current) {
       const v = viewport.current;
 
@@ -78,14 +78,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
       setMiddlePage(newMidPage);
     }
   }, [pageHeight, setMiddlePage, totalPages]);
-
-  const onScroll = () => {
-    getPages();
-  };
-
-  useEffect(() => {
-    getPages();
-  }, [viewport, getPages]);
 
   useLayoutEffect(() => {
     if (viewport?.current && jumpToPage) {
@@ -141,7 +133,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   }, [preloadPages, pageCache]);
 
   return (
-    <div ref={viewport} className={styles.scrollContainer} onScroll={onScroll}>
+    <div ref={viewport} className={styles.scrollContainer} onScroll={setPagesToLoad}>
       <div className={styles.pages} style={{ height: totalPages * pageHeight }}>
         {currentPages.map((page) => (
           <div


### PR DESCRIPTION
We set initial state values for `botPage`, `midPage`, `topPage`, but then we have a `useEffect()` which re-computes them from the viewport on init.

This causes it to unnecessarily unmount the third page on every load, which exposes an underlying problem with promise callbacks firing for pages after they've been unmounted.

The promise [cleanup problem](https://reactjs.org/docs/hooks-effect.html#effects-with-cleanup) needs a separate solution (think we may need to wrap those promises into [cancellable promises](https://dev.to/praveenkumarrr/cancellable-promises-in-react-and-why-is-it-required-5ghf)) but this stops us pointlessly mounting then unmounting the third page on every fresh page load.

# before
<img width="721" alt="Screenshot 2022-05-31 at 16 27 11" src="https://user-images.githubusercontent.com/5122968/171211219-1be34853-db48-4ed2-a304-9f3bfa16e56e.png">

# after
<img width="726" alt="Screenshot 2022-05-31 at 16 27 42" src="https://user-images.githubusercontent.com/5122968/171211237-311b664c-c51b-4ab7-a5a7-83646bc7f9e5.png">
