### PR TITLE
Send AWS SDK metrics to CloudWatch

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -2,10 +2,10 @@ import java.net.InetAddress
 import java.nio.file.Paths
 import java.security.Security
 import java.time.Clock
-
 import akka.actor.CoordinatedShutdown
 import akka.actor.CoordinatedShutdown.Reason
 import cats.syntax.either._
+import com.amazonaws.metrics.AwsSdkMetrics
 import com.gu.pandomainauth
 import com.gu.pandomainauth.PublicSettings
 import controllers.AssetsComponents
@@ -72,6 +72,12 @@ class AppComponents(context: Context, config: Config)
     val neo4jExecutionContext = actorSystem.dispatchers.lookup("neo4j-context")
     val s3ExecutionContext = actorSystem.dispatchers.lookup("s3-context")
     val ingestionExecutionContext = actorSystem.dispatchers.lookup("ingestion-context")
+
+    config.aws foreach { awsDiscoveryConfig =>
+      AwsSdkMetrics.enableDefaultMetrics()
+      AwsSdkMetrics.setCredentialProvider(AwsCredentials())
+      AwsSdkMetrics.setMetricNameSpace(s"${awsDiscoveryConfig.stack}-${awsDiscoveryConfig.app}-${awsDiscoveryConfig.stage}")
+    }
 
     val s3Client = new S3Client(config.s3)(s3ExecutionContext)
 

--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -1,11 +1,6 @@
-import java.net.InetAddress
-import java.nio.file.Paths
-import java.security.Security
-import java.time.Clock
 import akka.actor.CoordinatedShutdown
 import akka.actor.CoordinatedShutdown.Reason
 import cats.syntax.either._
-import com.amazonaws.metrics.AwsSdkMetrics
 import com.gu.pandomainauth
 import com.gu.pandomainauth.PublicSettings
 import controllers.AssetsComponents
@@ -39,14 +34,18 @@ import services.manifest.Neo4jManifest
 import services.previewing.PreviewService
 import services.table.ElasticsearchTable
 import services.users.Neo4jUserManagement
+import utils._
 import utils.attempt.AttemptAwait._
+import utils.auth.providers.{DatabaseUserProvider, PanDomainUserProvider}
 import utils.auth.totp.{SecureSecretGenerator, Totp}
 import utils.auth.{DefaultAuthActionBuilder, PasswordHashing, PasswordValidator}
 import utils.aws.S3Client
-import utils._
-import utils.auth.providers.{DatabaseUserProvider, PanDomainUserProvider}
-import utils.controller.{AuthControllerComponents, CloudWatchReportingFailureToResultMapper, DefaultFailureToResultMapper}
+import utils.controller.{AuthControllerComponents, CloudWatchReportingFailureToResultMapper}
 
+import java.net.InetAddress
+import java.nio.file.Paths
+import java.security.Security
+import java.time.Clock
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps

--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -73,12 +73,6 @@ class AppComponents(context: Context, config: Config)
     val s3ExecutionContext = actorSystem.dispatchers.lookup("s3-context")
     val ingestionExecutionContext = actorSystem.dispatchers.lookup("ingestion-context")
 
-    config.aws foreach { awsDiscoveryConfig =>
-      AwsSdkMetrics.enableDefaultMetrics()
-      AwsSdkMetrics.setCredentialProvider(AwsCredentials())
-      AwsSdkMetrics.setMetricNameSpace(s"${awsDiscoveryConfig.stack}-${awsDiscoveryConfig.app}-${awsDiscoveryConfig.stage}")
-    }
-
     val s3Client = new S3Client(config.s3)(s3ExecutionContext)
 
     val workerName = config.worker.name.getOrElse(InetAddress.getLocalHost.getHostName)

--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,7 @@ lazy val backend = (project in file("backend"))
       "com.amazonaws" % "aws-java-sdk-ssm" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
+      "com.amazonaws" % "aws-java-sdk-cloudwatchmetrics" % awsVersion,
       "com.beachape" %% "enumeratum-play" % "1.6.1",
       "com.iheart" %% "ficus" % "1.4.4",
       "com.sun.mail" % "javax.mail" % "1.6.2",
@@ -170,6 +171,7 @@ lazy val backend = (project in file("backend"))
 
     Universal / javaOptions ++= Seq(
       "-Dpidfile.path=/dev/null",
+      "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=eu-west-1",
       "-J-XX:MaxRAMFraction=2",
       "-J-XX:InitialRAMFraction=2",
       "-J-XX:MaxMetaspaceSize=500m",


### PR DESCRIPTION
# The problem
In the past we've had Giant incidents caused by exhaustion of the S3 connection pool.

We've tried to mitigate by closing input streams (https://github.com/guardian/pfi/pull/924, #11) but they still crop up sometimes during large ingestions when the workers have lots of connections to S3.

The new page viewer (#32) has made this more common because it also makes lots of requests to S3 for individual pages.

# The solution
We want to get visibility on when we're in danger of hitting this issue. AWS provides extra metrics from its Java SDK, including around connection pools to AWS services such as S3, but you need to do some special stuff to enable it.

You can apparently do it by calling some methods on `AwsSdkMetrics`:
https://aws.amazon.com/blogs/developer/tuning-the-aws-sdk-for-java-to-improve-resiliency/

Or by setting some JVM options:
https://aws.amazon.com/blogs/developer/enabling-metrics-with-the-aws-sdk-for-java/

What neither of those tell you is **you need an extra dependency for it to work**:

```scala
"com.amazonaws" % "aws-java-sdk-cloudwatchmetrics" % awsVersion
```

# How they appear in CloudWatch
By default, they appear under custom namespaces formed from the stack/app/stage tags (no idea how AWS knows by default to use these... thought they were a Guardian-specific convention?)

If this is unhelpful I think we can customise. I haven't really played with CloudWatch metrics enough to know what makes the most sense

## top-level
<img width="1086" alt="Screzenshot 2022-08-11 at 12 50 59" src="https://user-images.githubusercontent.com/5122968/184127420-57dc36fc-f291-4cd1-ac14-9823437a5352.png">

## > pfi-playground-rex
Some useful JVM stuff in these other categories, e.g. heap space, number of threads, etc
<img width="1086" alt="Screenshot 2022-08-11 at 12 51 06" src="https://user-images.githubusercontent.com/5122968/184127427-eb99f845-2a1d-4a29-b6dc-240a0dcfd29b.png">

## > pfi-playground-rex > Metric Type
for some reason the connection pool metrics come under this generic "Metric Type" heading
<img width="1085" alt="Screenshot 2022-08-11 at 12 51 33" src="https://user-images.githubusercontent.com/5122968/184127428-311cf7ee-fa93-4a26-9372-9ddf97181ed2.png">

