### PR TITLE
--redo-ocr not --skip-text

### DIFF
--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -72,7 +72,7 @@ object Ocr {
   // OCRmyPDF is a wrapper for Tesseract that we use to overlay the OCR as a text layer in the resulting PDF
   def invokeOcrMyPdf(lang: String, inputFilePath: Path, dpi: Option[Int], stderr: OcrStderrLogger, tmpDir: Path): Path = {
     val tempFile = tmpDir.resolve(s"${inputFilePath.getFileName}.ocr.pdf")
-    val cmd = s"ocrmypdf --skip-text -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${inputFilePath.toAbsolutePath} ${tempFile.toAbsolutePath}"
+    val cmd = s"ocrmypdf --redo-ocr -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${inputFilePath.toAbsolutePath} ${tempFile.toAbsolutePath}"
 
     val stdout = mutable.Buffer.empty[String]
     val process = Process(cmd, cwd = None, extraEnv = "TMPDIR" -> tmpDir.toAbsolutePath.toString)


### PR DESCRIPTION
In guardian/giant#14 we changed `--redo-ocr` => `--skip-text`

Part of the justification was [this issue](https://github.com/ocrmypdf/OCRmyPDF/issues/700) which was fixed in [version 11.4.4](https://ocrmypdf.readthedocs.io/en/latest/release_notes.html#v11-4-4).

I'm currently upgrading our Amigo bake to use [13.7.0](https://ocrmypdf.readthedocs.io/en/latest/release_notes.html#v13-7-0) so this should no longer be a problem.

So I'm switching back to `--redo-ocr`.

## What do these options mean?
In short, `--redo-ocr` does more work (therefore is probably slower, though we haven't benchmarked) but it will try and add extra OCR text even to pages that already contain printable text. For instance, in a normal text PDF that contains images which happen to have text in them, it will get the text in those images. `--skip-text` makes a decision on a page-by-page basis, leaving any pages with printable text unchanged but OCR-ing any that don't have text.

Here is the detailed description of the options from https://ocrmypdf.readthedocs.io/en/latest/advanced.html?highlight=%22redo-ocr%22#when-ocr-is-skipped:

### `--skip-text`
No image processing or OCR will be performed on pages that already have text. The page will be copied to the output. This may be useful for documents that contain both “born digital” and scanned content, or to use OCRmyPDF to normalize and convert to PDF/A regardless of their contents.

### `--redo-ocr`
A detailed text analysis is performed. Text is categorized as either visible or invisible. Invisible text (OCR) is stripped out. Then an image of each page is created with visible text masked out. The page image is sent for OCR, and any additional text is inserted as OCR. If a file contains a mix of text and bitmap images that contain text, OCRmyPDF will locate the additional text in images without disrupting the existing text