### PR TITLE
If --redo-ocr fails with input file error, fall back to --skip-text

### DIFF
--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -77,7 +77,7 @@ object Ocr extends Logging {
     val stdout = mutable.Buffer.empty[String]
 
     def process(redoOcr: Boolean): Int = {
-      val redoOcrOrSkipText = if(redoOcr) "--redo ocr" else "--skip-text"
+      val redoOcrOrSkipText = if(redoOcr) "--redo-ocr" else "--skip-text"
       val cmd = s"ocrmypdf $redoOcrOrSkipText -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${inputFilePath.toAbsolutePath} ${tempFile.toAbsolutePath}"
       val process = Process(cmd, cwd = None, extraEnv = "TMPDIR" -> tmpDir.toAbsolutePath.toString)
       process.!(ProcessLogger(stdout.append(_), stderr.append))


### PR DESCRIPTION
## What does this change?
We recently noticed that if `--redo-ocr` is set as an ocrmypdf option it fails for PDFs with fillable forms:

`This PDF has a user fillable form. --redo-ocr is not currently possible on such files.`

The error is an 'input file error' - in this PR we attempt to detect all input file errors, and re-run the ocr job with `--skip-text` set instead of `--redo-ocr`. 

@joelochlann gives a description of the differences between these settings here https://github.com/guardian/giant/pull/68


## How to test
I tested this on playground using this PDF: http://foersom.com/net/HowTo/data/OoPdfFormExample.pdf and it seemed to work ok. It fails on prod. 

## How can we measure success?
Fewer OCR failures!
