### PR TITLE
Remove empty package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "giant",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## What does this change?
This file is breaking Giant's snyk integration as it then goes looking for a package.json file that doesn't exist