### PR TITLE
Move highlight state to <Controls /> component

### DIFF
--- a/backend/app/controllers/api/PagesController.scala
+++ b/backend/app/controllers/api/PagesController.scala
@@ -120,8 +120,8 @@ class PagesController(val controllerComponents: AuthControllerComponents, manife
     }
   }
 
-  def findInDocument(uri: Uri, fq: String) = ApiAction.attempt { req =>
-    val findQuery = fq
+  def findInDocument(uri: Uri, q: String) = ApiAction.attempt { req =>
+    val findQuery = q
 
     for {
       pagesWithHits <- pagesService.findInPages(uri, findQuery)

--- a/backend/app/controllers/api/PagesController.scala
+++ b/backend/app/controllers/api/PagesController.scala
@@ -120,6 +120,9 @@ class PagesController(val controllerComponents: AuthControllerComponents, manife
     }
   }
 
+  // This endpoint is used for both "find in document" on-demand queries,
+  // and for getting highlights for the "search across documents" query which
+  // should be fixed for the lifetime of the page viewer of a given document.
   def findInDocument(uri: Uri, q: String) = ApiAction.attempt { req =>
     val findQuery = q
 

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -33,7 +33,7 @@ GET           /api/pages/text/:uri                                          cont
 GET           /api/pages/preview/:language/:uri/:pageNumber                 controllers.api.Resource.getPagePreview(uri: model.Uri, language: model.Language, pageNumber: Int)
 
 GET           /api/pages2/:uri/pageCount                                    controllers.api.PagesController.getPageCount(uri: model.Uri)
-GET           /api/pages2/:uri/find                                         controllers.api.PagesController.findInDocument(uri: model.Uri, fq: String)
+GET           /api/pages2/:uri/find                                         controllers.api.PagesController.findInDocument(uri: model.Uri, q: String)
 GET           /api/pages2/:uri/:pageNumber/preview                          controllers.api.PagesController.getPagePreview(uri: model.Uri, pageNumber: Int)
 GET           /api/pages2/:uri/:pageNumber/text                             controllers.api.PagesController.getPageData(uri: model.Uri, pageNumber: Int, sq: Option[String], fq: Option[String])
 

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -42,7 +42,7 @@ export const Controls: FC<ControlsProps> = ({
 
 
   const performFind = useCallback((query: string) => {
-    const params = new URLSearchParams();
+   const params = new URLSearchParams();
     // The backend will respect quotes and do an exact search,
     // but if quotes are unbalanced elasticsearch will error
     // TODO: change to "q"

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -66,7 +66,7 @@ export const Controls: FC<ControlsProps> = ({
           setFocusedFindHighlightIndex(null);
         }
       })
-  },   [uri]);
+  },   [uri, onQueryChange]);
 
 
   const jumpToNextFindHit = useCallback(() => {

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -23,7 +23,7 @@ export const Controls: FC<ControlsProps> = ({
   rotateAnticlockwise,
   uri,
   onHighlightStateChange,
-    onQueryChange
+  onQueryChange
 }) => {
   const [focusedFindHighlightIndex, setFocusedFindHighlightIndex] = useState<number | null>(null);
   const [findHighlights, setFindHighlights] = useState<HighlightForSearchNavigation[]>([]);
@@ -45,6 +45,7 @@ export const Controls: FC<ControlsProps> = ({
     if (!query) {
       setFocusedFindHighlightIndex(null);
       setFindHighlights([]);
+      onQueryChange(query);
       return;
     }
 
@@ -127,8 +128,6 @@ export const Controls: FC<ControlsProps> = ({
       </div>
 
       <FindInput
-        value={findQuery}
-        setValue={setFindQuery}
         highlights={findHighlights}
         focusedFindHighlightIndex={focusedFindHighlightIndex}
         performFind={performFind}

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -11,8 +11,8 @@ type ControlsProps = {
   rotateAnticlockwise: () => void;
 
   // Find Search Input
-  findSearch: string;
-  setFind: (v: string) => void;
+  query: string;
+  setQuery: (v: string) => void;
 
   performFind: (query: string) => Promise<void>;
   isPending: boolean;
@@ -26,8 +26,8 @@ type ControlsProps = {
 export const Controls: FC<ControlsProps> = ({
   rotateClockwise,
   rotateAnticlockwise,
-  findSearch,
-  setFind,
+  query,
+  setQuery,
   jumpToNextFindHit,
   jumpToPreviousFindHit,
   performFind,
@@ -47,8 +47,8 @@ export const Controls: FC<ControlsProps> = ({
       </div>
 
       <FindInput
-        value={findSearch}
-        setValue={setFind}
+        value={query}
+        setValue={setQuery}
         highlights={findHighlights}
         focusedFindHighlightIndex={focusedFindHighlightIndex}
         performFind={performFind}

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -1,40 +1,114 @@
-import React, { FC } from "react";
-import RotateLeft from "react-icons/lib/md/rotate-left";
-import RotateRight from "react-icons/lib/md/rotate-right";
-import styles from "./Controls.module.css";
-import { FindInput } from "./FindInput";
+import React, { FC, useCallback, useEffect, useState } from 'react';
+import RotateLeft from 'react-icons/lib/md/rotate-left';
+import RotateRight from 'react-icons/lib/md/rotate-right';
+import styles from './Controls.module.css';
+import { FindInput } from './FindInput';
 import { HighlightForSearchNavigation } from './model';
+import { removeLastUnmatchedQuote } from '../../util/stringUtils';
+import authFetch from '../../util/auth/authFetch';
+import { HighlightsState } from './PageViewer';
 
 type ControlsProps = {
   // Rotation
   rotateClockwise: () => void;
   rotateAnticlockwise: () => void;
 
-  // Find Search Input
-  query: string;
-  setQuery: (v: string) => void;
-
-  performFind: (query: string) => Promise<void>;
-  isPending: boolean;
-
-  jumpToNextFindHit: () => void;
-  jumpToPreviousFindHit: () => void;
-  findHighlights: HighlightForSearchNavigation[];
-  focusedFindHighlightIndex: number | null;
+  uri: string;
+  onHighlightStateChange: (newState: HighlightsState) => void;
+  onQueryChange: (newQuery: string) => void;
 };
 
 export const Controls: FC<ControlsProps> = ({
   rotateClockwise,
   rotateAnticlockwise,
-  query,
-  setQuery,
-  jumpToNextFindHit,
-  jumpToPreviousFindHit,
-  performFind,
-  isPending,
-  findHighlights,
-  focusedFindHighlightIndex,
+  uri,
+  onHighlightStateChange,
+    onQueryChange
 }) => {
+  const [focusedFindHighlightIndex, setFocusedFindHighlightIndex] = useState<number | null>(null);
+  const [findHighlights, setFindHighlights] = useState<HighlightForSearchNavigation[]>([]);
+  // TODO: should we use ths?
+  const [, setFindVisible] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const [isFindPending, setIsFindPending] = useState<boolean>(false);
+
+  useEffect(() => {
+    console.log('focusedFindHighlightIndex: ', focusedFindHighlightIndex);
+    onHighlightStateChange({
+      focusedIndex: focusedFindHighlightIndex,
+      highlights: findHighlights
+    });
+  }, [focusedFindHighlightIndex, findHighlights, onHighlightStateChange])
+
+
+  const performFind = useCallback((query: string) => {
+    const params = new URLSearchParams();
+    // The backend will respect quotes and do an exact search,
+    // but if quotes are unbalanced elasticsearch will error
+    // TODO: change to "q"
+    params.set("fq", removeLastUnmatchedQuote(query));
+
+    // In order to use same debounce on communicating query change to parent
+    onQueryChange(query);
+    setIsFindPending(true);
+    return authFetch(`/api/pages2/${uri}/find?${params.toString()}`)
+      .then((res) => res.json())
+      .then((highlights) => {
+        setIsFindPending(false);
+        setFindHighlights(highlights);
+        if (highlights.length) {
+          console.log('setFocusedFindHighlightIndex to 0');
+          setFocusedFindHighlightIndex(0);
+        } else {
+          setFocusedFindHighlightIndex(null);
+        }
+      })
+  },   [uri]);
+
+
+  const jumpToNextFindHit = useCallback(() => {
+    if (findHighlights.length > 0) {
+      const nextHighlightIndex = (focusedFindHighlightIndex !== null && focusedFindHighlightIndex < (findHighlights.length - 1))
+          ? (focusedFindHighlightIndex + 1)
+          : 0;
+
+      setFocusedFindHighlightIndex(nextHighlightIndex);
+    }
+  }, [findHighlights, focusedFindHighlightIndex, setFocusedFindHighlightIndex]);
+
+  const jumpToPreviousFindHit = useCallback(() => {
+    if (findHighlights.length > 0) {
+      const previousHighlightIndex = (focusedFindHighlightIndex !== null && focusedFindHighlightIndex > 0)
+          ? (focusedFindHighlightIndex - 1)
+          : (findHighlights.length - 1);
+
+      setFocusedFindHighlightIndex(previousHighlightIndex);
+    }
+  }, [findHighlights, focusedFindHighlightIndex, setFocusedFindHighlightIndex]);
+
+  const handleUserKeyPress = useCallback((e) => {
+    if ((e.ctrlKey || e.metaKey) && e.keyCode === 70) {
+      e.preventDefault();
+      setFindVisible(true);
+
+      const maybeInput = document.getElementById(
+          "find-search-input"
+      ) as HTMLInputElement;
+      if (maybeInput) {
+        maybeInput.focus();
+        maybeInput.setSelectionRange(0, maybeInput.value.length);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleUserKeyPress);
+    return () => {
+      window.removeEventListener("keydown", handleUserKeyPress);
+    };
+  }, [handleUserKeyPress]);
+
+
   return (
     <div className={styles.bar}>
       <div>
@@ -47,12 +121,12 @@ export const Controls: FC<ControlsProps> = ({
       </div>
 
       <FindInput
-        value={query}
-        setValue={setQuery}
+        value={findQuery}
+        setValue={setFindQuery}
         highlights={findHighlights}
         focusedFindHighlightIndex={focusedFindHighlightIndex}
         performFind={performFind}
-        isPending={isPending}
+        isPending={isFindPending}
         jumpToNextFindHit={jumpToNextFindHit}
         jumpToPreviousFindHit={jumpToPreviousFindHit}
       />

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -32,7 +32,6 @@ export const Controls: FC<ControlsProps> = ({
   const [isFindPending, setIsFindPending] = useState<boolean>(false);
 
   useEffect(() => {
-    console.log('focusedFindHighlightIndex: ', focusedFindHighlightIndex);
     onHighlightStateChange({
       focusedIndex: focusedFindHighlightIndex,
       highlights: findHighlights
@@ -62,7 +61,6 @@ export const Controls: FC<ControlsProps> = ({
         setIsFindPending(false);
         setFindHighlights(highlights);
         if (highlights.length) {
-          console.log('setFocusedFindHighlightIndex to 0');
           setFocusedFindHighlightIndex(0);
         } else {
           setFocusedFindHighlightIndex(null);

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -42,7 +42,13 @@ export const Controls: FC<ControlsProps> = ({
 
 
   const performFind = useCallback((query: string) => {
-   const params = new URLSearchParams();
+    if (!query) {
+      setFocusedFindHighlightIndex(null);
+      setFindHighlights([]);
+      return;
+    }
+
+    const params = new URLSearchParams();
     // The backend will respect quotes and do an exact search,
     // but if quotes are unbalanced elasticsearch will error
     // TODO: change to "q"

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -29,7 +29,6 @@ export const Controls: FC<ControlsProps> = ({
   const [findHighlights, setFindHighlights] = useState<HighlightForSearchNavigation[]>([]);
   // TODO: should we use ths?
   const [, setFindVisible] = useState(false);
-  const [findQuery, setFindQuery] = useState("");
   const [isFindPending, setIsFindPending] = useState<boolean>(false);
 
   useEffect(() => {

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -51,8 +51,7 @@ export const Controls: FC<ControlsProps> = ({
     const params = new URLSearchParams();
     // The backend will respect quotes and do an exact search,
     // but if quotes are unbalanced elasticsearch will error
-    // TODO: change to "q"
-    params.set("fq", removeLastUnmatchedQuote(query));
+    params.set("q", removeLastUnmatchedQuote(query));
 
     // In order to use same debounce on communicating query change to parent
     onQueryChange(query);

--- a/frontend/src/js/components/PageViewer/FindInput.tsx
+++ b/frontend/src/js/components/PageViewer/FindInput.tsx
@@ -15,7 +15,7 @@ import { Loader } from 'semantic-ui-react';
 type FindInputProps = {
   value: string;
   setValue: (v: string) => void;
-  performFind: (query: string) => Promise<void>;
+  performFind: (query: string) => Promise<void> | undefined;
   isPending: boolean;
   jumpToNextFindHit: () => void;
   jumpToPreviousFindHit: () => void;

--- a/frontend/src/js/components/PageViewer/FindInput.tsx
+++ b/frontend/src/js/components/PageViewer/FindInput.tsx
@@ -13,8 +13,6 @@ import { HighlightForSearchNavigation } from './model';
 import { Loader } from 'semantic-ui-react';
 
 type FindInputProps = {
-  value: string;
-  setValue: (v: string) => void;
   performFind: (query: string) => Promise<void> | undefined;
   isPending: boolean;
   jumpToNextFindHit: () => void;
@@ -29,8 +27,6 @@ type FindInputProps = {
 const MAX_PAGE_HITS = 500;
 
 export const FindInput: FC<FindInputProps> = ({
-  value,
-  setValue,
   jumpToNextFindHit,
   jumpToPreviousFindHit,
   performFind,
@@ -43,6 +39,8 @@ export const FindInput: FC<FindInputProps> = ({
   const debouncedPerformSearch = useMemo(() => _.debounce(performFind, 500), [
     performFind,
   ]);
+
+  const [value, setValue] = useState('');
 
   const onKeyDown: KeyboardEventHandler = (event) => {
     if (event.key === "Enter") {

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -123,12 +123,28 @@ export class PageCache {
   };
 
   getPageAndRefreshHighlights = (pageNumber: number): CachedPage => {
+    if (this.findQuery) {
+      const preview = this.previewCache.get(pageNumber);
+      const data = this.dataCache.getAndForceRefresh(pageNumber);
+
+      return {
+        ...preview,
+        ...data,
+      };
+    } else {
+      return this.getPageAndWipeHighlights(pageNumber);
+    }
+  };
+
+  getPageAndWipeHighlights = (pageNumber: number): CachedPage => {
     const preview = this.previewCache.get(pageNumber);
-    const data = this.dataCache.getAndForceRefresh(pageNumber);
+    const data = this.dataCache.get(pageNumber);
+    // TODO: Is it a good idea to mutate??
+    data.data = data.data.then(d => ({...d, highlights: []}));
 
     return {
       ...preview,
       ...data,
     };
-  };
+  }
 }

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -139,7 +139,6 @@ export class PageCache {
   getPageAndWipeHighlights = (pageNumber: number): CachedPage => {
     const preview = this.previewCache.get(pageNumber);
     const data = this.dataCache.get(pageNumber);
-    // TODO: Is it a good idea to mutate??
     data.data = data.data.then(d => ({...d, highlights: []}));
 
     return {

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -25,8 +25,10 @@ export const PageViewer: FC<PageViewerProps> = () => {
 
   const [totalPages, setTotalPages] = useState<number | null>(null);
 
+  // The below are stored here because they are set (debounced) by
+  // <Controls /> when the user types in the find query box, and are used
+  // by <VirtualScroll /> to refresh highlights and preload pages with hits.
   const [findQuery, setFindQuery] = useState('');
-
   const [findHighlightsState, setFindHighlightsState] = useState<HighlightsState>({
     focusedIndex: null,
     highlights: []

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -12,6 +12,7 @@ type PageViewerProps = {
 };
 
 export type HighlightsState = {
+  // Beware !focusedIndex for checking null, since it can be 0
   focusedIndex: number | null,
   highlights: HighlightForSearchNavigation[]
 };
@@ -30,6 +31,7 @@ export const PageViewer: FC<PageViewerProps> = () => {
   // by <VirtualScroll /> to refresh highlights and preload pages with hits.
   const [findQuery, setFindQuery] = useState('');
   const [findHighlightsState, setFindHighlightsState] = useState<HighlightsState>({
+    // Beware !focusedIndex for checking null, since it can be 0
     focusedIndex: null,
     highlights: []
   });

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -45,7 +45,6 @@ export const PageViewer: FC<PageViewerProps> = () => {
   }, [uri]);
 
   useEffect(() => {
-    // TODO: better way of handling null? so it doesn't cause bugs that escape type checker
     if (findHighlightsState.focusedIndex !== null && findHighlightsState.highlights.length) {
       const length = findHighlightsState.highlights.length;
 

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -21,13 +21,21 @@ export const PageViewer: FC<PageViewerProps> = () => {
 
   const [totalPages, setTotalPages] = useState<number | null>(null);
 
-  // Find searching...
+  // Finding (within document)
   const [focusedFindHighlightIndex, setFocusedFindHighlightIndex] = useState<number | null>(null);
   const [focusedFindHighlight, setFocusedFindHighlight] = useState<HighlightForSearchNavigation | null>(null);
   const [findHighlights, setFindHighlights] = useState<HighlightForSearchNavigation[]>([]);
+  // TODO: should we use ths?
   const [, setFindVisible] = useState(false);
-  const [findSearch, setFind] = useState("");
+  const [findQuery, setFindQuery] = useState("");
   const [isFindPending, setIsFindPending] = useState<boolean>(false);
+
+  // Searching (from main Giant cross-document search)
+  const [focusedSearchHighlightIndex, setFocusedSearchHighlightIndex] = useState<number | null>(null);
+  const [focusedSearchHighlight, setFocusedSearchHighlight] = useState<HighlightForSearchNavigation | null>(null);
+  const [searchHighlights, setSearchHighlights] = useState<HighlightForSearchNavigation[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isSearchPending, setIsSearchPending] = useState<boolean>(false);
 
   const [triggerRefresh, setTriggerRefresh] = useState(0);
   const [pageNumbersToPreload, setPageNumbersToPreload] = useState<number[]>([]);
@@ -142,9 +150,9 @@ export const PageViewer: FC<PageViewerProps> = () => {
       <Controls
         rotateAnticlockwise={() => setRotation((r) => r - 90)}
         rotateClockwise={() => setRotation((r) => r + 90)}
-        findSearch={findSearch}
-        setFind={(q) => {
-          setFind(q);
+        query={findQuery}
+        setQuery={(q) => {
+          setFindQuery(q);
         }}
         findHighlights={findHighlights}
         focusedFindHighlightIndex={focusedFindHighlightIndex}
@@ -157,7 +165,7 @@ export const PageViewer: FC<PageViewerProps> = () => {
         <VirtualScroll
           uri={uri}
           query={query}
-          findQuery={findSearch}
+          findQuery={findQuery}
           focusedFindHighlight={focusedFindHighlight}
           triggerHighlightRefresh={triggerRefresh}
           totalPages={totalPages}

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -32,17 +32,7 @@ export const PageViewer: FC<PageViewerProps> = () => {
     highlights: []
   });
 
-  // const [triggerRefresh, setTriggerRefresh] = useState(0);
-
   const [pageNumbersToPreload, setPageNumbersToPreload] = useState<number[]>([]);
-
-  // useEffect(() => {
-  //   // setTriggerRefresh(current => current + 1);
-  // }, [findHighlightsState.highlights])
-
-  // useEffect(() => {
-  //   setTriggerRefresh(current => current + 1);
-  // }, [findQuery]);
 
   const [rotation, setRotation] = useState(0);
 
@@ -53,7 +43,6 @@ export const PageViewer: FC<PageViewerProps> = () => {
   }, [uri]);
 
   useEffect(() => {
-    console.log('findHighlightsState.focusedIndex: ', findHighlightsState.focusedIndex);
     // TODO: better way of handling null? so it doesn't cause bugs that escape type checker
     if (findHighlightsState.focusedIndex !== null && findHighlightsState.highlights.length) {
       const length = findHighlightsState.highlights.length;
@@ -66,9 +55,6 @@ export const PageViewer: FC<PageViewerProps> = () => {
             return ((offsetIndex % length) + length) % length;
           })
       );
-
-      console.log('indexesOfHighlightsToPreload: ', indexesOfHighlightsToPreload);
-      console.log('findHighlightsState.highlights: ', findHighlightsState.highlights);
 
       const newPreloadPages = uniq(indexesOfHighlightsToPreload.map(
           (idx) => findHighlightsState.highlights[idx].pageNumber
@@ -103,7 +89,6 @@ export const PageViewer: FC<PageViewerProps> = () => {
           query={query}
           findQuery={findQuery}
           focusedFindHighlight={focusedFindHighlight}
-          // triggerHighlightRefresh={triggerRefresh}
           totalPages={totalPages}
           pageNumbersToPreload={pageNumbersToPreload}
           rotation={rotation}

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -7,6 +7,7 @@ import { VirtualScroll } from './VirtualScroll';
 import { HighlightForSearchNavigation } from './model';
 import { range, uniq } from 'lodash';
 import { removeLastUnmatchedQuote } from '../../util/stringUtils';
+import { PageCache } from './PageCache';
 
 type PageViewerProps = {
   page: number;
@@ -19,6 +20,8 @@ export const PageViewer: FC<PageViewerProps> = () => {
 
   const { uri } = useParams<{ uri: string }>();
 
+  const [pageCache] = useState(() => new PageCache(uri, query));
+
   const [totalPages, setTotalPages] = useState<number | null>(null);
 
   // Finding (within document)
@@ -30,13 +33,6 @@ export const PageViewer: FC<PageViewerProps> = () => {
   const [findQuery, setFindQuery] = useState("");
   const [isFindPending, setIsFindPending] = useState<boolean>(false);
 
-  // Searching (from main Giant cross-document search)
-  const [focusedSearchHighlightIndex, setFocusedSearchHighlightIndex] = useState<number | null>(null);
-  const [focusedSearchHighlight, setFocusedSearchHighlight] = useState<HighlightForSearchNavigation | null>(null);
-  const [searchHighlights, setSearchHighlights] = useState<HighlightForSearchNavigation[]>([]);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [isSearchPending, setIsSearchPending] = useState<boolean>(false);
-
   const [triggerRefresh, setTriggerRefresh] = useState(0);
   const [pageNumbersToPreload, setPageNumbersToPreload] = useState<number[]>([]);
 
@@ -47,6 +43,16 @@ export const PageViewer: FC<PageViewerProps> = () => {
       .then((res) => res.json())
       .then((obj) => setTotalPages(obj.pageCount));
   }, [uri]);
+
+  // TODO: move into Controls
+  useEffect(() => {
+    pageCache.setFindQuery(findQuery);
+  }, [findQuery, pageCache]);
+
+  // TODO: move into Controls
+  useEffect(() => {
+    pageNumbersToPreload.forEach((pageNumber) => pageCache.getPage(pageNumber));
+  }, [pageNumbersToPreload, pageCache]);
 
   // Keypress overrides
   const handleUserKeyPress = useCallback((e) => {
@@ -164,12 +170,10 @@ export const PageViewer: FC<PageViewerProps> = () => {
       {totalPages ? (
         <VirtualScroll
           uri={uri}
-          query={query}
-          findQuery={findQuery}
+          pageCache={pageCache}
           focusedFindHighlight={focusedFindHighlight}
           triggerHighlightRefresh={triggerRefresh}
           totalPages={totalPages}
-          pageNumbersToPreload={pageNumbersToPreload}
           rotation={rotation}
         />
       ) : null}

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -63,6 +63,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   const [renderedPages, setRenderedPages] = useState<RenderedPage[]>([]);
 
   useEffect(() => {
+    console.log('findQuery: ', findQuery);
     pageCache.setFindQuery(findQuery);
     setRenderedPages((currentPages) => {
       const newPages: RenderedPage[] = currentPages.map((page) => {

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -57,6 +57,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
 
   const viewport = useRef<HTMLDivElement>(null);
 
+  // TODO: move pageCache up?
   const [pageCache] = useState(() => new PageCache(uri, query));
 
   // We have a second tier cache tied to the React component lifecycle for storing

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -11,7 +11,6 @@ type VirtualScrollProps = {
   query?: string;
   findQuery?: string;
   focusedFindHighlight: HighlightForSearchNavigation | null;
-  // triggerHighlightRefresh: number;
 
   totalPages: number;
   pageNumbersToPreload: number[];
@@ -38,7 +37,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   query,
   findQuery,
   focusedFindHighlight,
-  // triggerHighlightRefresh,
 
   totalPages,
   jumpToPage,
@@ -63,7 +61,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   const [renderedPages, setRenderedPages] = useState<RenderedPage[]>([]);
 
   useEffect(() => {
-    console.log('findQuery: ', findQuery);
     pageCache.setFindQuery(findQuery);
     setRenderedPages((currentPages) => {
       const newPages: RenderedPage[] = currentPages.map((page) => {
@@ -162,13 +159,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
 
     setRenderedPages(renderedPages);
   }, [pageRange.top, pageRange.bottom, pageCache, setRenderedPages]);
-
-  // TODO: try use useEffect
-  // useLayoutEffect(() => {
-  //   if (triggerHighlightRefresh > 0) {
-  //
-  //   }
-  // }, [triggerHighlightRefresh, pageCache]);
 
   useEffect(() => {
     pageNumbersToPreload.forEach((pageNumber) => pageCache.getPage(pageNumber));

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -8,16 +8,11 @@ import throttle from 'lodash/throttle';
 
 type VirtualScrollProps = {
   uri: string;
-  query?: string;
-  findQuery?: string;
   focusedFindHighlight: HighlightForSearchNavigation | null;
   triggerHighlightRefresh: number;
-
+  pageCache: PageCache;
   totalPages: number;
-  pageNumbersToPreload: number[];
-
   jumpToPage?: number | null;
-
   rotation: number;
 };
 
@@ -35,15 +30,11 @@ type PageRange = {
 
 export const VirtualScroll: FC<VirtualScrollProps> = ({
   uri,
-  query,
-  findQuery,
   focusedFindHighlight,
   triggerHighlightRefresh,
-
+  pageCache,
   totalPages,
   jumpToPage,
-  pageNumbersToPreload,
-
   rotation,
 }) => {
   // Tweaked this and 2 seems to be a good amount on a regular monitor
@@ -55,16 +46,9 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
 
   const viewport = useRef<HTMLDivElement>(null);
 
-  // TODO: move pageCache up?
-  const [pageCache] = useState(() => new PageCache(uri, query));
-
   // We have a second tier cache tied to the React component lifecycle for storing
   // rendered pages which allows us to swap out stale pages without flickering pages
   const [renderedPages, setRenderedPages] = useState<RenderedPage[]>([]);
-
-  useEffect(() => {
-    pageCache.setFindQuery(findQuery);
-  }, [findQuery, pageCache]);
 
   const [pageRange, setPageRange] = useState<PageRange>({bottom: 1 + PRELOAD_PAGES, middle: 1, top: 1});
   const debouncedSetPageRange = useMemo(() => debounce(setPageRange, 150), [setPageRange]);
@@ -167,10 +151,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
       });
     }
   }, [triggerHighlightRefresh, pageCache]);
-
-  useEffect(() => {
-    pageNumbersToPreload.forEach((pageNumber) => pageCache.getPage(pageNumber));
-  }, [pageNumbersToPreload, pageCache]);
 
   return (
     <div ref={viewport} className={styles.scrollContainer} onScroll={throttledSetPageRangeFromScrollPosition}>

--- a/frontend/src/js/util/LruCache.ts
+++ b/frontend/src/js/util/LruCache.ts
@@ -83,4 +83,8 @@ export class LruCache<K extends string | number, V> {
 
     return newValue;
   };
+
+  replace = (k: K, v: V): void => {
+    this.addToCache(k, v);
+  }
 }


### PR DESCRIPTION
There is a lot of state associated with highlights and navigating between them.

In order to not duplicate it all when I add "search in document" highlighting, I've moved as much as possible into `<Controls />` so that when I add the search controls I'll get a lot of functionality for free and properly encapsulated.

On refactor, the complex chain of state changes culminating in `triggerHighlightRefresh` was causing bugs, so I made the following changes:
- Remove `triggerHighlightRefresh` and refresh highlights when `findQuery` changes
- Group `pageCache.setFindQuery` and the subsequent re-rendering of pages together in the above effect to reduce chance that these end up out of sync
- Do not go to the server when `findQuery` is emptied, but rather wipe the highlights from cached pages. This has the effect that on initial page load (when `findQuery` is empty) we do not hit the server and cause an unnecessary re-render, which was causing some weird issues. (Previously the `triggerHighightRefresh > 0` check prevented this)