### PR TITLE
Scala 2.13

### DIFF
--- a/backend/app/commands/DeleteResource.scala
+++ b/backend/app/commands/DeleteResource.scala
@@ -67,7 +67,7 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
          _ <- manifest.deleteBlob(uri)
          _ <- successAttempt
        } yield {
-         Unit
+         ()
        }
      }
 

--- a/backend/app/controllers/api/PagesController.scala
+++ b/backend/app/controllers/api/PagesController.scala
@@ -100,9 +100,9 @@ class PagesController(val controllerComponents: AuthControllerComponents, manife
       hlText.highlights.map(span => (lang, span))
     }.groupBy(_._2).toList.map { case (lang, commonSpans) =>
       commonSpans.head
-    }.groupBy(_._1).mapValues(_.map(_._2)).filter { case (k, v) =>
+    }.groupBy(_._1).view.mapValues(_.map(_._2)).filter { case (k, v) =>
       v.nonEmpty
-    }
+    }.toMap
   }
 
   def getPagePreview(uri: Uri, pageNumber: Int) = ApiAction.attempt { req =>

--- a/backend/app/extraction/archives/RarExtractor.scala
+++ b/backend/app/extraction/archives/RarExtractor.scala
@@ -14,7 +14,7 @@ import services.{FingerprintServices, ScratchSpace}
 import utils.Logging
 import utils.attempt.Failure
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 // Does not support RAR 5
 class RarExtractor(scratch: ScratchSpace, ingestionServices: IngestionServices) extends FileExtractor(scratch) with Logging {

--- a/backend/app/extraction/archives/ZipExtractor.scala
+++ b/backend/app/extraction/archives/ZipExtractor.scala
@@ -17,7 +17,7 @@ import services.{FingerprintServices, ScratchSpace}
 import utils.Logging
 import utils.attempt.{Failure, UnknownFailure}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ZipExtractor(scratch: ScratchSpace, ingestionServices: IngestionServices) extends FileExtractor(scratch) with Logging {
   val mimeTypes = Set(

--- a/backend/app/extraction/email/eml/EmlParser.scala
+++ b/backend/app/extraction/email/eml/EmlParser.scala
@@ -17,7 +17,7 @@ import services.ingestion.IngestionServices
 import services.{FingerprintServices, ScratchSpace}
 import utils.{HtmlToPlainText, DateTimeUtils, Logging}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 class EmlParser(val scratch: ScratchSpace, val ingestionServices: IngestionServices) extends Logging {

--- a/backend/app/extraction/email/msg/MsgEmailExtractor.scala
+++ b/backend/app/extraction/email/msg/MsgEmailExtractor.scala
@@ -17,7 +17,7 @@ import utils.attempt.{Failure, UnknownFailure}
 import utils.{DateTimeUtils, Logging}
 
 import java.util.stream.Collectors
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class MsgEmailExtractor(scratch: ScratchSpace, ingestionServices: IngestionServices, tika: Tika) extends Extractor with Logging {
   val mimeTypes = Set(

--- a/backend/app/extraction/email/msg/MsgEmailExtractor.scala
+++ b/backend/app/extraction/email/msg/MsgEmailExtractor.scala
@@ -103,6 +103,6 @@ class MsgEmailExtractor(scratch: ScratchSpace, ingestionServices: IngestionServi
 
   override def extract(blob: Blob, stream: InputStream, params: ExtractionParams): Either[Failure, Unit] = {
     processMessage(blob, new OutlookMessageParser().parseMsg(stream), params)
-    Right(Unit)
+    Right(())
   }
 }

--- a/backend/app/extraction/email/olm/OlmEmailExtractor.scala
+++ b/backend/app/extraction/email/olm/OlmEmailExtractor.scala
@@ -17,7 +17,7 @@ import services.{FingerprintServices, ScratchSpace}
 import utils.Logging
 import utils.attempt.Failure
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable.{Set => MutableSet}
 import scala.xml.XML
 

--- a/backend/app/extraction/email/pst/PstEmailExtractor.scala
+++ b/backend/app/extraction/email/pst/PstEmailExtractor.scala
@@ -19,7 +19,7 @@ import services.{FingerprintServices, ScratchSpace}
 import utils.Logging
 import utils.attempt.{Failure, UnknownFailure}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 class PstEmailExtractor(scratch: ScratchSpace, ingestionServices: IngestionServices) extends FileExtractor(scratch) with Logging {

--- a/backend/app/extraction/email/pst/iterators/PSTIterator.scala
+++ b/backend/app/extraction/email/pst/iterators/PSTIterator.scala
@@ -6,7 +6,7 @@ import com.pff._
 abstract class PSTIterator[T](val attachmentCount: Int, getAtIndex: Int => T) extends Iterator[T] {
   private var currentIdx = 0
 
-  override def hasNext(): Boolean = currentIdx < attachmentCount
+  override def hasNext: Boolean = currentIdx < attachmentCount
 
   override def next(): T = {
     val c = getAtIndex(currentIdx)

--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -69,7 +69,7 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
         )
 
         val textByLanguage = pdDocuments.map { case (lang, (_, doc)) =>
-          assert(doc.getNumberOfPages == numberOfPages, s"Number of pages mismatch across languages: ${pdDocuments.mapValues(_._2.getNumberOfPages)}")
+          assert(doc.getNumberOfPages == numberOfPages, s"Number of pages mismatch across languages: ${pdDocuments.view.mapValues(_._2.getNumberOfPages).toMap}")
 
           val reader = new PDFTextStripper()
           reader.setStartPage(pageNumber)

--- a/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
+++ b/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
@@ -54,7 +54,7 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
 
         // TODO MRB: does RGB colour help or hinder here?
         val imageFileName = s"${file.getAbsolutePath}-$pageNumber.png"
-        val image = renderer.renderImageWithDPI(pageNumber, config.dpi, ImageType.RGB)
+        val image = renderer.renderImageWithDPI(pageNumber, config.dpi.toFloat, ImageType.RGB)
         ImageIOUtil.writeImage(image, imageFileName, config.dpi)
 
         val dimensions = PageDimensions(

--- a/backend/app/extraction/tables/CsvTableExtractor.scala
+++ b/backend/app/extraction/tables/CsvTableExtractor.scala
@@ -12,7 +12,7 @@ import services.table.Tables
 import utils.attempt.{Attempt, Failure}
 import utils.attempt.AttemptAwait._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 
 class CsvTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: ExecutionContext) extends FileExtractor(scratch) {

--- a/backend/app/extraction/tables/ExcelTableExtractor.scala
+++ b/backend/app/extraction/tables/ExcelTableExtractor.scala
@@ -50,7 +50,7 @@ class ExcelTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: 
       breakable {
         while (xmlReader.hasNext) {
           result :+= readRows(1000, xmlReader, stringsTable, stylesTable, sheetName, blob)
-          if (xmlReader.isStartElement && xmlReader.getLocalName.equals("sheetData")) break
+          if (xmlReader.isStartElement && xmlReader.getLocalName.equals("sheetData")) break()
         }
       }
     }
@@ -69,7 +69,7 @@ class ExcelTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: 
               val dataRow = getDataRow(xmlReader, stringsTable, sheetName, stylesTable)
               dataRows :+= dataRow
             }
-          if (dataRows.size == batchSize) break
+          if (dataRows.size == batchSize) break()
         }
       }
     }
@@ -92,7 +92,7 @@ class ExcelTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: 
             val cellValue = getCellValue(cellType, xmlReader, stringsTable, stylesTable, cellStyleStr)
             rowValues :+= cellValue
           }
-        if (xmlReader.isEndElement && xmlReader.getLocalName.equals("row")) break
+        if (xmlReader.isEndElement && xmlReader.getLocalName.equals("row")) break()
       }
     }
     TableRow(Some(sheetName), cellReference.getRow, rowValues.zipWithIndex.map{ case (cell, index) => index.toString -> cell }.toMap)
@@ -120,7 +120,7 @@ class ExcelTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: 
           }
         }
 
-        if (xmlReader.isEndElement && xmlReader.getLocalName.equals("c")) break
+        if (xmlReader.isEndElement && xmlReader.getLocalName.equals("c")) break()
       }
     }
     value

--- a/backend/app/ingestion/IngestionContextBuilder.scala
+++ b/backend/app/ingestion/IngestionContextBuilder.scala
@@ -8,7 +8,7 @@ import extraction.ExtractionParams
 import model.ingestion.{EmailContext, FileContext, IngestionFile, WorkspaceItemContext}
 import model.{Email, Language, Uri}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 // The manifests resource graph is build piecemeal as paths of the overall graph which begin and end with a RootUri
 // This class is a helper to build those while walking some structure (file system, email store, etc.)

--- a/backend/app/ingestion/phase2/IngestStorePolling.scala
+++ b/backend/app/ingestion/phase2/IngestStorePolling.scala
@@ -88,7 +88,7 @@ class IngestStorePolling(
       )
       pollCompleteFuture.onComplete {
         case Success(pollDuration) => schedulePoll(pollDuration)
-        case SFailure(NonFatal(t)) =>
+        case SFailure(t) =>
           logger.error("Exception whilst processing ingestion batch", t)
           metricsService.updateMetric(Metrics.batchesFailed)
           schedulePoll(maximumWait)

--- a/backend/app/model/Email.scala
+++ b/backend/app/model/Email.scala
@@ -14,7 +14,7 @@ import play.api.libs.json._
 import utils.{DateTimeUtils, Logging, UriCleaner}
 
 import java.util.stream.Collectors
-import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.jdk.CollectionConverters._
 
 object Priority {
   val NotUrgent = "not_urgent"

--- a/backend/app/model/frontend/ClientConfig.scala
+++ b/backend/app/model/frontend/ClientConfig.scala
@@ -10,7 +10,7 @@ case class ClientConfig(label: Option[String],
                         userProvider: String,
                         authConfig: Map[String, JsValue],
                         hideDownloadButton: Boolean,
-                        buildInfo: Map[String, String] = BuildInfo.toMap.mapValues(_.toString))
+                        buildInfo: Map[String, String] = BuildInfo.toMap.view.mapValues(_.toString).toMap)
 
 object ClientConfig {
   implicit val format = Json.format[ClientConfig]

--- a/backend/app/model/frontend/Resource.scala
+++ b/backend/app/model/frontend/Resource.scala
@@ -170,7 +170,7 @@ object DocumentResource {
       parents = basic.parents,
       children = basic.children,
       text = HighlightableText.fromString(document.text, page = None),
-      ocr = document.ocr.map(ocrMap => ocrMap.mapValues { v => HighlightableText.fromString(v, page = None) }),
+      ocr = document.ocr.map(ocrMap => ocrMap.view.mapValues { v => HighlightableText.fromString(v, page = None) }.toMap),
       metadata = document.metadata,
       enrichedMetadata = document.enrichedMetadata,
       previewStatus = PreviewService.previewStatus(document.mimeTypes),

--- a/backend/app/model/frontend/Resource.scala
+++ b/backend/app/model/frontend/Resource.scala
@@ -8,7 +8,7 @@ import org.neo4j.driver.v1.Value
 import play.api.libs.json._
 import services.previewing.{PreviewService, PreviewStatus}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class RelatedResource(uri: String, `type`: String, display: Option[String], isExpandable: Boolean)
 

--- a/backend/app/model/frontend/email/EmailThread.scala
+++ b/backend/app/model/frontend/email/EmailThread.scala
@@ -7,7 +7,7 @@ import utils.attempt.Attempt
 import model._
 import play.api.libs.json.Json
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 
 case class EmailMetadata(subject: Option[String], fromAddress: Option[String], fromName: Option[String], sentAt: Option[ExtractedDateTime])

--- a/backend/app/model/manifest/Ingestion.scala
+++ b/backend/app/model/manifest/Ingestion.scala
@@ -6,7 +6,7 @@ import model._
 import org.neo4j.driver.v1.Value
 import play.api.libs.json.Json
 import utils.Time._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class Ingestion(display: String,
                      uri: String,

--- a/backend/app/services/ElasticsearchSyntax.scala
+++ b/backend/app/services/ElasticsearchSyntax.scala
@@ -55,7 +55,7 @@ trait ElasticsearchSyntax { this: Logging =>
 
   def multiLanguageValue(languages: List[Language], value: Any): Map[String, Any] = languages.map { lang =>
     lang.key -> value
-  }(scala.collection.breakOut)
+  }.toMap
 
   implicit def attemptExecutor(implicit ec: ExecutionContext): Executor[Attempt] =
     (client: HttpClient, request: ElasticRequest) => {

--- a/backend/app/services/IngestStorage.scala
+++ b/backend/app/services/IngestStorage.scala
@@ -12,7 +12,7 @@ import utils.Logging
 import utils.attempt.{Failure, IllegalStateFailure, JsonParseFailure, UnknownFailure}
 import utils.aws.S3Client
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 trait IngestStorage {

--- a/backend/app/services/MetricsService.scala
+++ b/backend/app/services/MetricsService.scala
@@ -37,9 +37,9 @@ trait MetricsService {
 }
 
 class NoOpMetricsService() extends MetricsService {
-  def updateMetrics(metrics:List[MetricUpdate]): Unit = Unit
-  def updateMetric(metricName: String, metricValue: Double = 1): Unit = Unit
-  def recordUsageEvent(username: String): Unit = Unit
+  def updateMetrics(metrics:List[MetricUpdate]): Unit = ()
+  def updateMetric(metricName: String, metricValue: Double = 1): Unit = ()
+  def recordUsageEvent(username: String): Unit = ()
 }
 
 class CloudwatchMetricsService(config: AWSDiscoveryConfig) extends MetricsService with Logging {

--- a/backend/app/services/ObjectStorage.scala
+++ b/backend/app/services/ObjectStorage.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 import model.ObjectMetadata
 import utils.attempt.{Failure, IllegalStateFailure, UnknownFailure}
 import utils.aws.{AwsErrors, S3Client}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import scala.util.control.NonFatal
 

--- a/backend/app/services/Tika.scala
+++ b/backend/app/services/Tika.scala
@@ -23,7 +23,7 @@ import utils.Logging
 import utils.attempt.{Failure, UnknownFailure}
 
 import scala.util.Try
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 trait TypeDetector {
   def detectType(path: Path): Either[Failure, MediaType]

--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -15,7 +15,7 @@ import services.annotations.Annotations.{AffectedResource, DeleteItemResult, Mov
 import utils._
 import utils.attempt.{Attempt, ClientFailure, Failure, IllegalStateFailure, NotFoundFailure}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 
 object Neo4jAnnotations {

--- a/backend/app/services/index/Aggregations.scala
+++ b/backend/app/services/index/Aggregations.scala
@@ -19,7 +19,7 @@ object Aggregations {
         mediaType,
         buckets.foldLeft(0L)((a, i) => a + i.docCount),
         Some(buckets.map(b => SearchAggregationBucket(b.key, b.docCount, None)).toList))
-    }(collection.breakOut).toList
+    }.toList
 
     SearchAggregation(IndexAggNames.mimeTypes, aggs)
   }

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -17,7 +17,7 @@ import services.index.HitReaders._
 import utils._
 import utils.attempt._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 
 class ElasticsearchResources(override val client: ElasticClient, indexName: String)(implicit executionContext: ExecutionContext) extends Index with Logging with ElasticsearchSyntax {

--- a/backend/app/services/index/HitReaders.scala
+++ b/backend/app/services/index/HitReaders.scala
@@ -252,7 +252,7 @@ object HitReaders {
 
   private def readOcr(fields: FieldMap): Option[Map[String, String]] = {
     fields.optField[FieldMap](ocr).map { languages =>
-      languages.mapValues(_.asInstanceOf[String])
+      languages.view.mapValues(_.asInstanceOf[String]).toMap
     }
   }
 

--- a/backend/app/services/index/HitReaders.scala
+++ b/backend/app/services/index/HitReaders.scala
@@ -33,7 +33,7 @@ object HitReaders {
     def optLongField(name: String): Option[Long] = if(fields.contains(name)) { Some(longField(name)) } else { None }
     def listField[T](name: String): List[T] = optField[List[T]](name).getOrElse(Nil)
     def setField[T](name: String): Set[T] = optField[List[T]](name).map(_.toSet).getOrElse(Set.empty)
-    def optEnumField[T <: EnumEntry](name: String, enum: PlayEnum[T]): Option[T] = optField(name).flatMap(enum.withNameOption)
+    def optEnumField[T <: EnumEntry](name: String, playEnum: PlayEnum[T]): Option[T] = optField(name).flatMap(playEnum.withNameOption)
     def objectField(name: String): FieldMap = field[FieldMap](name)
     def nestedField(name: String): Map[String, Seq[String]] = {
       val base = Map.empty[String, Seq[String]]

--- a/backend/app/services/index/Pages2.scala
+++ b/backend/app/services/index/Pages2.scala
@@ -115,7 +115,7 @@ class Pages2(val client: ElasticClient, indexNamePrefix: String)(implicit val ex
         )
     }.flatMap { response =>
       // TODO should really be a map of language -> page matches
-      val matchingPages: Seq[Int] = response.hits.hits.map(_.field[Int](PagesFields.page)).distinct.sorted
+      val matchingPages: Seq[Int] = response.hits.hits.map(_.field[Int](PagesFields.page)).distinct.sorted.toIndexedSeq
 
       Attempt.Right(matchingPages)
     }

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -19,7 +19,7 @@ import utils.attempt.{Attempt, Failure, IllegalStateFailure, NotFoundFailure}
 
 import java.nio.file.Path
 import java.time.Instant
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 
 object Neo4jManifest {

--- a/backend/app/services/users/Neo4jUserManagement.scala
+++ b/backend/app/services/users/Neo4jUserManagement.scala
@@ -16,7 +16,7 @@ import utils._
 import utils.attempt.{Attempt, ClientFailure, Failure, IllegalStateFailure, Neo4JFailure, NotFoundFailure, UnknownFailure, UserDoesNotExistFailure}
 import utils.auth.totp.Secret
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 

--- a/backend/app/utils/AwsDiscovery.scala
+++ b/backend/app/utils/AwsDiscovery.scala
@@ -11,7 +11,7 @@ import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import org.apache.commons.lang3.StringUtils
 import services.{AWSDiscoveryConfig, BucketConfig, Config, DatabaseAuthConfig}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class DiscoveryResult(updatedConfig: Config, jsonLoggingProperties: Map[String, String])
 

--- a/backend/app/utils/Neo4jHelper.scala
+++ b/backend/app/utils/Neo4jHelper.scala
@@ -38,29 +38,29 @@ class Neo4jHelper(driver: Driver, executionContext: ExecutionContext, queryLoggi
     */
   class AttemptWrappedTransaction(underlying: StatementRunner, executionContext: ExecutionContext) {
     def run(statementTemplate: String, statementParameters: Record): Attempt[StatementResult] =
-      attemptNeo4J {
+      attemptNeo4J({
         underlying.run(statementTemplate, statementParameters)
-      }
+      })()
 
     def run(statementTemplate: String): Attempt[StatementResult] =
-      attemptNeo4J {
+      attemptNeo4J({
         underlying.run(statementTemplate)
-      }
+      })()
 
     def run(statementTemplate: String, parameters: Value): Attempt[StatementResult] =
-      attemptNeo4J {
+      attemptNeo4J({
         underlying.run(statementTemplate, parameters)
-      }
+      })()
 
     def run(statementTemplate: String, statementParameters: java.util.Map[String, AnyRef]): Attempt[StatementResult] =
-      attemptNeo4J {
+      attemptNeo4J({
         underlying.run(statementTemplate, statementParameters)
-      }
+      })()
 
     def run(statement: Statement): Attempt[StatementResult] =
-      attemptNeo4J {
+      attemptNeo4J({
         underlying.run(statement)
-      }
+      })()
 
     def run(statementTemplate: String, parameters: (String, AnyRef)*): Attempt[StatementResult] = {
       val flattenedParameters = parameters.flatten { case (k, v) => Vector(k,v) }

--- a/backend/app/utils/Neo4jHelper.scala
+++ b/backend/app/utils/Neo4jHelper.scala
@@ -9,9 +9,8 @@ import org.neo4j.driver.v1._
 import org.neo4j.driver.v1.types.TypeSystem
 import play.api.Logger
 import services.Neo4jQueryLoggingConfig
-import utils.attempt.{Attempt, Failure, Neo4JFailure, Neo4JTransientFailure, NotFoundFailure, TransactionFailure, UnknownFailure}
+import utils.attempt.{Attempt, Failure, Neo4JFailure, Neo4JTransientFailure, NotFoundFailure, UnknownFailure}
 
-import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -309,7 +308,7 @@ class Neo4jHelper(driver: Driver, executionContext: ExecutionContext, queryLoggi
 }
 
 object Neo4jHelper {
-  implicit class RichRecords[T <: Seq[Record]](result: T) {
+  implicit class RichRecords[T <: mutable.Buffer[Record]](result: T) {
     def hasKeyOrFailure(expectedKey: String, errorMessage: String): Either[Failure, T] = {
       if (!result.exists(x => x.containsKey(expectedKey))) {
         Left(NotFoundFailure(errorMessage))

--- a/backend/app/utils/Neo4jHelper.scala
+++ b/backend/app/utils/Neo4jHelper.scala
@@ -15,6 +15,7 @@ import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.collection.JavaConverters._
+import utils.Logging
 
 class Neo4jHelper(driver: Driver, executionContext: ExecutionContext, queryLoggingConfig: Neo4jQueryLoggingConfig) extends Logging {
 

--- a/backend/app/utils/Neo4jHelper.scala
+++ b/backend/app/utils/Neo4jHelper.scala
@@ -14,7 +14,7 @@ import utils.attempt.{Attempt, Failure, Neo4JFailure, Neo4JTransientFailure, Not
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import utils.Logging
 
 class Neo4jHelper(driver: Driver, executionContext: ExecutionContext, queryLoggingConfig: Neo4jQueryLoggingConfig) extends Logging {

--- a/backend/app/utils/Neo4jHelper.scala
+++ b/backend/app/utils/Neo4jHelper.scala
@@ -309,7 +309,7 @@ class Neo4jHelper(driver: Driver, executionContext: ExecutionContext, queryLoggi
 }
 
 object Neo4jHelper {
-  implicit class RichRecords[T <: mutable.Buffer[Record]](result: T) {
+  implicit class RichRecords[T <: Iterable[Record]](result: T) {
     def hasKeyOrFailure(expectedKey: String, errorMessage: String): Either[Failure, T] = {
       if (!result.exists(x => x.containsKey(expectedKey))) {
         Left(NotFoundFailure(errorMessage))

--- a/backend/app/utils/PDFUtil.scala
+++ b/backend/app/utils/PDFUtil.scala
@@ -9,7 +9,7 @@ import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationTextMarkup
 import org.apache.pdfbox.text.{PDFTextStripper, TextPosition}
 
 import java.util
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.math.{atan2, cos, sin, sqrt}
 
 object PDFUtil {

--- a/backend/app/utils/RequestLoggingFilter.scala
+++ b/backend/app/utils/RequestLoggingFilter.scala
@@ -7,7 +7,7 @@ import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import net.logstash.logback.marker.Markers.appendEntries
 import net.logstash.logback.marker.LogstashMarker
 import play.api.mvc.Results.InternalServerError

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -14,7 +14,7 @@ import services.{AWSDiscoveryConfig, IngestStorage, WorkerConfig}
 import utils.AWSWorkerControl.{AddNewWorker, RemoveWorker}
 import utils.attempt.{Attempt, Failure, IllegalStateFailure}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 case class WorkerDetails(nodes: Set[String], thisNode: String)

--- a/backend/app/utils/aws/AwsAsyncHandler.scala
+++ b/backend/app/utils/aws/AwsAsyncHandler.scala
@@ -30,7 +30,7 @@ object AwsAsyncHandler {
   def awsToScala[R <: AmazonWebServiceRequest, T](sdkMethod: (R, AsyncHandler[R, T]) => java.util.concurrent.Future[T])
                                                  (req: R)
                                                  (implicit ec: ExecutionContext): Attempt[T] = {
-    val p = Promise[Either[Failure, T]]
+    val p = Promise[Either[Failure, T]]()
     sdkMethod(req, new AwsAsyncPromiseHandler(p))
     Attempt(p.future)
   }

--- a/backend/app/utils/controller/FailureToResultMapper.scala
+++ b/backend/app/utils/controller/FailureToResultMapper.scala
@@ -13,7 +13,7 @@ import utils.auth.User
 import utils.{AwsCredentials, Logging}
 
 import java.util.Date
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.language.higherKinds
 import scala.util.control.NonFatal
 

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -1,23 +1,23 @@
 # API
 GET           /api/events/uploads                                           controllers.api.Events.listAllUploads(showAdminUploads: Option[Boolean])
 
-GET           /api/collections                                              controllers.api.Collections.listCollections
+GET           /api/collections                                              controllers.api.Collections.listCollections()
 GET           /api/collections/:collection                                  controllers.api.Collections.getCollection(collection: model.Uri)
 
-POST          /api/collections                                              controllers.api.Collections.newCollection
+POST          /api/collections                                              controllers.api.Collections.newCollection()
 POST          /api/collections/:collection                                  controllers.api.Collections.newIngestion(collection: model.Uri)
 POST          /api/collections/:collection/:ingestion                       controllers.api.Collections.uploadIngestionFile(collection, ingestion)
 DELETE        /api/collections/:collection/:ingestion                       controllers.api.Collections.deleteIngestion(collection, ingestion)
 POST          /api/collections/:collection/:ingestion/verifyFiles           controllers.api.Collections.verifyFiles(collection, ingestion)
 
-GET           /api/blobs                                                    controllers.api.Blobs.getBlobs
+GET           /api/blobs                                                    controllers.api.Blobs.getBlobs()
 POST          /api/blobs/:id/reprocess                                      controllers.api.Blobs.reprocess(id, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])
 DELETE        /api/blobs/:id                                                controllers.api.Blobs.delete(id, deleteFolders: Boolean, checkChildren: Boolean)
 
-GET           /api/filters                                                  controllers.api.Filters.getFilters
+GET           /api/filters                                                  controllers.api.Filters.getFilters()
 
-GET           /api/search                                                   controllers.api.Search.search
-GET           /api/search/fields                                            controllers.api.Search.chips
+GET           /api/search                                                   controllers.api.Search.search()
+GET           /api/search/fields                                            controllers.api.Search.chips()
 
 GET           /api/download/auth/:uri                                       controllers.api.Documents.authoriseDownload(uri: model.Uri)
 GET           /api/download/get/:uri                                        controllers.api.Documents.actualDownload(uri: model.Uri)
@@ -38,16 +38,16 @@ GET           /api/pages2/:uri/search                                       cont
 GET           /api/pages2/:uri/:pageNumber/preview                          controllers.api.PagesController.getPagePreview(uri: model.Uri, pageNumber: Int)
 GET           /api/pages2/:uri/:pageNumber/text                             controllers.api.PagesController.getPageData(uri: model.Uri, pageNumber: Int, sq: Option[String], fq: Option[String])
 
-GET           /api/extractions/failures                                     controllers.api.Resource.getExtractionFailures
+GET           /api/extractions/failures                                     controllers.api.Resource.getExtractionFailures()
 POST          /api/extractions/failures/resources                           controllers.api.Resource.getResourcesForExtractionFailure(page: Int ?= 1, pageSize: Int ?= 20)
 
 GET           /api/emails/thread/:uri                                       controllers.api.Emails.getThread(uri: model.Uri)
 
-GET           /api/mimetypes/details                                        controllers.api.MimeTypes.getDetails
-GET           /api/mimetypes/coverage                                       controllers.api.MimeTypes.getCoverage
+GET           /api/mimetypes/details                                        controllers.api.MimeTypes.getDetails()
+GET           /api/mimetypes/coverage                                       controllers.api.MimeTypes.getCoverage()
 
-POST          /api/workspaces                                               controllers.api.Workspaces.create
-GET           /api/workspaces                                               controllers.api.Workspaces.getAll
+POST          /api/workspaces                                               controllers.api.Workspaces.create()
+GET           /api/workspaces                                               controllers.api.Workspaces.getAll()
 PUT           /api/workspaces/:workspaceId/followers                        controllers.api.Workspaces.updateWorkspaceFollowers(workspaceId: String)
 PUT           /api/workspaces/:workspaceId/isPublic                         controllers.api.Workspaces.updateWorkspaceIsPublic(workspaceId: String)
 PUT           /api/workspaces/:workspaceId/name                             controllers.api.Workspaces.updateWorkspaceName(workspaceId: String)
@@ -67,7 +67,7 @@ GET           /api/preview/auth/:uri                                        cont
 GET           /api/preview/get/:uri                                         controllers.api.Previews.preAuthorizedDownload(uri: model.Uri)
 
 # === User actions ===
-GET           /api/users                                                    controllers.api.Users.listUsers
+GET           /api/users                                                    controllers.api.Users.listUsers()
 POST          /api/users/:username/collections                              controllers.api.Collections.setUserCollections(username)
 PUT           /api/users/:username                                          controllers.api.Users.createUser(username: String)
 POST          /api/users/:username/displayName                              controllers.api.Users.updateUserFullname(username: String)
@@ -80,27 +80,27 @@ DELETE        /api/users/:username                                          cont
 + NOCSRF
 PUT           /api/users/:username/register                                 controllers.api.Users.registerUser(username: String)
 
-GET           /api/currentUser/permissions                                  controllers.api.Users.getMyPermissions
+GET           /api/currentUser/permissions                                  controllers.api.Users.getMyPermissions()
 
 + NOCSRF
-POST          /api/auth/token                                               controllers.api.Authentication.token
-DELETE        /api/auth/token                                               controllers.api.Authentication.invalidateExistingTokens
+POST          /api/auth/token                                               controllers.api.Authentication.token()
+DELETE        /api/auth/token                                               controllers.api.Authentication.invalidateExistingTokens()
 GET           /api/auth/generate2faToken/:username                          controllers.api.Authentication.generate2faToken(username: String)
-GET           /api/keepalive                                                controllers.api.Authentication.keepalive
+GET           /api/keepalive                                                controllers.api.Authentication.keepalive()
 
-GET           /api/config                                                   controllers.frontend.App.configuration
+GET           /api/config                                                   controllers.frontend.App.configuration()
 
 + NOCSRF
-GET           /healthcheck                                                  controllers.api.Authentication.healthcheck
+GET           /healthcheck                                                  controllers.api.Authentication.healthcheck()
 
-GET           /manifest                                                     controllers.frontend.App.manifest
+GET           /manifest                                                     controllers.frontend.App.manifest()
 
 # === Setup ====
-GET           /setup                                                        controllers.genesis.Genesis.checkSetup
+GET           /setup                                                        controllers.genesis.Genesis.checkSetup()
 + NOCSRF
-PUT           /setup                                                        controllers.genesis.Genesis.doSetup
+PUT           /setup                                                        controllers.genesis.Genesis.doSetup()
 
 # === Web Client ===
-GET           /                                                             controllers.frontend.App.index
+GET           /                                                             controllers.frontend.App.index()
 GET           /third-party/*file                                            controllers.Assets.at(path="/public/third-party", file)
 GET           /*path                                                        controllers.frontend.App.assetOrBundle(path)

--- a/backend/test/commands/CollectionSharingITest.scala
+++ b/backend/test/commands/CollectionSharingITest.scala
@@ -389,7 +389,7 @@ class CollectionSharingITest extends AnyFunSuite with Neo4jTestService with Elas
       await(futureFirstResponse)
       await(futureSecondResponse)
 
-      val collections = contentAsJson(controllers.collections.listCollections.apply(FakeRequest())).as[List[Collection]]
+      val collections = contentAsJson(controllers.collections.listCollections().apply(FakeRequest())).as[List[Collection]]
       val uris = collections.map(_.uri.value)
 
       uris should contain only("e2e-test-rapid-two")

--- a/backend/test/controllers/api/UsersTest.scala
+++ b/backend/test/controllers/api/UsersTest.scala
@@ -39,7 +39,7 @@ class UsersTest extends AnyFreeSpec with Matchers with Results with ScalaFutures
 
   "UsersController" - {
     "list partial user information to punters" in {
-      TestSetup(users + (paul -> (UserPermissions.bigBoss, List.empty), barry -> (UserPermissions.default, List.empty)), barry) { (controller, _) =>
+      TestSetup(Map(paul -> (UserPermissions.bigBoss, List.empty), barry -> (UserPermissions.default, List.empty)), barry) { (controller, _) =>
         val result = controller.listUsers.apply(FakeRequest())
         val json = contentAsJson(result)
 
@@ -53,7 +53,7 @@ class UsersTest extends AnyFreeSpec with Matchers with Results with ScalaFutures
     }
 
     "list full user information to admins" in {
-      TestSetup(users + (paul -> (UserPermissions.bigBoss, List.empty)), paul) { (controller, _) =>
+      TestSetup(Map(paul -> (UserPermissions.bigBoss, List.empty)), paul) { (controller, _) =>
         val result = controller.listUsers.apply(FakeRequest())
         val json = contentAsJson(result)
 
@@ -67,14 +67,14 @@ class UsersTest extends AnyFreeSpec with Matchers with Results with ScalaFutures
     }
 
     "get user permissions" in {
-      TestSetup(users + (paul -> (UserPermissions.bigBoss, List.empty)), paul) { (controller, _) =>
+      TestSetup(Map(paul -> (UserPermissions.bigBoss, List.empty)), paul) { (controller, _) =>
         val result = controller.getMyPermissions.apply(FakeRequest())
         val json = contentAsJson(result)
 
         json.as[UserPermissions] should be(UserPermissions.bigBoss)
       }
 
-      TestSetup(users + (paul -> (UserPermissions.default, List.empty)), barry) { (controller, _) =>
+      TestSetup(Map(paul -> (UserPermissions.default, List.empty)), barry) { (controller, _) =>
         val result = controller.getMyPermissions.apply(FakeRequest())
         val json = contentAsJson(result)
 
@@ -100,7 +100,7 @@ class UsersTest extends AnyFreeSpec with Matchers with Results with ScalaFutures
     }
 
     "create user that is flagged as not registered" in {
-      TestSetup(users + (paul -> (UserPermissions.bigBoss, List.empty)), paul) { (controller, db) =>
+      TestSetup(Map(paul -> (UserPermissions.bigBoss, List.empty)), paul) { (controller, db) =>
         val req = FakeRequest().withBody(Json.toJson(NewUser("test", "biglongpassword1234")))
 
         status(controller.createUser("test").apply(req)) should be(200)
@@ -177,7 +177,7 @@ class UsersTest extends AnyFreeSpec with Matchers with Results with ScalaFutures
       val dbAuthConfig = DatabaseAuthConfig(12, require2FA = false, "pfi")
       val hashing = new PasswordHashing
       val validator = new PasswordValidator(dbAuthConfig.minPasswordLength)
-      val userManagement = TestUserManagement(initialUsers)
+      val userManagement = TestUserManagement(users ++ initialUsers)
 
       val controllerComponents = stubControllerComponentsAsUser(reqUser.username, userManagement)
       val userProvider = new DatabaseUserProvider(dbAuthConfig, hashing, userManagement, Totp.googleAuthenticatorInstance(), generator, validator)

--- a/backend/test/controllers/api/UsersTest.scala
+++ b/backend/test/controllers/api/UsersTest.scala
@@ -105,7 +105,7 @@ class UsersTest extends AnyFreeSpec with Matchers with Results with ScalaFutures
 
         status(controller.createUser("test").apply(req)) should be(200)
 
-        val users = db.listUsers().asFuture.futureValue.right.get
+        val users = db.listUsers().asFuture.futureValue.toOption.get
         users.find(_._1.username == "test").map(_._1.registered) should contain(false)
       }
     }

--- a/backend/test/controllers/genesis/GenesisTest.scala
+++ b/backend/test/controllers/genesis/GenesisTest.scala
@@ -62,7 +62,7 @@ class GenesisTest extends AnyFreeSpec with Matchers with Results with AttemptVal
           val json = contentAsJson(result)
           json.as[PartialUser] shouldBe PartialUser("bob", "Spongebob")
 
-          val dbUsers = userManagement.listUsers().asFuture.futureValue.right.get
+          val dbUsers = userManagement.listUsers().asFuture.futureValue.toOption.get
           dbUsers should have length 1
           dbUsers.head._1.registered should not be false
         }

--- a/backend/test/model/ingestion/FileContextTest.scala
+++ b/backend/test/model/ingestion/FileContextTest.scala
@@ -35,7 +35,7 @@ class FileContextTest extends AnyFunSuite with Matchers {
       Uri("collection/ingestion")
     )
 
-    val actual = FileContext.fromIngestMetadata(input).right.get.parents
+    val actual = FileContext.fromIngestMetadata(input).toOption.get.parents
     actual must be(expected)
   }
 
@@ -53,7 +53,7 @@ class FileContextTest extends AnyFunSuite with Matchers {
       Uri("collection/ingestion")
     )
 
-    val actual = FileContext.fromIngestMetadata(input).right.get.parents
+    val actual = FileContext.fromIngestMetadata(input).toOption.get.parents
     actual must be(expected)
   }
 
@@ -68,7 +68,7 @@ class FileContextTest extends AnyFunSuite with Matchers {
       Uri("collection/ingestion")
     )
 
-    val actual = FileContext.fromIngestMetadata(input).right.get.parents
+    val actual = FileContext.fromIngestMetadata(input).toOption.get.parents
     actual must be(expected)
   }
 

--- a/backend/test/services/manifest/Neo4JManifestITest.scala
+++ b/backend/test/services/manifest/Neo4JManifestITest.scala
@@ -35,7 +35,7 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
   val ingestionServices: IngestionServices = stub[IngestionServices]
 
   lazy val manifest = {
-    Neo4jManifest.setupManifest(neo4jDriver, global, neo4jQueryLoggingConfig).right.value
+    Neo4jManifest.setupManifest(neo4jDriver, global, neo4jQueryLoggingConfig).toOption.get
   }
 
   def insertIngestion(collection: Uri, maybeIngestion: Option[Uri] = None, maybePath: Option[Path] = None, fixed: Boolean = true) = {
@@ -101,9 +101,9 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
           logger.warn(value.toString, value.cause.get)
         }
         result.isRight shouldBe true
-        manifest.getResource(Uri("a")).right.value.`type` shouldBe "email"
-        manifest.getResource(Uri("b")).right.value.`type` shouldBe "email"
-        manifest.getResource(Uri("c")).right.value.`type` shouldBe "email"
+        manifest.getResource(Uri("a")).toOption.get.`type` shouldBe "email"
+        manifest.getResource(Uri("b")).toOption.get.`type` shouldBe "email"
+        manifest.getResource(Uri("c")).toOption.get.`type` shouldBe "email"
       }
 
       "Can retrieve a thread" in {
@@ -168,7 +168,7 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
 
       def fetchWork(worker: String, maxBatchSize: Int, maxCost: Int = 10000): List[(Uri, String)] = {
         val result = manifest.fetchWork(worker, maxBatchSize, maxCost)
-        result.right.get.map { case WorkItem(blob, _, extractor, _, List(English), _) => blob.uri -> extractor }
+        result.toOption.get.map { case WorkItem(blob, _, extractor, _, List(English), _) => blob.uri -> extractor }
       }
 
       def buildBlobs(collection: String, ingestion: String) = List(
@@ -350,7 +350,7 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
 
         manifest.insert(blobs, collection).isRight should be(true)
 
-        val rawResults = manifest.fetchWork("test", maxBatchSize = 3, maxCost = 10000).right.get
+        val rawResults = manifest.fetchWork("test", maxBatchSize = 3, maxCost = 10000).toOption.get
         val results = rawResults.map { case WorkItem(blob, _, _,  ingestion, List(English), _) => blob.uri -> ingestion }
 
         results should contain allOf(
@@ -378,13 +378,13 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
 
         manifest.insert(List(blobs(0)), collection).isRight should be(true)
 
-        val firstItem = manifest.fetchWork("test", maxBatchSize = 1, maxCost = 10000).right.get.head
+        val firstItem = manifest.fetchWork("test", maxBatchSize = 1, maxCost = 10000).toOption.get.head
         firstItem.blob.uri should be(blobs(0).blobUri)
 
         val wut = manifest.insert(List(blobs(1), blobs(2)), collection)
         wut.isRight should be(true)
 
-        val secondItem = manifest.fetchWork("test", maxBatchSize = 1, maxCost = 10000).right.get.head
+        val secondItem = manifest.fetchWork("test", maxBatchSize = 1, maxCost = 10000).toOption.get.head
         secondItem.blob.uri should be(blobs(2).blobUri)
       }
     }
@@ -445,7 +445,7 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
         val result = command.process().eitherValue
         result.isRight should be(true)
 
-        manifest.getResource(Uri("upload/test/wut/up")).right.value.children(0).`type` shouldBe "blob"
+        manifest.getResource(Uri("upload/test/wut/up")).toOption.get.children(0).`type` shouldBe "blob"
       }
     }
   }

--- a/backend/test/services/manifest/Neo4JManifestITest.scala
+++ b/backend/test/services/manifest/Neo4JManifestITest.scala
@@ -168,7 +168,7 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
 
       def fetchWork(worker: String, maxBatchSize: Int, maxCost: Int = 10000): List[(Uri, String)] = {
         val result = manifest.fetchWork(worker, maxBatchSize, maxCost)
-        result.toOption.get.map { case WorkItem(blob, _, extractor, _, List(English), _) => blob.uri -> extractor }
+        result.toOption.get.map { case WorkItem(blob, _, extractor, _, _, _) => blob.uri -> extractor }
       }
 
       def buildBlobs(collection: String, ingestion: String) = List(

--- a/backend/test/services/manifest/Neo4JManifestITest.scala
+++ b/backend/test/services/manifest/Neo4JManifestITest.scala
@@ -97,7 +97,7 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
       "Can insert emails" in {
         val result = manifest.insert(emails, Uri("test-collection/test-ingestion"))
         if (result.isLeft) {
-          val value = result.left.get
+          val value = result.swap.toOption.get
           logger.warn(value.toString, value.cause.get)
         }
         result.isRight shouldBe true
@@ -403,7 +403,7 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
         Files.write(fileToUpload, "This is a test".getBytes(StandardCharsets.UTF_8))
 
         val command = new IngestFile(collectionUri, ingestionUri, "test", None, "someoneElse", fileToUpload, originalFilePath, None, manifest, esEvents, ingestionServices, null)(global)
-        command.process().eitherValue.left.get shouldBe a [MissingPermissionFailure]
+        command.process().eitherValue.swap.toOption.get shouldBe a [MissingPermissionFailure]
       }
 
       "Cannot upload to a fixed ingestion" in {
@@ -419,7 +419,7 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
         Files.write(fileToUpload, "This is a test".getBytes(StandardCharsets.UTF_8))
 
         val command = new IngestFile(collectionUri, ingestionUri, "test", None, "someoneElse", fileToUpload, originalFilePath, None, manifest, esEvents, ingestionServices, null)(global)
-        command.process().eitherValue.left.get shouldBe a [MissingPermissionFailure]
+        command.process().eitherValue.swap.toOption.get shouldBe a [MissingPermissionFailure]
       }
 
       "Upload" in {

--- a/backend/test/services/manifest/Neo4JManifestITest.scala
+++ b/backend/test/services/manifest/Neo4JManifestITest.scala
@@ -351,7 +351,7 @@ class Neo4JManifestITest extends AnyFreeSpec with Matchers with Neo4jTestService
         manifest.insert(blobs, collection).isRight should be(true)
 
         val rawResults = manifest.fetchWork("test", maxBatchSize = 3, maxCost = 10000).toOption.get
-        val results = rawResults.map { case WorkItem(blob, _, _,  ingestion, List(English), _) => blob.uri -> ingestion }
+        val results = rawResults.map { case WorkItem(blob, _, _,  ingestion, _, _) => blob.uri -> ingestion }
 
         results should contain allOf(
           blobs(0).blobUri -> ingestions(0).value,

--- a/backend/test/test/AttemptValues.scala
+++ b/backend/test/test/AttemptValues.scala
@@ -28,7 +28,7 @@ trait AttemptValues extends EitherValues with ScalaFutures with SomePatience {
     def failureValue(implicit patienceConfig: PatienceConfig, pos: Position): Failure = {
       val underlyingEither: Either[Failure, A] = eitherValue
       try {
-        underlyingEither.left.get
+        underlyingEither.swap.toOption.get
       } catch {
         case cause: NoSuchElementException =>
           throw new TestFailedException((_: StackDepthException) => Some(s"Expected Attempt to have failed, but was successful: $underlyingEither"), Some(cause), pos)
@@ -38,7 +38,7 @@ trait AttemptValues extends EitherValues with ScalaFutures with SomePatience {
     def successValue(implicit patienceConfig: PatienceConfig, pos: Position): A = {
       val underlyingEither: Either[Failure, A] = eitherValue(patienceConfig, pos)
       try {
-        underlyingEither.right.get
+        underlyingEither.toOption.get
       } catch {
         case cause: NoSuchElementException =>
           throw new TestFailedException((_: StackDepthException) => Some(s"Expected Attempt to have succeeded, but failed: $underlyingEither"), Some(cause), pos)

--- a/backend/test/test/TestUserManagement.scala
+++ b/backend/test/test/TestUserManagement.scala
@@ -11,7 +11,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object TestUserManagement {
   def apply(initialUsers: List[user.DBUser]): TestUserManagement = {
-    val withPermissions: Map[String, (user.DBUser, user.UserPermissions, List[Collection])] = initialUsers.map(user => user.username -> (user, UserPermissions.default, List.empty))(scala.collection.breakOut)
+    val withPermissions: Map[String, (user.DBUser, user.UserPermissions, List[Collection])] = initialUsers.map(user => user.username -> (user, UserPermissions.default, List.empty)).toMap
     new TestUserManagement(withPermissions)
   }
 

--- a/backend/test/test/integration/DockerNeo4jService.scala
+++ b/backend/test/test/integration/DockerNeo4jService.scala
@@ -3,7 +3,7 @@ package test.integration
 import com.whisk.docker.{DockerContainer, DockerKit, DockerReadyChecker}
 import org.neo4j.driver.v1.{AuthTokens, GraphDatabase}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Try

--- a/backend/test/test/integration/Helpers.scala
+++ b/backend/test/test/integration/Helpers.scala
@@ -229,8 +229,8 @@ object Helpers extends Matchers with Logging with OptionValues with Inside {
     (implicit ec: ExecutionContext): Map[String, Controllers] = {
 
     val queryLoggingConfig = new Neo4jQueryLoggingConfig(1.second, logAllQueries = false)
-    val manifest = Neo4jManifest.setupManifest(neo4jDriver, ec, queryLoggingConfig).right.get
-    val annotations = Neo4jAnnotations.setupAnnotations(neo4jDriver, ec, queryLoggingConfig).right.get
+    val manifest = Neo4jManifest.setupManifest(neo4jDriver, ec, queryLoggingConfig).toOption.get
+    val annotations = Neo4jAnnotations.setupAnnotations(neo4jDriver, ec, queryLoggingConfig).toOption.get
 
     val typeDetector = new TestTypeDetector("application/pdf")
 

--- a/backend/test/test/integration/Helpers.scala
+++ b/backend/test/test/integration/Helpers.scala
@@ -492,7 +492,7 @@ object Helpers extends Matchers with Logging with OptionValues with Inside {
   }
 
   def listCollections()(implicit controllers: Controllers, timeout: Timeout): List[String] = {
-    contentAsJson(controllers.collections.listCollections.apply(FakeRequest()))
+    contentAsJson(controllers.collections.listCollections().apply(FakeRequest()))
       .as[List[Collection]].map(_.uri.value)
   }
 

--- a/backend/test/test/integration/Neo4jTestService.scala
+++ b/backend/test/test/integration/Neo4jTestService.scala
@@ -55,7 +55,7 @@ trait Neo4jTestService
 
   def deleteAllNeo4jNodes(): Unit = {
     // Abort the test if this operation failed (see scalatest EitherValues)
-    deleteNodes().right.value
+    deleteNodes().toOption.get
   }
 
   override def afterAll(): Unit = {

--- a/backend/test/users/Neo4jUserManagementITest.scala
+++ b/backend/test/users/Neo4jUserManagementITest.scala
@@ -46,7 +46,7 @@ class Neo4jUserManagementITest extends AnyFreeSpec with Matchers with Neo4jTestS
   }
 
   class TestSetup {
-    val manifest = Neo4jManifest.setupManifest(neo4jDriver, global, neo4jQueryLoggingConfig).right.value
+    val manifest = Neo4jManifest.setupManifest(neo4jDriver, global, neo4jQueryLoggingConfig).toOption.get
 
     val index = stub[Index]
     val pages = stub[Pages]

--- a/backend/test/utils/auth/AuthActionBuilderTest.scala
+++ b/backend/test/utils/auth/AuthActionBuilderTest.scala
@@ -157,7 +157,7 @@ class AuthActionBuilderTest extends AnyFreeSpec with Matchers with BaseOneAppPer
         val requestTime = now.plusMinutes(10)
         val futureResult = authActionBuilder.invokeBlockWithTime(request, block, requestTime.getMillis)
         val resultEither = Helpers.await(futureResult)
-        val result = resultEither.right.value
+        val result = resultEither.toOption.get
 
         val newToken = tokenFromResult(result)
         newToken.user shouldBe token.user
@@ -178,7 +178,7 @@ class AuthActionBuilderTest extends AnyFreeSpec with Matchers with BaseOneAppPer
         val requestTime = now.plusMinutes(10)
         val futureResult = authActionBuilder.invokeBlockWithTime(request, block, requestTime.getMillis)
         val resultEither = Helpers.await(futureResult)
-        val result = resultEither.right.value
+        val result = resultEither.toOption.get
 
         val newToken = tokenFromResult(result)
         newToken.user shouldBe token.user
@@ -248,7 +248,7 @@ class AuthActionBuilderTest extends AnyFreeSpec with Matchers with BaseOneAppPer
         val futureResult = authActionBuilderWithInvalidatedUser.
           invokeBlockWithTime(request, block, now.getMillis)
         val resultOrFailure = Helpers.await(futureResult)
-        val result = resultOrFailure.right.value
+        val result = resultOrFailure.toOption.get
         result.header.status shouldBe 200
       }
     }

--- a/backend/test/utils/auth/AuthActionBuilderTest.scala
+++ b/backend/test/utils/auth/AuthActionBuilderTest.scala
@@ -30,7 +30,7 @@ import org.scalatest.matchers.should.Matchers
 class AuthActionBuilderTest extends AnyFreeSpec with Matchers with BaseOneAppPerSuite with FakeApplicationFactory
   with EitherValues with Results with Inside {
 
-  override def fakeApplication: Application = {
+  override def fakeApplication(): Application = {
     val env = Environment.simple(new File("."))
     val initialSettings: Map[String, AnyRef] = Map(
       "play.http.secret.key" -> "TestKey",
@@ -45,13 +45,13 @@ class AuthActionBuilderTest extends AnyFreeSpec with Matchers with BaseOneAppPer
   }
 
   // To appease jwt-scala
-  implicit val configuration: Configuration = fakeApplication.configuration
+  implicit val configuration: Configuration = fakeApplication().configuration
   implicit val clock: Clock = Clock.systemUTC()
 
   val fakeUsers = TestUserManagement(List(user.DBUser("mickey", Some("Mickey Mouse"), Some(BCryptPassword("invalid")), None, registered = true, None)))
 
   "AuthActionBuilder" - {
-    val authActionBuilder = new DefaultAuthActionBuilder(Helpers.stubControllerComponents(), new DefaultFailureToResultMapper, 8 hours, 15 minutes, fakeUsers)(fakeApplication.configuration, Clock.systemUTC())
+    val authActionBuilder = new DefaultAuthActionBuilder(Helpers.stubControllerComponents(), new DefaultFailureToResultMapper, 8 hours, 15 minutes, fakeUsers)(fakeApplication().configuration, Clock.systemUTC())
     val userMickey = User("mickey", "Mickey Mouse")
     val now = new DateTime(2017, 1, 5, 16, 0, 0)
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ lazy val root = (project in file("."))
 lazy val common = (project in file("common"))
   .settings(
     name := "common",
+    scalacOptions := compilerFlags,
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.2.0",
       "com.typesafe.play" %% "play-json" % "2.9.0",

--- a/build.sbt
+++ b/build.sbt
@@ -148,8 +148,8 @@ lazy val backend = (project in file("backend"))
 
       "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
       "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
-      "com.whisk" %% "docker-testkit-scalatest" % "0.11.0" % Test,
-      "com.whisk" %% "docker-testkit-impl-spotify" % "0.11.0-beta1" % Test,
+      "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % Test,
+      "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % Test,
       "org.scalamock" %% "scalamock" % "4.4.0" % Test
     ),
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "giant"
 description := "Tool for journalists to search, analyse and categorise unstructured data, often during an investigation"
 version := "0.1.0"
 
-scalaVersion in ThisBuild := "2.12.15"
+ThisBuild / scalaVersion := "2.13.9"
 
 import com.gu.riffraff.artifact.BuildInfo
 import play.sbt.PlayImport.PlayKeys._
@@ -12,8 +12,7 @@ val compilerFlags = Seq(
   "-unchecked",
   "-deprecation",
   "-feature",
-  "-Xfatal-warnings",
-  "-Ypartial-unification"
+  "-Xfatal-warnings"
 )
 
 val awsVersion = "1.11.566"
@@ -112,7 +111,6 @@ lazy val backend = (project in file("backend"))
       "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "7.9.2",
       "com.typesafe.akka" %% "akka-cluster-typed" % "2.6.5", // should match what we get transitively from Play
       "org.neo4j.driver" % "neo4j-java-driver" % "1.6.3",
-      "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1",
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the
       // conf/org/apache/tika/mimecustom-mimetypes.xml file
@@ -130,10 +128,10 @@ lazy val backend = (project in file("backend"))
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatchmetrics" % awsVersion,
       "com.beachape" %% "enumeratum-play" % "1.6.1",
-      "com.iheart" %% "ficus" % "1.4.4",
+      "com.iheart" %% "ficus" % "1.5.2",
       "com.sun.mail" % "javax.mail" % "1.6.2",
       "org.jsoup" % "jsoup" % "1.11.3",
-      "com.gu" %% "pan-domain-auth-verification" % "0.8.0",
+      "com.gu" %% "pan-domain-auth-verification" % "1.2.0",
 
       // Libraries whose use are potentially contentious
 
@@ -149,9 +147,9 @@ lazy val backend = (project in file("backend"))
 
       "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
       "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
-      "com.whisk" %% "docker-testkit-scalatest" % "0.9.8" % Test,
-      "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.8" % Test,
-      "org.scalamock" %% "scalamock" % "4.1.0" % Test
+      "com.whisk" %% "docker-testkit-scalatest" % "0.11.0" % Test,
+      "com.whisk" %% "docker-testkit-impl-spotify" % "0.11.0-beta1" % Test,
+      "org.scalamock" %% "scalamock" % "4.4.0" % Test
     ),
 
     // set up separate tests and integration tests - http://www.scala-sbt.org/0.13.1/docs/Detailed-Topics/Testing.html#custom-test-configuration
@@ -191,7 +189,7 @@ lazy val cli = (project in file("cli"))
     name := "pfi-cli",
     scalacOptions := compilerFlags,
     libraryDependencies ++= Seq(
-      "org.rogach" %% "scallop" % "3.1.3",
+      "org.rogach" %% "scallop" % "3.5.1",
       "com.beachape" %% "enumeratum" % "1.5.13",
       "com.squareup.okhttp3" % "okhttp" % "3.10.0",
       "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,

--- a/cli/src/main/scala/com/gu/pfi/cli/DeleteIngestions.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/DeleteIngestions.scala
@@ -51,7 +51,7 @@ class DeleteIngestions(ingestions: List[(String, String)], ingestionService: Cli
           logger.warn(
             s"""${b.uri} in [${b.ingestion.mkString(", ")}] is also present in [${conflictingIngestions.mkString(" ")}].
            Skipping for now.""".stripMargin)
-          Attempt.Right(Unit)
+          Attempt.Right(())
         case Delete =>
               logger.warn(
                 s"""${b.uri} in [${b.ingestion.mkString(", ")}] is also present in [${conflictingIngestions.mkString(" ")}].

--- a/cli/src/main/scala/com/gu/pfi/cli/Main.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/Main.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration.Duration
 object Main extends App with Logging {
   import scala.language.reflectiveCalls
 
-  val options = new Options(args)
+  val options = new Options(args.toIndexedSeq)
 
   options.subcommand match {
     case Some(options.hashCmd) =>

--- a/cli/src/main/scala/com/gu/pfi/cli/Main.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/Main.scala
@@ -23,8 +23,8 @@ object Main extends App with Logging {
     case Some(options.hashCmd) =>
       HashFiles.run(options.hashCmd.files())
 
-    case Some(cmd @ options.loginCmd) =>
-      run("Login", cmd) { services =>
+    case Some(_ @ options.loginCmd) =>
+      run("Login", options.loginCmd) { services =>
         services.http.login(
           options.loginCmd.username.toOption,
           options.loginCmd.password.toOption,
@@ -33,13 +33,13 @@ object Main extends App with Logging {
         )
       }
 
-    case Some(cmd @ options.logoutCmd) =>
-      run("Logout", cmd) { services =>
+    case Some(_ @ options.logoutCmd) =>
+      run("Logout", options.logoutCmd) { services =>
         services.http.logout()
       }
 
-    case Some(cmd @ options.apiCmd) =>
-      run("API call", cmd) { services =>
+    case Some(_ @ options.apiCmd) =>
+      run("API call", options.apiCmd) { services =>
         val uri = options.apiCmd.endpoint()
 
         options.apiCmd.verb() match {
@@ -62,15 +62,15 @@ object Main extends App with Logging {
         }
       }
 
-    case Some(cmd @ options.authCmd) =>
-      run("Authorisation token", cmd) { services =>
+    case Some(_ @ options.authCmd) =>
+      run("Authorisation token", options.authCmd) { services =>
         services.http.getCredentials.map { creds =>
           logger.info(s"${CliHttpClient.authHeader}: ${creds.authorization}")
         }
       }
 
-    case Some(cmd @ options.listCmd) =>
-      run("List ingestions", cmd) { services =>
+    case Some(_ @ options.listCmd) =>
+      run("List ingestions", options.listCmd) { services =>
         services.ingestion.listIngestions().map { ingestions =>
           ingestions.sortBy(_.uri.toLowerCase(Locale.UK)).foreach { ingestion =>
             logger.info(ingestion.uri)
@@ -81,8 +81,8 @@ object Main extends App with Logging {
         }
       }
 
-    case Some(cmd @ options.verifyCmd) =>
-      run("Verify ingestion", cmd) { services =>
+    case Some(_ @ options.verifyCmd) =>
+      run("Verify ingestion", options.verifyCmd) { services =>
         val result = services.ingestion.verifyIngestion(
           options.verifyCmd.ingestion(),
           options.verifyCmd.checkDigest(),
@@ -110,21 +110,21 @@ object Main extends App with Logging {
         }
       }
 
-    case Some(cmd @ options.ingestCmd) =>
-      run("Ingest", cmd) { services =>
+    case Some(_ @ options.ingestCmd) =>
+      run("Ingest", options.ingestCmd) { services =>
         val ingestArgs = options.ingestCmd
 
         val source = IngestionSource(options)
         val credentials = AwsCredentials(ingestArgs.minioAccessKey.toOption, ingestArgs.minioSecretKey.toOption, ingestArgs.awsProfile.toOption)
 
-        val ingestionS3Client = new DefaultIngestionS3Client(cmd, credentials)
+        val ingestionS3Client = new DefaultIngestionS3Client(options.ingestCmd, credentials)
 
         val command = new RunIngestion(services.ingestion, ingestionS3Client, services.veracrypt)
-        command.run(Uri(ingestArgs.ingestionUri()), source, cmd.languages)
+        command.run(Uri(ingestArgs.ingestionUri()), source, options.ingestCmd.languages)
       }
 
-    case Some(cmd @ options.createUsers) =>
-      run("Create users", cmd) { services =>
+    case Some(_ @ options.createUsers) =>
+      run("Create users", options.createUsers) { services =>
         services.users.createUsers(options.createUsers.usernames()).map { newUsers =>
           newUsers.foreach { user =>
             logger.info(s"username: ${user.username}\tpassword: ${user.password}")
@@ -132,18 +132,18 @@ object Main extends App with Logging {
         }
       }
 
-    case Some(cmd @ options.deleteIngestions) =>
-      run("Delete ingestions", cmd) { services =>
-        val command = new DeleteIngestions(cmd.ingestionUris, services.ingestion, cmd.conflictBehaviour)
+    case Some(_ @ options.deleteIngestions) =>
+      run("Delete ingestions", options.deleteIngestions) { services =>
+        val command = new DeleteIngestions(options.deleteIngestions.ingestionUris, services.ingestion, options.deleteIngestions.conflictBehaviour)
         command.run()
       }
 
-    case Some(cmd @ options.createIngestion) =>
-      run("Create ingestion", cmd) { services =>
-        val Array(collection, ingestionName) = cmd.ingestionUri().split('/')
+    case Some(_ @ options.createIngestion) =>
+      run("Create ingestion", options.createIngestion) { services =>
+        val Array(collection, ingestionName) = options.createIngestion.ingestionUri().split('/')
 
         services.ingestion.createCollection(collection).flatMap { _ =>
-          services.ingestion.createIngestion(collection, root = None, ingestionName, cmd.languages, fixed = false)
+          services.ingestion.createIngestion(collection, root = None, ingestionName, options.createIngestion.languages, fixed = false)
         }
       }
 

--- a/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliFileWalker.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliFileWalker.scala
@@ -6,7 +6,7 @@ import model.{Language, Uri}
 import model.ingestion.{IngestionFile, OnDiskFileContext}
 import utils.Logging
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 class CliFileWalker(enrich: Path => IngestionFile) extends Logging {

--- a/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliFileWalker.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliFileWalker.scala
@@ -6,15 +6,15 @@ import model.{Language, Uri}
 import model.ingestion.{IngestionFile, OnDiskFileContext}
 import utils.Logging
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.StreamConverters._
 import scala.util.Try
 
 class CliFileWalker(enrich: Path => IngestionFile) extends Logging {
-  def walk(path: Path, root: Uri, languages: List[Language]): Stream[OnDiskFileContext] = {
+  def walk(path: Path, root: Uri, languages: List[Language]): LazyList[OnDiskFileContext] = {
     walk(path, List(root.chain(path.getFileName.toString), root), root, languages)
   }
 
-  private def walk(thisPath: Path, parents: List[Uri], root: Uri, languages: List[Language]): Stream[OnDiskFileContext] = {
+  private def walk(thisPath: Path, parents: List[Uri], root: Uri, languages: List[Language]): LazyList[OnDiskFileContext] = {
     val enrichedPath = enrich(thisPath)
 
     OnDiskFileContext(enrichedPath, parents, root.value, languages, thisPath) #:: {
@@ -22,15 +22,15 @@ class CliFileWalker(enrich: Path => IngestionFile) extends Logging {
         Try {
           val fileStream = Files.list(thisPath)
           // eagerly evaluate the file stream; allowing it to be closed to avoid resource exhaustion
-          val evaluated = fileStream.iterator().asScala.toList
+          val evaluated = fileStream.toScala(LazyList)
           fileStream.close()
           evaluated
-        }.map(_.toStream.flatMap(p => walk(p, parents.head.chain(p.getFileName.toString) :: parents, root, languages))).getOrElse {
+        }.map(_.flatMap(p => walk(p, parents.head.chain(p.getFileName.toString) :: parents, root, languages))).getOrElse {
           logger.error(s"IO error reading '$thisPath'")
-          Stream.empty[OnDiskFileContext]
+          LazyList.empty[OnDiskFileContext]
         }
       } else {
-        Stream.empty[OnDiskFileContext]
+        LazyList.empty[OnDiskFileContext]
       }
     }
   }

--- a/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliIngestionPipeline.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliIngestionPipeline.scala
@@ -141,7 +141,7 @@ class CliIngestionPipeline(ingestionService: CliIngestionService, s3Client: Inge
   }
 
   private def filesIterator(rootPath: Path, rootUri: Uri, languages: List[Language]): Iterator[OnDiskFileContext] = {
-    val walker = new CliFileWalker(path ⇒
+    val walker = new CliFileWalker(path =>
       CliIngestionPipeline.makeRelativeFile(path, rootPath, rootUri, Files.readAttributes(path, "*", LinkOption.NOFOLLOW_LINKS))
     )
     walker.walk(rootPath, rootUri, languages).toIterator

--- a/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliIngestionPipeline.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliIngestionPipeline.scala
@@ -144,7 +144,7 @@ class CliIngestionPipeline(ingestionService: CliIngestionService, s3Client: Inge
     val walker = new CliFileWalker(path =>
       CliIngestionPipeline.makeRelativeFile(path, rootPath, rootUri, Files.readAttributes(path, "*", LinkOption.NOFOLLOW_LINKS))
     )
-    walker.walk(rootPath, rootUri, languages).toIterator
+    walker.walk(rootPath, rootUri, languages).iterator
   }
 }
 

--- a/cli/src/main/scala/com/gu/pfi/cli/service/CliIngestionService.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/service/CliIngestionService.scala
@@ -14,7 +14,7 @@ import utils.attempt.AttemptAwait._
 import utils.attempt._
 import utils.{IngestionVerification, Logging}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 
 class CliIngestionService(http: CliHttpClient)(implicit ec: ExecutionContext) extends Logging {

--- a/common/src/main/scala/utils/attempt/Attempt.scala
+++ b/common/src/main/scala/utils/attempt/Attempt.scala
@@ -105,7 +105,7 @@ object Attempt {
     * or the successful result.
     */
   def traverse[A, B, M[X] <: IterableOnce[X]](as: M[A])(f: A => Attempt[B])(implicit cbf: BuildFrom[M[A], B, M[B]], ec: ExecutionContext): Attempt[M[B]] = {
-    as.iterator.foldLeft(Right(cbf(as))) {
+    as.iterator.foldLeft(Right(cbf.newBuilder(as))) {
       (attempt, a) => attempt.zipWith(f(a))(_ += _)
     }.map(_.result())
   }

--- a/common/src/main/scala/utils/attempt/Attempt.scala
+++ b/common/src/main/scala/utils/attempt/Attempt.scala
@@ -104,8 +104,8 @@ object Attempt {
     * This implementation returns the first failure in the resulting list,
     * or the successful result.
     */
-  def traverse[A, B, M[X] <: TraversableOnce[X]](as: M[A])(f: A => Attempt[B])(implicit cbf: BuildFrom[M[A], B, M[B]], ec: ExecutionContext): Attempt[M[B]] = {
-    as.foldLeft(Right(cbf(as))) {
+  def traverse[A, B, M[X] <: IterableOnce[X]](as: M[A])(f: A => Attempt[B])(implicit cbf: BuildFrom[M[A], B, M[B]], ec: ExecutionContext): Attempt[M[B]] = {
+    as.iterator.foldLeft(Right(cbf(as))) {
       (attempt, a) => attempt.zipWith(f(a))(_ += _)
     }.map(_.result())
   }

--- a/common/src/main/scala/utils/attempt/Attempt.scala
+++ b/common/src/main/scala/utils/attempt/Attempt.scala
@@ -1,10 +1,8 @@
 package utils.attempt
 
 import cats.data.EitherT
-
-import scala.collection.generic.CanBuildFrom
+import scala.collection.BuildFrom
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.higherKinds
 import scala.util.control.NonFatal
 
 /**
@@ -106,7 +104,7 @@ object Attempt {
     * This implementation returns the first failure in the resulting list,
     * or the successful result.
     */
-  def traverse[A, B, M[X] <: TraversableOnce[X]](as: M[A])(f: A => Attempt[B])(implicit cbf: CanBuildFrom[M[A], B, M[B]], ec: ExecutionContext): Attempt[M[B]] = {
+  def traverse[A, B, M[X] <: TraversableOnce[X]](as: M[A])(f: A => Attempt[B])(implicit cbf: BuildFrom[M[A], B, M[B]], ec: ExecutionContext): Attempt[M[B]] = {
     as.foldLeft(Right(cbf(as))) {
       (attempt, a) => attempt.zipWith(f(a))(_ += _)
     }.map(_.result())
@@ -137,7 +135,7 @@ object Attempt {
     *
     * This implementation returns the first failure in the list, or the successful result.
     */
-  def sequence[A, M[X] <: TraversableOnce[X]](in: M[Attempt[A]])(implicit cbf: CanBuildFrom[M[Attempt[A]], A, M[A]], executor: ExecutionContext): Attempt[M[A]] = {
+  def sequence[A, M[X] <: TraversableOnce[X]](in: M[Attempt[A]])(implicit cbf: BuildFrom[M[Attempt[A]], A, M[A]], executor: ExecutionContext): Attempt[M[A]] = {
     traverse(in)(identity)
   }
 

--- a/common/src/main/scala/utils/attempt/Attempt.scala
+++ b/common/src/main/scala/utils/attempt/Attempt.scala
@@ -135,7 +135,7 @@ object Attempt {
     *
     * This implementation returns the first failure in the list, or the successful result.
     */
-  def sequence[A, M[X] <: TraversableOnce[X]](in: M[Attempt[A]])(implicit cbf: BuildFrom[M[Attempt[A]], A, M[A]], executor: ExecutionContext): Attempt[M[A]] = {
+  def sequence[A, M[X] <: IterableOnce[X]](in: M[Attempt[A]])(implicit cbf: BuildFrom[M[Attempt[A]], A, M[A]], executor: ExecutionContext): Attempt[M[A]] = {
     traverse(in)(identity)
   }
 

--- a/common/src/main/scala/utils/attempt/Failure.scala
+++ b/common/src/main/scala/utils/attempt/Failure.scala
@@ -5,6 +5,8 @@ import java.io.{PrintWriter, StringWriter}
 import cats.kernel.Semigroup
 import play.api.libs.json._
 
+import scala.collection.Seq
+
 sealed trait Failure {
   def msg: String
   def cause: Option[Throwable] = None

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,10 @@
 // The Typesafe repository
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
-resolvers += "JBoss" at "https://repository.jboss.org" // needed for the scrooge-sbt-plugin due to broken jboss deps
 
-libraryDependencies += "org.vafer" % "jdeb" % "1.6" artifacts (Artifact("jdeb", "jar", "jar"))
+libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M7")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "18.4.0")
-
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
-
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")


### PR DESCRIPTION
Have some free work on me :)

Upgrades Scala to 2.13 and fixes the MANY MANY warnings that come as a result. Also updates SBT to the latest too. Where I've had to upgrade dependencies to get 2.13 builds I have been as conservative as possible and gone for the latest version I can that doesn't involve additional code changes.

I've done individual commits per compile error so you'll probably want to squash and merge. I'll put in some inline comments for anything that is a wider change.

It's a lot of files changed but fundamentally it's all rewrites to avoid deprecation warnings. All the tests still pass (including integration tests) and I've spun up Giant, gone through the genesis flow, logged in as the admin and uploaded a file successfully.