### PR TITLE
Support local development on ARM64 laptops

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
 brew "tesseract"
 cask "libreoffice"
-brew "wkhtmltopdf"
+cask "wkhtmltopdf"
+brew "ocrmypdf"

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -39,6 +39,45 @@
             }
           }
         }
+      },
+      "ocrmypdf": {
+        "version": "13.7.0",
+        "bottle": {
+          "rebuild": 0,
+          "root_url": "https://ghcr.io/v2/homebrew/core",
+          "files": {
+            "arm64_monterey": {
+              "cellar": ":any",
+              "url": "https://ghcr.io/v2/homebrew/core/ocrmypdf/blobs/sha256:fc0cdf1382e63980be844ab60dfa6c1a8fe56cb6bd2218249c5f76ccf5269066",
+              "sha256": "fc0cdf1382e63980be844ab60dfa6c1a8fe56cb6bd2218249c5f76ccf5269066"
+            },
+            "arm64_big_sur": {
+              "cellar": ":any",
+              "url": "https://ghcr.io/v2/homebrew/core/ocrmypdf/blobs/sha256:d1f4a41cafafce247ce2961f75e79627568bde9defb0879647ab409569795211",
+              "sha256": "d1f4a41cafafce247ce2961f75e79627568bde9defb0879647ab409569795211"
+            },
+            "monterey": {
+              "cellar": ":any",
+              "url": "https://ghcr.io/v2/homebrew/core/ocrmypdf/blobs/sha256:2121f1eff069fab3a99ac230b863df6c7bcf61539c7d68e8f4077828ca9bbb87",
+              "sha256": "2121f1eff069fab3a99ac230b863df6c7bcf61539c7d68e8f4077828ca9bbb87"
+            },
+            "big_sur": {
+              "cellar": ":any",
+              "url": "https://ghcr.io/v2/homebrew/core/ocrmypdf/blobs/sha256:dd11ac432cd5df72412b4685bbeef5662859b68f862615898bedc1c96a3ce66b",
+              "sha256": "dd11ac432cd5df72412b4685bbeef5662859b68f862615898bedc1c96a3ce66b"
+            },
+            "catalina": {
+              "cellar": ":any",
+              "url": "https://ghcr.io/v2/homebrew/core/ocrmypdf/blobs/sha256:15c210caa9b0b4a765125fc5c77bc881022863e13e86fc119a28eea620506ed9",
+              "sha256": "15c210caa9b0b4a765125fc5c77bc881022863e13e86fc119a28eea620506ed9"
+            },
+            "x86_64_linux": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/ocrmypdf/blobs/sha256:54c04c2c503db4cba0863deff7eec881a78a1ee8db0063a666f7163cdd31892a",
+              "sha256": "54c04c2c503db4cba0863deff7eec881a78a1ee8db0063a666f7163cdd31892a"
+            }
+          }
+        }
       }
     },
     "cask": {
@@ -47,15 +86,21 @@
         "options": {
           "full_name": "libreoffice"
         }
+      },
+      "wkhtmltopdf": {
+        "version": "0.12.6-2",
+        "options": {
+          "full_name": "wkhtmltopdf"
+        }
       }
     }
   },
   "system": {
     "macos": {
       "monterey": {
-        "HOMEBREW_VERSION": "3.5.7",
+        "HOMEBREW_VERSION": "3.5.9",
         "HOMEBREW_PREFIX": "/opt/homebrew",
-        "Homebrew/homebrew-core": "dc3439dba267910b7ee5832aa6f752394d758dae",
+        "Homebrew/homebrew-core": "4878fc24808cf6239f8206d993b928e936e6d85f",
         "CLT": "13.4.0.0.1.1651278267",
         "Xcode": "13.4",
         "macOS": "12.5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   neo4j:
-    image: neo4j:3.4.0
+    image: neo4j/neo4j-arm64-experimental:3.5
     container_name: pfi-neo4j
     environment:
       NEO4J_AUTH: neo4j/bob

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   neo4j:
-    image: neo4j/neo4j-arm64-experimental:3.5
+    image: ${NEO4J_IMAGE_OVERRIDE:-neo4j:3.4.0}
     container_name: pfi-neo4j
     environment:
       NEO4J_AUTH: neo4j/bob

--- a/scripts/start-backend.sh
+++ b/scripts/start-backend.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 
+
+ARCHITECTURE=$(uname -m)
+
+if [ "$ARCHITECTURE" == "arm64" ]; then
+  echo "Running on arm64 architecture - using experimental neo4j arm64 image."
+  export NEO4J_IMAGE_OVERRIDE=neo4j/neo4j-arm64-experimental:3.5.30
+fi
 docker compose up -d
 
 AVAILABLE_MEMORY=$( docker stats --format "{{.MemUsage}}" --no-stream \


### PR DESCRIPTION
## What does this change?
The current docker image we're using for neo4j doesn't support M1 arm64 macbooks. Neo4j don't support version 3.5 of neo4j anymore so aren't providing images but there is an experimental one we can use that seems to work: https://hub.docker.com/r/neo4j/neo4j-arm64-experimental/tags?page=1&name=3.

Elasticsearch also fails to start on a M1. @joelochlann  found that [this](https://stackoverflow.com/questions/50314586/elasticsearch-fails-to-start-config-seccomp-and-config-seccomp-filter-are-neede) solution worked - setting `bootstrap.system_call_filter=false` 

Note that people using M1 chips will need to either use the start-backend script or set `export NEO4J_IMAGE_OVERRIDE=neo4j/neo4j-arm64-experimental:3.5.30` prior to running docker compose in order to set docker to user the experimental image