### PR TITLE
Prevent page request thrashing on scrollbar drag

### DIFF
--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -152,7 +152,7 @@ export const PageViewer: FC<PageViewerProps> = () => {
           totalPages={totalPages}
           jumpToPage={jumpToPage}
           preloadPages={preloadPages}
-          setMiddlePage={setMiddlePage}
+          onMiddlePageChange={setMiddlePage}
           rotation={rotation}
         />
       ) : null}

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -1,9 +1,10 @@
-import _ from "lodash";
-import React, { FC, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import _, { debounce } from 'lodash';
+import React, { FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { CONTAINER_AND_MARGIN_SIZE } from "./model";
 import { Page } from "./Page";
 import { PageCache } from "./PageCache";
 import styles from "./VirtualScroll.module.css";
+import throttle from 'lodash/throttle';
 
 type VirtualScrollProps = {
   uri: string;
@@ -14,7 +15,8 @@ type VirtualScrollProps = {
   totalPages: number;
   jumpToPage: number | null;
   preloadPages: number[];
-  setMiddlePage: (n: number) => void;
+
+  onMiddlePageChange: (n: number) => void;
 
   rotation: number;
 };
@@ -28,7 +30,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   totalPages,
   jumpToPage,
   preloadPages,
-  setMiddlePage,
+  onMiddlePageChange,
 
   rotation,
 }) => {
@@ -52,33 +54,49 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   }, [findQuery, pageCache]);
 
   const [pages, setPages] = useState({bottom: 1, middle: 1, top: 1 + PRELOAD_PAGES});
+  const debouncedSetPages = useMemo(() => debounce(setPages, 150), [setPages]);
 
   const getPages = useCallback(() => {
-    if (viewport?.current) {
-      const v = viewport.current;
+    setPages(currentPages => {
+      console.log('setPages');
+      if (viewport?.current) {
+        const v = viewport.current;
 
-      const currentMid = v.scrollTop + v.clientHeight / 2;
+        const currentMid = v.scrollTop + v.clientHeight / 2;
 
-      const topEdge = currentMid - PRELOAD_PAGES * pageHeight;
-      const botEdge = currentMid + PRELOAD_PAGES * pageHeight;
+        const topEdge = currentMid - PRELOAD_PAGES * pageHeight;
+        const botEdge = currentMid + PRELOAD_PAGES * pageHeight;
 
-      const newMiddle = Math.floor(currentMid / pageHeight) + 1;
-      setPages({
-        bottom: Math.min(Math.ceil(botEdge / pageHeight), totalPages),
-        middle: newMiddle,
-        top: Math.max(Math.floor(topEdge / pageHeight), 1)
-      });
+        const newMiddle = Math.floor(currentMid / pageHeight) + 1;
+        const newPages = {
+          bottom: Math.min(Math.ceil(botEdge / pageHeight), totalPages),
+          middle: newMiddle,
+          top: Math.max(Math.floor(topEdge / pageHeight), 1)
+        }
 
-      // Inform the parent component of the new middle page
-      // This allows it to do useful things such as have a sensible "next" page
-      // to go to for the find hits
-      setMiddlePage(newMiddle);
-    }
-  }, [pageHeight, setMiddlePage, totalPages]);
+        const distanceFromPreviousPage = Math.abs(newPages.middle - currentPages.middle);
+        if (distanceFromPreviousPage > 2) {
+          // If we've jumped around, debounce the page change to avoid spamming
+          // requests and jamming things up handling server responses of pages we'll never see.
+          debouncedSetPages(newPages);
+        } else {
+          // Otherwise, update the pages right away so we get a responsive experience
+          // when scrolling smoothly.
+          return newPages;
+        }
+      }
+      return currentPages
+    });
+  }, [pageHeight, onMiddlePageChange, totalPages]);
 
-  const onScroll = () => {
-    getPages();
-  };
+  useEffect(() => {
+    // Inform the parent component of the new middle page
+    // This allows it to do useful things such as have a sensible "next" page
+    // to go to for the find hits
+    onMiddlePageChange(pages.middle);
+  }, [pages.middle]);
+
+  const onScroll = useMemo(() => throttle(getPages, 75), [getPages]);
 
   useEffect(() => {
     getPages();
@@ -93,7 +111,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   }, [pageHeight, jumpToPage]);
 
   useEffect(() => {
-    console.log('pages: ', pages);
     const renderedPages = _.range(pages.top, pages.bottom + 1).map((pageNumber) => {
       const cachedPage = pageCache.getPage(pageNumber);
       return {


### PR DESCRIPTION
This fixes an issue whereby dragging the scrollbar causes huge numbers of requests for intervening pages. This slows down the loading of the page the user settles on, because of the large number of responses that need to be handled for the pages the user scrolled past.

The solution is to debounce the page number update, but only if there has been a discontinuity in the page numbers. This avoids compromising the experience of smooth scrolling.

Separately, I've also throttled the scroll events to avoid large numbers of calls to `getPages`. This doesn't appear to be an issue on my machine but on a slower one it could be.

# Jumping
## before
https://user-images.githubusercontent.com/5122968/172441224-80984ae6-5ee8-4f40-9302-b468500c949a.mov

## after
https://user-images.githubusercontent.com/5122968/172441269-2e5a9aff-fcb5-488e-a690-f375900cd8cb.mov

# Smooth scrolling
## before
https://user-images.githubusercontent.com/5122968/172441511-859f8c02-bb69-414a-8516-d4dcfe1d3fa4.mov

## after
https://user-images.githubusercontent.com/5122968/172441627-b0ee2e36-a455-40f2-b7fb-4870a0215c2e.mov




