### PR TITLE
Fix email preview, use wkhtmltopdf for html to pdf conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ There are two optional dependencies:
   - `brew install tesseract`
 - [Libre Office](https://www.libreoffice.org/)
   - To convert and preview Microsoft Office documents in the UI
+- [wkhtmltopdf](https://wkhtmltopdf.org/)
+  - To preview html files (such as emails)
+  - `brew install wkhtmltopdf`
 
 Elasticsearch requires Docker to have at least 4GB of memory from the preferences menu otherwise
 it will exit with no log output and error 137.

--- a/backend/app/services/Config.scala
+++ b/backend/app/services/Config.scala
@@ -123,7 +123,7 @@ case class IngestConfig(
 
 case class PreviewConfig(
   libreOfficeBinary: String,
-  chromiumBinary: String,
+  wkhtmltopdfBinary: String,
   workspace: String
 )
 

--- a/backend/app/services/previewing/HtmlPreviewGenerator.scala
+++ b/backend/app/services/previewing/HtmlPreviewGenerator.scala
@@ -15,7 +15,7 @@ class HtmlPreviewGenerator(binary: String, workspace: Path) extends PreviewGener
   }
 
   override def buildCommand(workspace: String, input: String, output: String): Seq[String] = {
-    Seq(binary, "--headless", "--disable-gpu", s"--print-to-pdf=$output", s"file://$input")
+    Seq("wkhtmltopdf", "--enable-local-file-access", input, output)
   }
 }
 

--- a/backend/app/services/previewing/HtmlPreviewGenerator.scala
+++ b/backend/app/services/previewing/HtmlPreviewGenerator.scala
@@ -15,7 +15,7 @@ class HtmlPreviewGenerator(binary: String, workspace: Path) extends PreviewGener
   }
 
   override def buildCommand(workspace: String, input: String, output: String): Seq[String] = {
-    Seq("wkhtmltopdf", "--enable-local-file-access", input, output)
+    Seq(binary, "--enable-local-file-access", input, output)
   }
 }
 

--- a/backend/app/services/previewing/PreviewService.scala
+++ b/backend/app/services/previewing/PreviewService.scala
@@ -171,7 +171,7 @@ object PreviewService {
     val workspace = Paths.get(preview.workspace)
     Files.createDirectories(workspace)
 
-    val html = new HtmlPreviewGenerator(preview.chromiumBinary, workspace)
+    val html = new HtmlPreviewGenerator(preview.wkhtmltopdfBinary, workspace)
     val libreOffice = new LibreOfficePreviewGenerator(preview.libreOfficeBinary, workspace)
 
     new DefaultPreviewService(index, blobStorage, previewStorage, html, libreOffice)

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -180,7 +180,7 @@ ingestion {
 preview {
   workspace = "/tmp/pfi-preview"
   libreOfficeBinary = "soffice"
-  chromiumBinary = "chromium-browser"
+  wkhtmltopdfBinary = "wkhtmltopdf"
   annotateSearchHighlightsDirectlyOnPage = false
 }
 

--- a/frontend/src/js/components/viewer/EmbeddedPdfViewer.tsx
+++ b/frontend/src/js/components/viewer/EmbeddedPdfViewer.tsx
@@ -6,7 +6,7 @@ const viewerLocation = '/third-party/pdfjs-2.4.456-dist/web/viewer.html';
 
 
 export function EmbeddedPdfViewer({ doc }: { doc: string }) {
-    const url = `${viewerLocation}?file=${doc}`;
+    const url = `${viewerLocation}?file=${encodeURIComponent(doc)}`;
 
     const iframeRef = useCallback((iframe: HTMLIFrameElement | null) => {
         if(iframe) {

--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -55,7 +55,6 @@ fi
 case "$OSTYPE" in
     darwin*)
         SOFFICE_BIN="/Applications/LibreOffice.app/Contents/MacOS/soffice"
-        CHROMIUM_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
         ;;
 esac
 
@@ -71,15 +70,6 @@ preview.libreOfficeBinary = "${SOFFICE_BIN}"
 EOF
 else
     echo "Unable to find Open Office. Please set preview.libreOfficeBinary to point to 'soffice' in your installation"
-fi
-
-if [ -f "$CHROMIUM_BIN" ]
-then
-    cat << EOF >> "$SITECONFDIR/site.conf"
-preview.chromiumBinary = "${CHROMIUM_BIN}"
-EOF
-else
-    echo "Unable to find Chromium/Google Chrome. Please set preview.chromiumBinary in site.conf"
 fi
 
 echo "Finished cluster setup"


### PR DESCRIPTION
## What does this change?
Email preview is currently broken. This is due to some linux permissions issue when giant tries to call out to chromium-browser to generate the PDF preview. 

It would definitely be possible to fix the permissions issue (giant would need write access to /home/pfi/snap I think) but @itsibitzi suggested abandoning chromium-browser and instead using wkthmltopdf.

This works round the permissions issue, and should somewhat speed up the preview process now that we're not spinning up an entire browser to generate the pdf.

Separately, I noticed that we're not properly url encoding the filename in the url we pass to PDF.js - this PR also fixes that. 

## How to test
Open any .eml file in giant - here's an example on playground https://playground.pfi.gutools.co.uk/viewer/CAGHe3Pmc37CiMwbWks-CVOiM=uYhnpvq2=Zg51dkESL80On94g@mail.gmail.com?details=summary&view=preview
