### PR TITLE
Only count pages with 'new' id type when returning pageviewer page count

### DIFF
--- a/backend/app/controllers/api/PagesController.scala
+++ b/backend/app/controllers/api/PagesController.scala
@@ -20,6 +20,7 @@ class PagesController(val controllerComponents: AuthControllerComponents, manife
     index: Index, pagesService: Pages2, annotations: Annotations, previewStorage: ObjectStorage) extends AuthApiController {
 
   def getPageCount(uri: Uri) = ApiAction.attempt { req =>
+
     pagesService.getPageCount(uri).map(count => Ok(Json.obj("pageCount" -> count)))
   }
 

--- a/backend/app/services/index/Pages2.scala
+++ b/backend/app/services/index/Pages2.scala
@@ -18,19 +18,39 @@ class Pages2(val client: ElasticClient, indexNamePrefix: String)(implicit val ex
   extends ElasticsearchSyntax with Logging {
   val textIndexName = s"$indexNamePrefix-text"
 
-  def getPageCount(uri: Uri): Attempt[Long] = {
+  private def firstPageExistsInNewIdFormat(uri: Uri): Attempt[Boolean] = {
+    // Only count documents whose id is of the format `{documentHash}-{pageNumber}`,
+    // to avoid telling the frontend to try and render documents that were uploaded before
+    // the id format changed in https://github.com/guardian/pfi/pull/884 and https://github.com/guardian/pfi/pull/886
     execute {
       count(textIndexName).query(
-        boolQuery().must(
-          termQuery(PagesFields.resourceId, uri.value),
-          // Only count documents whose id is of the format `{documentHash}-{pageNumber}`,
-          // to avoid telling the frontend to try and render documents that were uploaded before
-          // the id format changed in https://github.com/guardian/pfi/pull/884 and https://github.com/guardian/pfi/pull/886
-          prefixQuery("_id", s"${uri.value}")
-        )
+        termQuery("_id", s"${uri.value}-1")
+      )
+    }.map { resp =>
+      resp.count > 0
+    }
+  }
+
+  private def pageCount(uri: Uri): Attempt[Long] = {
+    execute {
+      count(textIndexName).query(
+        termQuery(PagesFields.resourceId, uri.value)
       )
     }.map { resp =>
       resp.count
+    }
+  }
+
+  def getPageCount(uri: Uri): Attempt[Long] = {
+    for {
+      hasPages <- firstPageExistsInNewIdFormat(uri)
+      count <- pageCount(uri)
+    } yield {
+      if (!hasPages) {
+        0
+      } else {
+        count
+      }
     }
   }
 

--- a/backend/app/services/index/Pages2.scala
+++ b/backend/app/services/index/Pages2.scala
@@ -21,7 +21,10 @@ class Pages2(val client: ElasticClient, indexNamePrefix: String)(implicit val ex
   def getPageCount(uri: Uri): Attempt[Long] = {
     execute {
       count(textIndexName).query(
-        termQuery(PagesFields.resourceId, uri.value),
+        boolQuery().must(
+          termQuery(PagesFields.resourceId, uri.value),
+          prefixQuery("_id", s"${uri.value}")
+        )
       )
     }.map { resp =>
       resp.count

--- a/backend/app/services/index/Pages2.scala
+++ b/backend/app/services/index/Pages2.scala
@@ -23,6 +23,9 @@ class Pages2(val client: ElasticClient, indexNamePrefix: String)(implicit val ex
       count(textIndexName).query(
         boolQuery().must(
           termQuery(PagesFields.resourceId, uri.value),
+          // Only count documents whose id is of the format `{documentHash}-{pageNumber}`,
+          // to avoid telling the frontend to try and render documents that were uploaded before
+          // the id format changed in https://github.com/guardian/pfi/pull/884 and https://github.com/guardian/pfi/pull/886
           prefixQuery("_id", s"${uri.value}")
         )
       )


### PR DESCRIPTION
The format of the id used for pages in ES and S3 changed in https://github.com/guardian/pfi/pull/884 and https://github.com/guardian/pfi/pull/886 to be

```
{documentHash}-{pageNumber}
```

We use the `pageCount` endpoint to determine whether to use the page viewer or fall back to the old text/OCR/preview viewer. This means that documents with the old id would have a non-zero page count, but fetching the page preview or data by id would fail because of the different id format.

This PR changes the `pageCount` endpoint to return 0 pages for documents with the old id, which will tell the frontend to fall back to the old viewer.

Examples of old-style and new-style ES pages docs:

## Old id
```json
{
  "_index": "pfi-pages-text",
  "_type": "_doc",
  "_id": "_z1TYXIBKUVvS4VMPvmz",
  "_version": 1,
  "_score": 0,
  "_source": {
    "resourceId": "TbzD1ZdaGDFcVduonjP_3BWM-lpMrU1H4xKS61qqr5QO4giJYZxZDNqJEs7O-qTzbIa1GTtYJ_rDfW1WKKjrEA",
    "dimensions.width": 1190.52001953125,
    "dimensions.height": 841.9199829101562,
    "dimensions.bottom": 841.9199829101562,
    "page": 1,
    "value": {
      "english": "OFFICIAL: Potential impact of behavioural and social interventions on a Covid-19 epidemic in the UK – 9 March 2020 \n \nOFFICIAL \n \nPotential impact of behavioural and social interventions on an epidemic of Covid-19 in the UK \n \nPurpose: \n1. This paper outlines the available scientific evidence base around behavioural and social interventions (previously referred to as non-pharmaceutical interventions) that could be applied as part \nof the HMG response to a UK epidemic of Covid-19, including the expected impacts on the spread of the virus and public behaviours. The note does not cover economic, operational or policy \nconsiderations. \n \n2. SAGE advises that a combination of individual home isolation of symptomatic cases, household isolation and social distancing of the over 70s1 could have a positive effect on: delaying the \nonset of the peak; reducing the number of cases during the peak; and reducing the total number of cases.  Any decision must consider the impacts these interventions may have on society, on \nindividuals, the workforce and businesses, and the operation of Government and public services.  \n \nBackground: \n3. In the event of a severe epidemic, the NHS will be unable to meet all demands placed on it. In the reasonable worst-case scenario, demand on beds is likely to overtake supply well before the \npeak is reached.  \n \n4. There are a range of behavioural and social interventions which are evidenced as having been effective in responding to historic epidemics. These interventions are well understood by the \npublic and have been enacted in other countries.  Modelling suggests as compliance drops so does impact, but there is no major inflexion point at which a drop in compliance leads to a \ndisproportionate drop in effect. \n \n5. Applying these interventions could be helpful in containing an epidemic to some degree or changing the shape of the epidemiological curve, see figure 1, potentially making the response of the \nNHS and other sectors more sustainable. The objectives of these interventions could be to:  \n1. Contain the outbreak so that it does not become an epidemic; \n2. Delaying the peak so it occurs when the NHS is out of Winter pressures;  \n3. Reducing the size of and/or extending the peak so that the response by the NHS and other sectors can be maintained more sustainably; and  \n4. Reducing the total number of deaths by limiting the number of cases in vulnerable groups. \n \n6. Any intervention would need to be Government policy for a significant duration (2-3 months) in order to see the benefit, as removing and/or relaxing the intervention too early could result in a \nnew outbreak and potentially extend transmission of the virus into Winter 2020.  However, the timescale for this are uncertain and would need to be kept under review to provide confidence \nthat these are in place to sufficiently cover the peak of the outbreak. \n \n7. SAGE advises that measures relating to individual and household isolation will likely need to be enacted within the next two weeks to be fully effective, and those concerning social distancing \nof the elderly and vulnerable 2-3 weeks after this.  However, the triggers for individual and household isolation could be met earlier depending on the progress of the outbreak in the UK.  CMO, \nGCSA and PHE will review case numbers daily to advise further on the meeting of any trigger points.  \n \n \n \n \n \n1 To be discussed and agreed by SAGE on 10 March as a change from over 65’s \n"
    },
    "dimensions.top": 0
  },
  "highlight": {
    "resourceId": [
      "@kibana-highlighted-field@TbzD1ZdaGDFcVduonjP_3BWM-lpMrU1H4xKS61qqr5QO4giJYZxZDNqJEs7O-qTzbIa1GTtYJ_rDfW1WKKjrEA@/kibana-highlighted-field@"
    ]
  }
}
```

## New id
```json
{
  "_index": "pfi-pages-text",
  "_type": "_doc",
  "_id": "R78l_QnuESe0S0aGZ_N2ki7eSJyHeiGo-EKYxPUBlPgyYf6rE8Up2i9osL8-ZmAjppBv7QnA8ZgbYFq5Pd_J_w-1",
  "_version": 2,
  "_score": 0,
  "_source": {
    "resourceId": "R78l_QnuESe0S0aGZ_N2ki7eSJyHeiGo-EKYxPUBlPgyYf6rE8Up2i9osL8-ZmAjppBv7QnA8ZgbYFq5Pd_J_w",
    "dimensions.width": 530.1599731445312,
    "page": 1,
    "dimensions.top": 0,
    "dimensions.bottom": 668.4000244140625,
    "dimensions.height": 668.4000244140625,
    "value": {
      "english": "C/) \nPaul Chiusano \nRunar Bjarnason \nIga MANNING Foreword by Martin Odersky\n"
    }
  },
  "highlight": {
    "resourceId": [
      "@kibana-highlighted-field@R78l_QnuESe0S0aGZ_N2ki7eSJyHeiGo-EKYxPUBlPgyYf6rE8Up2i9osL8-ZmAjppBv7QnA8ZgbYFq5Pd_J_w@/kibana-highlighted-field@"
    ]
  }
}
```