### PR TITLE
Navigate between individual highlights

### DIFF
--- a/backend/app/model/frontend/HighlightableText.scala
+++ b/backend/app/model/frontend/HighlightableText.scala
@@ -19,7 +19,7 @@ object HighlightRange {
   implicit val format: Format[HighlightRange] = Json.format[HighlightRange]
 }
 
-case class TextHighlight(id: String, `type`: HighlightRangeType, range: HighlightRange)
+case class TextHighlight(id: String, index: Int, `type`: HighlightRangeType, range: HighlightRange)
 object TextHighlight {
   implicit val format: Format[TextHighlight] = Json.format[TextHighlight]
 }
@@ -51,6 +51,7 @@ object HighlightableText {
 
       val highlight = TextHighlight(
         id = searchHighlightId(acc.highlights.length, page, isFind),
+        index = acc.highlights.length,
         HighlightRangeType.SearchResult,
         HighlightRange(
           startOfTag + acc.contents.length,

--- a/backend/app/model/index/Page.scala
+++ b/backend/app/model/index/Page.scala
@@ -2,7 +2,7 @@ package model.index
 
 import model.Language
 import model.frontend.HighlightableText
-import play.api.libs.json.{Format, JsNumber, JsString, JsValue, Json, Writes, JsArray}
+import play.api.libs.json.{Format, JsArray, JsNull, JsNumber, JsString, JsValue, Json, Writes}
 
 case class PagesSummary(numberOfPages: Long, height: Double)
 object PagesSummary {
@@ -56,6 +56,35 @@ object PageHighlight {
           "height" -> JsNumber(s.height),
           "rotation" -> JsNumber(s.rotation),
         )
+      })
+    )
+  }
+}
+
+case class HighlightForSearchNavigation(
+  pageNumber: Long,
+  highlightNumber: Long,
+  id: String,
+  firstSpan: Option[HighlightSpan]
+)
+object HighlightForSearchNavigation {
+  def fromPageHighlight(pageNumber: Long, highlightNumber: Long, pageHighlight: PageHighlight) =
+    HighlightForSearchNavigation(pageNumber, highlightNumber, pageHighlight.id, pageHighlight.spans.headOption)
+
+  implicit val writes: Writes[HighlightForSearchNavigation] = { h =>
+    Json.obj(
+      "pageNumber" -> JsNumber(h.pageNumber),
+      "highlightNumber" -> JsNumber(h.highlightNumber),
+      "id" -> JsString(h.id),
+      "firstSpan" -> (h.firstSpan match {
+        case Some(s) => Json.obj(
+          "x" -> JsNumber(s.x),
+          "y" -> JsNumber(s.y),
+          "width" -> JsNumber(s.width),
+          "height" -> JsNumber(s.height),
+          "rotation" -> JsNumber(s.rotation),
+        )
+        case None => JsNull
       })
     )
   }

--- a/backend/app/model/index/Page.scala
+++ b/backend/app/model/index/Page.scala
@@ -18,9 +18,14 @@ object PageDimensions {
 
 case class HighlightSpan(x: Double, y: Double, width: Double, height: Double, rotation: Double)
 
-sealed abstract class PageHighlight { def id: String }
-case class SearchHighlight(id: String, spans: List[HighlightSpan]) extends PageHighlight
-case class FindHighlight(id: String, spans: List[HighlightSpan]) extends PageHighlight
+sealed abstract class PageHighlight {
+  def id: String
+  def index: Int
+  def spans: List[HighlightSpan]
+}
+// TODO: these are identical... why do we need them?
+case class SearchHighlight(id: String, index: Int, spans: List[HighlightSpan]) extends PageHighlight
+case class FindHighlight(id: String, index: Int, spans: List[HighlightSpan]) extends PageHighlight
 // Other types of highlight might include comments or Ctrl-F searches
 
 object PageHighlight {
@@ -28,6 +33,7 @@ object PageHighlight {
     case h: SearchHighlight => Json.obj(
       "type" -> JsString("SearchHighlight"),
       "id" -> JsString(h.id),
+      "index" -> JsNumber(h.index),
       "data" -> JsArray(h.spans.map  { s =>
         Json.obj(
           "x" -> JsNumber(s.x),
@@ -41,6 +47,7 @@ object PageHighlight {
     case h: FindHighlight => Json.obj(
       "type" -> JsString("FindHighlight"),
       "id" -> JsString(h.id),
+      "index" -> JsNumber(h.index),
       "data" -> JsArray(h.spans.map  { s =>
         Json.obj(
           "x" -> JsNumber(s.x),

--- a/backend/app/utils/PDFUtil.scala
+++ b/backend/app/utils/PDFUtil.scala
@@ -131,9 +131,9 @@ object PDFUtil {
       }
 
       if (isFind) {
-        FindHighlight(highlight.id, spans)
+        FindHighlight(highlight.id, highlight.index, spans)
       } else {
-        SearchHighlight(highlight.id, spans)
+        SearchHighlight(highlight.id, highlight.index, spans)
       }
     }
   }

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -15,6 +15,7 @@ type ControlsProps = {
   setFind: (v: string) => void;
 
   performFind: (query: string) => Promise<void>;
+  isPending: boolean;
 
   jumpToNextFindHit: () => void;
   jumpToPreviousFindHit: () => void;
@@ -30,6 +31,7 @@ export const Controls: FC<ControlsProps> = ({
   jumpToNextFindHit,
   jumpToPreviousFindHit,
   performFind,
+  isPending,
   findHighlights,
   focusedFindHighlightIndex,
 }) => {
@@ -50,6 +52,7 @@ export const Controls: FC<ControlsProps> = ({
         highlights={findHighlights}
         focusedFindHighlightIndex={focusedFindHighlightIndex}
         performFind={performFind}
+        isPending={isPending}
         jumpToNextFindHit={jumpToNextFindHit}
         jumpToPreviousFindHit={jumpToPreviousFindHit}
       />

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -3,6 +3,7 @@ import RotateLeft from "react-icons/lib/md/rotate-left";
 import RotateRight from "react-icons/lib/md/rotate-right";
 import styles from "./Controls.module.css";
 import { FindInput } from "./FindInput";
+import { HighlightForSearchNavigation } from './model';
 
 type ControlsProps = {
   // Rotation
@@ -17,8 +18,8 @@ type ControlsProps = {
 
   jumpToNextFindHit: () => void;
   jumpToPreviousFindHit: () => void;
-  findSearchHits: number[];
-  lastPageHit: number;
+  findHighlights: HighlightForSearchNavigation[];
+  focusedFindHighlightIndex: number | null;
 };
 
 export const Controls: FC<ControlsProps> = ({
@@ -29,8 +30,8 @@ export const Controls: FC<ControlsProps> = ({
   jumpToNextFindHit,
   jumpToPreviousFindHit,
   performFind,
-  findSearchHits,
-  lastPageHit,
+  findHighlights,
+  focusedFindHighlightIndex,
 }) => {
   return (
     <div className={styles.bar}>
@@ -46,8 +47,8 @@ export const Controls: FC<ControlsProps> = ({
       <FindInput
         value={findSearch}
         setValue={setFind}
-        hits={findSearchHits}
-        lastPageHit={lastPageHit}
+        highlights={findHighlights}
+        focusedFindHighlightIndex={focusedFindHighlightIndex}
         performFind={performFind}
         jumpToNextFindHit={jumpToNextFindHit}
         jumpToPreviousFindHit={jumpToPreviousFindHit}

--- a/frontend/src/js/components/PageViewer/FindInput.module.css
+++ b/frontend/src/js/components/PageViewer/FindInput.module.css
@@ -18,7 +18,7 @@
   margin: auto;
   position: absolute;
   top: 0;
-  bottom: 4px;
+  bottom: 2px;
   right: 5px;
 }
 

--- a/frontend/src/js/components/PageViewer/FindInput.tsx
+++ b/frontend/src/js/components/PageViewer/FindInput.tsx
@@ -9,6 +9,7 @@ import React, {
 import DownIcon from "react-icons/lib/md/arrow-downward";
 import UpIcon from "react-icons/lib/md/arrow-upward";
 import styles from "./FindInput.module.css";
+import { HighlightForSearchNavigation } from './model';
 
 type FindInputProps = {
   value: string;
@@ -16,8 +17,9 @@ type FindInputProps = {
   performFind: (query: string) => Promise<void>;
   jumpToNextFindHit: () => void;
   jumpToPreviousFindHit: () => void;
-  hits: number[];
-  lastPageHit: number;
+  // TODO: could be null?
+  highlights: HighlightForSearchNavigation[];
+  focusedFindHighlightIndex: number | null;
 };
 
 // The backend will only return 500 pages of hits.
@@ -31,8 +33,8 @@ export const FindInput: FC<FindInputProps> = ({
   jumpToNextFindHit,
   jumpToPreviousFindHit,
   performFind,
-  hits,
-  lastPageHit,
+  highlights,
+  focusedFindHighlightIndex,
 }) => {
   const [showWarning, setShowWarning] = useState(false);
 
@@ -51,13 +53,12 @@ export const FindInput: FC<FindInputProps> = ({
   };
 
   useEffect(() => {
-    if (hits.length >= MAX_HITS) {
+    if (highlights.length >= MAX_HITS) {
       setShowWarning(true);
       setTimeout(() => setShowWarning(false), 5000);
     }
-  }, [hits]);
+  }, [highlights]);
 
-  const currentHit = hits.findIndex((p) => lastPageHit === p);
   return (
     <div className={styles.container}>
       <div className={styles.inputContainer}>
@@ -73,11 +74,11 @@ export const FindInput: FC<FindInputProps> = ({
           }}
         />
         <div className={styles.count}>
-          {currentHit === -1 ? " - " : currentHit + 1}/
-          {hits.length > 0
-            ? hits.length >= MAX_HITS
+          {(focusedFindHighlightIndex !== null) ? focusedFindHighlightIndex + 1 : " - " }/
+          {highlights.length > 0
+            ? highlights.length >= MAX_HITS
               ? ">" + MAX_HITS
-              : hits.length
+              : highlights.length
             : " - "}
         </div>
       </div>

--- a/frontend/src/js/components/PageViewer/FindInput.tsx
+++ b/frontend/src/js/components/PageViewer/FindInput.tsx
@@ -19,7 +19,6 @@ type FindInputProps = {
   isPending: boolean;
   jumpToNextFindHit: () => void;
   jumpToPreviousFindHit: () => void;
-  // TODO: could be null?
   highlights: HighlightForSearchNavigation[];
   focusedFindHighlightIndex: number | null;
 };

--- a/frontend/src/js/components/PageViewer/FindInput.tsx
+++ b/frontend/src/js/components/PageViewer/FindInput.tsx
@@ -66,10 +66,8 @@ export const FindInput: FC<FindInputProps> = ({
       return '';
     }
 
-    const current = (focusedFindHighlightIndex !== null) ? focusedFindHighlightIndex + 1 : " - ";
-    const total = highlights.length > 0
-        ? `${showWarning ? ">" : ""}${highlights.length}`
-        : " - ";
+    const current = (focusedFindHighlightIndex !== null) ? focusedFindHighlightIndex + 1 : 0;
+    const total = `${showWarning ? ">" : ""}${highlights.length}`;
     return `${current}/${total}`
   }, [value, focusedFindHighlightIndex, highlights, showWarning])
 

--- a/frontend/src/js/components/PageViewer/FindInput.tsx
+++ b/frontend/src/js/components/PageViewer/FindInput.tsx
@@ -62,12 +62,16 @@ export const FindInput: FC<FindInputProps> = ({
   }, [highlights]);
 
   const renderFindCount = useCallback(() => {
+    if (!value) {
+      return '';
+    }
+
     const current = (focusedFindHighlightIndex !== null) ? focusedFindHighlightIndex + 1 : " - ";
     const total = highlights.length > 0
         ? `${showWarning ? ">" : ""}${highlights.length}`
         : " - ";
     return `${current}/${total}`
-  }, [focusedFindHighlightIndex, highlights, showWarning])
+  }, [value, focusedFindHighlightIndex, highlights, showWarning])
 
   return (
     <div className={styles.container}>

--- a/frontend/src/js/components/PageViewer/FindInput.tsx
+++ b/frontend/src/js/components/PageViewer/FindInput.tsx
@@ -41,7 +41,7 @@ export const FindInput: FC<FindInputProps> = ({
 }) => {
   const [showWarning, setShowWarning] = useState(false);
 
-    const debouncedPerformSearch = useMemo(() => _.debounce(performFind, 500), [
+  const debouncedPerformSearch = useMemo(() => _.debounce(performFind, 500), [
     performFind,
   ]);
 

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -1,17 +1,19 @@
-import React, { FC, useEffect, useRef, useState } from "react";
-import { CachedPreview, PageData, PdfText } from "./model";
-import styles from "./Page.module.css";
-import { PageHighlight } from "./PageHighlight";
-import { PageOverlayText } from "./PageOverlayText";
-import { renderTextOverlays } from "./PdfHelpers";
+import React, { FC, useEffect, useRef, useState } from 'react';
+import { CachedPreview, PageData, PdfText } from './model';
+import styles from './Page.module.css';
+import { PageHighlight } from './PageHighlight';
+import { PageOverlayText } from './PageOverlayText';
+import { renderTextOverlays } from './PdfHelpers';
 
 type PageProps = {
+  focusedFindHighlightId: string | undefined;
   pageNumber: number;
   getPagePreview: Promise<CachedPreview>;
   getPageData: Promise<PageData>;
 };
 
 export const Page: FC<PageProps> = ({
+  focusedFindHighlightId,
   pageNumber,
   getPagePreview,
   getPageData,
@@ -75,7 +77,7 @@ export const Page: FC<PageProps> = ({
           <PageHighlight
             key={hl.id}
             highlight={hl}
-            focused={false}
+            focused={hl.id === focusedFindHighlightId}
             scale={scale}
           />
         ))}

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -85,6 +85,8 @@ export class PageCache {
   private onDataCacheMiss = (pageNumber: number): CachedPageData => {
     const dataAbortController = new AbortController();
     const textParams = new URLSearchParams();
+    // The backend will respect quotes and do an exact search,
+    // but if quotes are unbalanced elasticsearch will error
     if (this.searchQuery) {
       textParams.set("sq", removeLastUnmatchedQuote(this.searchQuery));
     }

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -3,6 +3,7 @@ import { LruCache } from "../../util/LruCache";
 import { CachedPreview, PageData } from "./model";
 import { renderPdfPreview } from "./PdfHelpers";
 import * as pdfjs from 'pdfjs-dist';
+import { removeLastUnmatchedQuote } from '../../util/stringUtils';
 
 export type CachedPage = {
   previewAbortController: AbortController;
@@ -85,10 +86,10 @@ export class PageCache {
     const dataAbortController = new AbortController();
     const textParams = new URLSearchParams();
     if (this.searchQuery) {
-      textParams.set("sq", this.searchQuery);
+      textParams.set("sq", removeLastUnmatchedQuote(this.searchQuery));
     }
     if (this.findQuery) {
-      textParams.set("fq", this.findQuery);
+      textParams.set("fq", removeLastUnmatchedQuote(this.findQuery));
     }
     const data = authFetch(
       `/api/pages2/${this.uri}/${pageNumber}/text?${textParams.toString()}`,

--- a/frontend/src/js/components/PageViewer/PageHighlight.module.css
+++ b/frontend/src/js/components/PageViewer/PageHighlight.module.css
@@ -18,9 +18,16 @@
 }
 
 .findHighlight::before {
-  background-color: hotpink !important;
+  background-color: hotpink;
+}
+
+.findHighlight.focused::before {
+  background-color: cornflowerblue;
+  box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.5);
+  transition: box-shadow 0.2s;
 }
 
 .searchHighlight::before {
   background-color: #fdb600;
 }
+

--- a/frontend/src/js/components/PageViewer/PageHighlight.tsx
+++ b/frontend/src/js/components/PageViewer/PageHighlight.tsx
@@ -18,7 +18,7 @@ export const PageHighlight: FC<PageHighlightProps> = ({
   const isFind = type === "FindHighlight";
   return (
     <>
-      {highlight.data.map((span, i) => {
+      {highlight.data.map(span => {
         const style: CSSProperties = {
           position: "absolute",
           left: span.x * scale,
@@ -32,14 +32,15 @@ export const PageHighlight: FC<PageHighlightProps> = ({
 
         const classes = [
           styles.highlight,
-          ...(focused ? ["pfi-page-highlight--focused"] : []),
+          ...(focused ? [styles.focused] : []),
           ...(isFind ? [styles.findHighlight] : [styles.searchHighlight]),
         ];
 
         return (
           <span
+            id={id}
+            key={id}
             className={classes.join(" ")}
-            key={`${id}-${i}`}
             style={style}
           />
         );

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -79,6 +79,8 @@ export const PageViewer: FC<PageViewerProps> = () => {
           setFindHighlights(highlights);
           if (highlights.length) {
             setFocusedFindHighlightIndex(0);
+          } else {
+            setFocusedFindHighlightIndex(null);
           }
           setTriggerRefresh((t) => t + 1);
         })

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -67,6 +67,8 @@ export const PageViewer: FC<PageViewerProps> = () => {
   const performFind = useCallback(
     (query: string) => {
       const params = new URLSearchParams();
+      // The backend will respect quotes and do an exact search,
+      // but if quotes are unbalanced elasticsearch will error
       params.set("fq", removeLastUnmatchedQuote(query));
 
       setIsFindPending(true);

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -108,26 +108,21 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   // TODO: try just useEffect
   useLayoutEffect(() => {
     if (viewport?.current) {
-      const v = viewport.current;
       if (jumpToPage) {
-        // TODO: page jump should go to middle?
         const scrollTo = (jumpToPage - 1) * pageHeight;
-        v.scrollTop = scrollTo;
+        viewport.current.scrollTop = scrollTo;
       }
       if (jumpToScrollPosition) {
-        const scrollTo = jumpToScrollPosition + (v.clientHeight / 2);
-        v.scrollTop = scrollTo;
+        const scrollTo = jumpToScrollPosition + (viewport.current.clientHeight / 2);
+        viewport.current.scrollTop = scrollTo;
       }
     }
   }, [pageHeight, jumpToPage, jumpToScrollPosition]);
 
   useLayoutEffect(() => {
     if (viewport?.current && focusedFindHighlight) {
-      const v = viewport.current;
       const topOfHighlightPage = (pageHeight * (focusedFindHighlight.pageNumber - 1));
-      // const highlight = topOfHighlightPage + (focusedFindHighlight.firstSpan?.y ?? 0);
-      // v.scrollTop = highlight + (v.clientHeight / 2);
-      v.scrollTop = topOfHighlightPage;
+      viewport.current.scrollTop = topOfHighlightPage;
     }
   }, [pageHeight, focusedFindHighlight]);
 

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -17,7 +17,6 @@ type VirtualScrollProps = {
   pageNumbersToPreload: number[];
 
   jumpToPage?: number | null;
-  jumpToScrollPosition?: number;
 
   rotation: number;
 };
@@ -43,7 +42,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
 
   totalPages,
   jumpToPage,
-  jumpToScrollPosition,
   pageNumbersToPreload,
 
   rotation,
@@ -112,12 +110,8 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
         const scrollTo = (jumpToPage - 1) * pageHeight;
         viewport.current.scrollTop = scrollTo;
       }
-      if (jumpToScrollPosition) {
-        const scrollTo = jumpToScrollPosition + (viewport.current.clientHeight / 2);
-        viewport.current.scrollTop = scrollTo;
-      }
     }
-  }, [pageHeight, jumpToPage, jumpToScrollPosition]);
+  }, [pageHeight, jumpToPage]);
 
   useLayoutEffect(() => {
     if (viewport?.current && focusedFindHighlight) {

--- a/frontend/src/js/components/PageViewer/model.ts
+++ b/frontend/src/js/components/PageViewer/model.ts
@@ -61,3 +61,10 @@ export type CachedPreview = {
   // text overlays *after* the first paint which should imporove snappiness.
   pdfPage: PDFPageProxy;
 };
+
+export type HighlightForSearchNavigation = {
+  pageNumber: number,
+  highlightNumber: number,
+  id: string,
+  firstSpan: {x: number, y: number, height: number, rotation: number, width: number} | null,
+};

--- a/frontend/src/js/util/stringUtils.ts
+++ b/frontend/src/js/util/stringUtils.ts
@@ -1,3 +1,11 @@
 export function getLastPart(input: string, separator: string) {
-    return input.split(separator).slice(-1)[0];
+  return input.split(separator).slice(-1)[0];
+}
+
+export function removeLastUnmatchedQuote(input: string) {
+  const quoteCount = [...input.matchAll(/"/g)].length;
+  if ((quoteCount % 2) !== 0) {
+    return input.replace(/(.*)(")(.*)$/, '$1$3');
+  }
+  return input;
 }


### PR DESCRIPTION
Since our existing text view (as well as Google Docs) allows navigation between individual highlights, I thought it would be good to have it behave this way in the new page viewer.

The backend now gets the page hits (which is fast), and then for each page hit parses the highlights (which is slower).

So for searches with hits on lots of page, performance is noticeably slower. But more specific searches return quickly.

In Playground searching Functional Programming in Scala:
- "the" takes 10 seconds
- "function" takes 6 seconds
- "monoidal" takes 366 milliseconds

## Other changes
- Spinner while find is pending
- Do not quote the query when getting find hits, i.e. allow stemming by default and let the user put quotes if they don't want stemming. (Beforehand we were quoting when getting the page hits, but not when rendering highlights, leading to a mismatch between visible highlights and the navigation)

## Notes on stemming/tokenisation
- Because we use elasticsearch to do the find operation, it searches for occurrences of word stems by default
  - i.e. `functional` will match `function`, `functions`, `functional`, etc
- You can search for exact matches by quoting
  - i.e. `"functional"` will only match `functional`
- However you cannot search within tokens/words regardless of quotes
  - i.e. neither `"sc"` nor `sc` will match `scala`, but `s` will match usages of `s` as a variable name in code examples
- This **differs** from typical find functionality (Google Docs, Preview, browser Cmd+F etc), but is **consistent** with Giant's primary search functionality
- There is a [detailed ADR](https://github.com/guardian/pfi/blob/1dca05c24b24e79322d7e00dbe7da2c723b92d24/docs/adrs/2020-09-28_quoted-searches.md) about our approach to quoted searches in Giant more generally

# before

https://user-images.githubusercontent.com/5122968/174096748-7ec8d1be-3724-47e7-a2cf-fc8398faf2e6.mov



# after

https://user-images.githubusercontent.com/5122968/174096836-ee85d5de-5c61-4afb-9db1-0afc6241ebdb.mov



