### PR TITLE
getBlobs by collection

### DIFF
--- a/backend/app/controllers/api/Blobs.scala
+++ b/backend/app/controllers/api/Blobs.scala
@@ -24,22 +24,11 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
     checkPermission(CanPerformAdminOperations, req) {
       (param("collection", req), param("ingestion", req)) match {
         case (Some(collection), maybeIngestion) =>
-          val parentExists = maybeIngestion match {
-            case Some(ingestion) => manifest.getIngestion(Uri(collection).chain(ingestion))
-            case _ => manifest.getCollection(Uri(collection))
-          }
-
           val size = param("size", req).map(_.toInt).getOrElse(500)
 
-          for {
-            _ <- parentExists
-            blobs <- index.getBlobs(collection, maybeIngestion, size)
-          } yield {
-            Ok(Json.obj(
-              "blobs" -> blobs
-            ))
-          }
-
+          index.getBlobs(collection, maybeIngestion, size).map(blobs =>
+            Ok(Json.obj("blobs" -> blobs))
+          )
         case _ =>
           Attempt.Right(BadRequest("Missing collection query parameter"))
       }

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -442,13 +442,18 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
 
   }
 
-  def getBlobs(collection: String, ingestion: Option[String], size: Int): Attempt[Iterable[IndexedBlob]] = {
+  def getBlobs(collection: String, maybeIngestion: Option[String], size: Int): Attempt[Iterable[IndexedBlob]] = {
+    val query = maybeIngestion match {
+      case Some(ingestion) => matchQuery(IndexFields.ingestionRaw, s"$collection/$ingestion")
+      case _ => matchQuery(IndexFields.collectionRaw, collection)
+    }
+
     execute {
       search(indexName)
         .sourceInclude(IndexFields.ingestion)
         .size(size)
         .bool(
-          must(matchQuery(IndexFields.ingestionRaw, s"$collection/${ingestion.getOrElse("")}"))
+          must(query)
         )
     }.map { response =>
       response.to[IndexedBlob]

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -442,13 +442,13 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
 
   }
 
-  def getBlobs(collection: String, ingestion: String, size: Int): Attempt[Iterable[IndexedBlob]] = {
+  def getBlobs(collection: String, ingestion: Option[String], size: Int): Attempt[Iterable[IndexedBlob]] = {
     execute {
       search(indexName)
         .sourceInclude(IndexFields.ingestion)
         .size(size)
         .bool(
-          must(matchQuery(IndexFields.ingestionRaw, s"$collection/$ingestion"))
+          must(matchQuery(IndexFields.ingestionRaw, s"$collection/${ingestion.getOrElse("")}"))
         )
     }.map { response =>
       response.to[IndexedBlob]

--- a/backend/app/services/index/Index.scala
+++ b/backend/app/services/index/Index.scala
@@ -28,7 +28,7 @@ trait Index {
 
   def flag(uri: Uri, flagValue: String): Attempt[Unit]
 
-  def getBlobs(collection: String, ingestion: String, size: Int): Attempt[Iterable[IndexedBlob]]
+  def getBlobs(collection: String, ingestion: Option[String], size: Int): Attempt[Iterable[IndexedBlob]]
 
   def delete(id: String): Attempt[Unit]
 


### PR DESCRIPTION
Make the ingestion param optional so you can get all blobs under a collection without also specifying an ingestion.

This is so the CLI can have a "delete by collection" functionality. Every use case we've had for deletion via the CLI involves deleting an entire collection and it's annoying to have to find out all the ingestions first and pass them as an array to the CLI.

This could also form the basis of a (very dangerous! probably admin-only) "delete collection" button in the UI, if we wanted it.