### PR TITLE
CLI delete ingestion improvements

### DIFF
--- a/cli/src/main/scala/com/gu/pfi/cli/DeleteIngestions.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/DeleteIngestions.scala
@@ -4,11 +4,12 @@ import com.gu.pfi.cli.service.CliIngestionService
 import utils.Logging
 import utils.attempt.{Attempt, IllegalStateFailure}
 import _root_.model.index.IndexedBlob
+import com.gu.pfi.cli.model.{ConflictBehaviour, Delete, Skip, Stop}
 
 import scala.concurrent.ExecutionContext
 import utils.attempt.AttemptAwait._
 
-class DeleteIngestions(ingestions: List[(String, String)], ingestionService: CliIngestionService)(implicit ec: ExecutionContext) extends Logging {
+class DeleteIngestions(ingestions: List[(String, String)], ingestionService: CliIngestionService, conflictBehaviour: Option[ConflictBehaviour])(implicit ec: ExecutionContext) extends Logging {
   private val ingestionUris = ingestions.map { case (c, i) => c + '/' + i }
 
   def run(): Attempt[Unit] = Attempt.catchNonFatalBlasé {
@@ -40,10 +41,23 @@ class DeleteIngestions(ingestions: List[(String, String)], ingestionService: Cli
     val conflictingIngestions = b.ingestion.filterNot(ingestionUris.contains)
 
     if(conflictingIngestions.nonEmpty) {
-      Attempt.Left(IllegalStateFailure(
-        s"""${b.uri} cannot be deleted as it is also present in [${conflictingIngestions.mkString(" ")}].
+      conflictBehaviour.getOrElse(Stop) match {
+        case Stop =>
+          Attempt.Left(IllegalStateFailure(
+            s"""${b.uri} cannot be deleted as it is also present in [${conflictingIngestions.mkString(" ")}].
         To delete it (and any other conflicting files) re-run the command passing in additional ingestions""")
-      )
+          )
+        case Skip =>
+          logger.warn(
+            s"""${b.uri} in [${b.ingestion.mkString(", ")}] is also present in [${conflictingIngestions.mkString(" ")}].
+           Skipping for now.""".stripMargin)
+          Attempt.Right(Unit)
+        case Delete =>
+              logger.warn(
+                s"""${b.uri} in [${b.ingestion.mkString(", ")}] is also present in [${conflictingIngestions.mkString(" ")}].
+                   Deleting it from all locations.""".stripMargin)
+              ingestionService.deleteBlob(b.uri)
+      }
     } else {
       logger.info(s"Deleting ${b.uri} from [${b.ingestion.mkString(", ")}]")
       ingestionService.deleteBlob(b.uri)

--- a/cli/src/main/scala/com/gu/pfi/cli/Main.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/Main.scala
@@ -134,7 +134,7 @@ object Main extends App with Logging {
 
     case Some(cmd @ options.deleteIngestions) =>
       run("Delete ingestions", cmd) { services =>
-        val command = new DeleteIngestions(cmd.ingestionUris, services.ingestion)
+        val command = new DeleteIngestions(cmd.ingestionUris, services.ingestion, cmd.conflictBehaviour)
         command.run()
       }
 

--- a/cli/src/main/scala/com/gu/pfi/cli/Options.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/Options.scala
@@ -1,8 +1,8 @@
 package com.gu.pfi.cli
 
 import java.io.File
-
-import _root_.model.{Language, Languages, English}
+import _root_.model.{English, Language, Languages}
+import com.gu.pfi.cli.model.{ConflictBehaviour, Delete, Skip, Stop}
 import enumeratum.{Enum, EnumEntry}
 import org.rogach.scallop.{DefaultConverters, ScallopConf, Subcommand, ValueConverter}
 
@@ -152,6 +152,20 @@ class Options(args: Seq[String]) extends ScallopConf(args) {
     def ingestionUris: List[(String, String)] = ingestionUrisOpt().map { uri =>
       val parts = uri.split("/")
       (parts.head, parts.last)
+    }
+
+    val conflictBehaviourOpt = opt[String](
+      name = "conflictBehaviour",
+      descr =
+        """
+          |What to do when a blob in the ingest is also included in another ingest. Valid options: delete,skip,stop.
+          |Note that if you select 'delete' the blob will be deleted from all ingestions in giant.
+        """.stripMargin,
+      noshort = true)
+    def conflictBehaviour: Option[ConflictBehaviour] = conflictBehaviourOpt.toOption.map {
+      case Skip.name => Skip
+      case Delete.name => Delete
+      case Stop.name => Stop
     }
   }
 

--- a/cli/src/main/scala/com/gu/pfi/cli/model/ConflictBehaviour.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/model/ConflictBehaviour.scala
@@ -1,0 +1,14 @@
+package com.gu.pfi.cli.model
+
+trait ConflictBehaviour {
+  def name: String
+}
+case object Delete extends ConflictBehaviour {
+  val name = "delete"
+}
+case object Skip extends ConflictBehaviour {
+  val name = "skip"
+}
+case object Stop extends ConflictBehaviour {
+  val name = "stop"
+}

--- a/cli/src/main/scala/com/gu/pfi/cli/service/CliIngestionService.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/service/CliIngestionService.scala
@@ -72,7 +72,8 @@ class CliIngestionService(http: CliHttpClient)(implicit ec: ExecutionContext) ex
   }
 
   def deleteBlob(id: String): Attempt[Unit] = {
-    http.delete(s"/api/blobs/$id?deleteFolders=false&checkChildren=false").map { r =>
+
+    http.delete(s"/api/blobs/${URLEncoder.encode(id, "UTF-8")}?deleteFolders=false&checkChildren=false").map { r =>
       if(r.code() == 204) {
         Attempt.Right(())
       } else {

--- a/cli/src/main/scala/com/gu/pfi/cli/service/CliIngestionService.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/service/CliIngestionService.scala
@@ -73,6 +73,11 @@ class CliIngestionService(http: CliHttpClient)(implicit ec: ExecutionContext) ex
 
   def deleteBlob(id: String): Attempt[Unit] = {
 
+    // delete the blob. deleteFolders=false is a very confusing param which should be fixed in a future pr. It means
+    // "don't search for the parent of the blob and delete that" - which we don't need to do in this context as everything
+    // is being deleted. Likewise checkChildren is a fairly silly name - setting it to false means that we delete this blob
+    // regardless of whether or not it has children. Both of these params need better names following their introduction
+    // in https://github.com/guardian/giant/pull/42
     http.delete(s"/api/blobs/${URLEncoder.encode(id, "UTF-8")}?deleteFolders=false&checkChildren=false").map { r =>
       if(r.code() == 204) {
         Attempt.Right(())


### PR DESCRIPTION
## What does this change?
Prior to this PR, the delete-ingest CLI command only worked where the blobs in an ingestion didn't exist in any other ingestions, or you specified every single ingestion URI where the files included in an ingestion are included.

This was a problem as there are lots of files that are likely to exist all over the place, for example `.DS_Store` files created by macOS. 

This introduces a new `--conflictBehaviour` parameter allowing cli users to specify the behaviour in the scenario where a file exists in more than one ingestion. The options are:

 - stop: the previous behaviour - throw an exception explaining what's gone wrong, including sharing the names of the other places the file exists
 - skip: skip the file but carry on deleting everything else in the ingest
 - delete: delete the file anyway (this deletes the file from ALL locations in giant - so e.g. EVERY .DS_Store file)

## How to test

I've tested this locally by creating/deleting data from playground

## How can we measure success?
Easier ingestion deletion in future!
