### PR TITLE
Close PDF document

### DIFF
--- a/backend/app/controllers/api/PagesController.scala
+++ b/backend/app/controllers/api/PagesController.scala
@@ -76,13 +76,17 @@ class PagesController(val controllerComponents: AuthControllerComponents, manife
         try {
           val pdf = PDDocument.load(pdfData)
 
-          val highlightSpans = highlights.getOrElse(lang, Nil)
-          val findHighlightSpans = findHighlights.getOrElse(lang, Nil)
+          try {
+            val highlightSpans = highlights.getOrElse(lang, Nil)
+            val findHighlightSpans = findHighlights.getOrElse(lang, Nil)
 
-          val highlightGeometries = PDFUtil.getSearchResultHighlights(highlightSpans, pdf, pageNumber, false)
-          val findHighlightGeometries = PDFUtil.getSearchResultHighlights(findHighlightSpans, pdf, pageNumber, true)
+            val highlightGeometries = PDFUtil.getSearchResultHighlights(highlightSpans, pdf, pageNumber, false)
+            val findHighlightGeometries = PDFUtil.getSearchResultHighlights(findHighlightSpans, pdf, pageNumber, true)
 
-          HighlightGeometries(lang, highlightGeometries ++ findHighlightGeometries)
+            HighlightGeometries(lang, highlightGeometries ++ findHighlightGeometries)
+          } finally {
+            pdf.close()
+          }
         } finally {
           pdfData.close()
         }


### PR DESCRIPTION
We were previously getting loads of warnings like this:

```
[WARN] 2022-07-05 11:48:33 +0100 - org.apache.pdfbox.cos.COSDocument - Finalizer - Warning: You did not close a PDF Document
```

solved by `pdf.close()` after extracting highlights