### PR TITLE
Remove Guava from common

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,9 +83,6 @@ lazy val common = (project in file("common"))
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.2.0",
       "com.typesafe.play" %% "play-json" % "2.9.0",
-      // This version has been chosen the match the transitive dependency from Play.
-      // Do not upgrade! Unless maybe you're upgrading Play...
-      "com.google.guava" % "guava" % "28.2-jre",
       "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
       "org.slf4j" % "slf4j-api" % "1.7.25",
       "org.scalatest" %% "scalatest" % scalatestVersion
@@ -198,6 +195,7 @@ lazy val cli = (project in file("cli"))
       "com.auth0" % "java-jwt" % "3.3.0",
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "org.slf4j" % "jcl-over-slf4j" % "1.7.25",
+      "com.google.guava" % "guava" % "28.2-jre",
       "org.scalatest" %% "scalatest" % scalatestVersion
     ),
     run / fork := true,

--- a/common/src/main/scala/services/FingerprintServices.scala
+++ b/common/src/main/scala/services/FingerprintServices.scala
@@ -1,7 +1,5 @@
 package services
 
-import org.apache.commons.codec.digest.DigestUtils
-
 import java.io.{File, InputStream, OutputStream}
 import java.nio.file.Files
 import java.security.{DigestInputStream, MessageDigest}

--- a/common/src/main/scala/services/FingerprintServices.scala
+++ b/common/src/main/scala/services/FingerprintServices.scala
@@ -1,23 +1,37 @@
 package services
 
-import java.io.File
-import java.nio.file.Files
-import java.util.{Base64, UUID}
+import org.apache.commons.codec.digest.DigestUtils
 
-import com.google.common.hash.{HashFunction, Hashing}
-import com.google.common.io.{Files => GuavaFiles}
+import java.io.{File, InputStream, OutputStream}
+import java.nio.file.Files
+import java.security.{DigestInputStream, MessageDigest}
+import java.util.{Base64, UUID}
 
 object FingerprintServices {
   val DEFAULT_HASH: String = "SHA-512"
-  val DEFAULT_HASH_FUNCTION: HashFunction = Hashing.sha512()
+
   private val encoder = Base64.getUrlEncoder.withoutPadding
 
   def createFingerprintFromFile(file: File): String = {
     if(Files.size(file.toPath) == 0) {
       s"urn:pfi:giant:zero-byte-file:${UUID.randomUUID()}"
     } else {
-      val bytes = GuavaFiles.asByteSource(file).hash(DEFAULT_HASH_FUNCTION).asBytes()
-      encoder.encodeToString(bytes)
+      var inputStream: InputStream = null
+
+      try {
+        inputStream = Files.newInputStream(file.toPath)
+
+        val digest = MessageDigest.getInstance(DEFAULT_HASH)
+        val digestInputStream = new DigestInputStream(inputStream, digest)
+
+        digestInputStream.transferTo(OutputStream.nullOutputStream())
+
+        val bytes = digest.digest()
+
+        encoder.encodeToString(bytes)
+      } finally {
+        Option(inputStream).foreach(_.close())
+      }
     }
   }
 }


### PR DESCRIPTION
I've been playing around learning and implementing [Webauthn](https://webauthn.guide) (Yubikeys etc). WIP branch here: [mbarton/giant/webauthn](https://github.com/mbarton/giant/tree/mbarton/webauthn).

To use [webauthn4j](https://webauthn4j.github.io) I had to update to Jackson 2.13 and the latest Play 2.8. As part of this I was going through all the libraries and noticed that we don't really need Guava in common since we're just using it to hash files.

We do need it in the CLI to walk the file tree so I've just moved the dependency there. The CLI doesn't depend on the Play Framework at all (just play-json) so it doesn't matter what version of Guava we use. I haven't upgraded it though just to keep the changes minimal.

One less thing to worry about for the next Play upgrade :)