### PR TITLE
Add DEV to giant allowed stages to support DEV db in aws

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,6 +4,7 @@ stacks: [pfi-playground]
 regions: [eu-west-1]
 allowedStages:
  - rex
+ - DEV
 
 deployments:
   pfi-ami-update:


### PR DESCRIPTION
## What does this change?
This adds 'DEV' to the list of allowed stages for giant, in order to support AMI updates/deployment of the new remote Neo4j DEV instance we're setting up to work around M1 incompatibility with Neo4j 3. 

This should be a temporary thing - longer term we need to get onto Neo4j 4 as soon as possible