### PR TITLE
Remove deleteFolders param

### DIFF
--- a/backend/app/commands/DeleteResource.scala
+++ b/backend/app/commands/DeleteResource.scala
@@ -61,9 +61,6 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
          _ <- Attempt.fromEither(previewStorage.delete(uri.toStoragePath))
          _ <- Attempt.fromEither(objectStorage.delete(uri.toStoragePath))
          _ <- index.delete(uri.value)
-         _ <- manifest.deleteBlobFileParent(uri)
-         // not all blobs are in workspaces so ignore failures here
-         _ <- manifest.deleteBlobWorkspaceNode(uri).recoverWith{ case _ => successAttempt}
          _ <- manifest.deleteBlob(uri)
          _ <- successAttempt
        } yield {

--- a/backend/app/commands/DeleteResource.scala
+++ b/backend/app/commands/DeleteResource.scala
@@ -51,7 +51,7 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
        pagePreviewObjectsAttempt.flatMap(deletePagePreviewObjects)
      }
 
-     private def deleteResource(uri: Uri, deleteFolders: Boolean): Attempt[Unit] = {
+     private def deleteResource(uri: Uri): Attempt[Unit] = {
        val successAttempt = Attempt.Right(())
        for {
          // For blobs not processed by the OcrMyPdfExtractor, ocrLanguages will be an empty list
@@ -61,9 +61,9 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
          _ <- Attempt.fromEither(previewStorage.delete(uri.toStoragePath))
          _ <- Attempt.fromEither(objectStorage.delete(uri.toStoragePath))
          _ <- index.delete(uri.value)
-         _ <- if (deleteFolders) manifest.deleteBlobFileParent(uri) else successAttempt
+         _ <- manifest.deleteBlobFileParent(uri)
          // not all blobs are in workspaces so ignore failures here
-         _ <- if (deleteFolders) manifest.deleteBlobWorkspaceNode(uri).recoverWith{ case _ => successAttempt} else successAttempt
+         _ <- manifest.deleteBlobWorkspaceNode(uri).recoverWith{ case _ => successAttempt}
          _ <- manifest.deleteBlob(uri)
          _ <- successAttempt
        } yield {
@@ -72,20 +72,20 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
      }
 
      // Deletes resource after checking it has no child nodes
-     def deleteBlobCheckChildren(id: String, deleteFolders: Boolean): Attempt[_ <: Unit] = {
+     def deleteBlobCheckChildren(id: String): Attempt[_ <: Unit] = {
        val uri = Uri(id)
 
        // casting to an option here because Attempt[Resource] and Attempt[Unit] are incompatible - so can't use a for comprehension with toAttempt
        val deleteResult = manifest.getResource(uri).toOption map { resource =>
-         if (resource.children.isEmpty) deleteResource(uri, deleteFolders)
+         if (resource.children.isEmpty) deleteResource(uri)
          else Attempt.Left(IllegalStateFailure(s"Cannot delete $uri as it has child nodes"))
        }
        deleteResult.getOrElse(Attempt.Left(DeleteFailure("Failed to fetch resource")))
      }
 
-     def deleteBlob(id: String, deleteFolders: Boolean): Attempt[Unit] = {
+     def deleteBlob(id: String): Attempt[Unit] = {
        val uri = Uri(id)
-       deleteResource(uri, deleteFolders)
+       deleteResource(uri)
      }
 
    }

--- a/backend/app/controllers/api/Blobs.scala
+++ b/backend/app/controllers/api/Blobs.scala
@@ -67,12 +67,12 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
   }
 
 
-  def delete(id: String, deleteFolders: Boolean, checkChildren: Boolean): Action[AnyContent] = ApiAction.attempt { req =>
+  def delete(id: String, checkChildren: Boolean): Action[AnyContent] = ApiAction.attempt { req =>
     import scala.language.existentials
     val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage)
     checkPermission(CanPerformAdminOperations, req) {
-      val result = if (checkChildren) deleteResource.deleteBlobCheckChildren(id, deleteFolders)
-      else deleteResource.deleteBlob(id, deleteFolders)
+      val result = if (checkChildren) deleteResource.deleteBlobCheckChildren(id)
+      else deleteResource.deleteBlob(id)
       result.map(_ => NoContent)
     }
   }

--- a/backend/app/services/manifest/Manifest.scala
+++ b/backend/app/services/manifest/Manifest.scala
@@ -83,8 +83,6 @@ trait Manifest extends WorkerManifest {
   def getLanguagesProcessedByOcrMyPdf(uri: Uri): Attempt[List[Language]]
 
   def deleteBlob(uri: Uri): Attempt[Unit]
-  def deleteBlobFileParent(uri: Uri): Attempt[Unit]
-  def deleteBlobWorkspaceNode(uri: Uri): Attempt[Unit]
 
   def deleteIngestion(uri: Uri): Attempt[Unit]
 }

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -987,26 +987,15 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
     }
   }
 
-  def deleteBlobWorkspaceNode(uri: Uri): Attempt[Unit] = processDelete(
-    uri,
-    """
-        |MATCH (w: WorkspaceNode:Resource { uri: { uri }})  DETACH DELETE w
-      """.stripMargin,
-    count => count == 1,
-    "Error deleting workspace node")
-
-  def deleteBlobFileParent(uri: Uri): Attempt[Unit] = processDelete(
-    uri,
-    """
-      |MATCH (: Blob:Resource { uri: { uri }}) -->(f: File) DETACH DELETE f
-      """.stripMargin,
-    count => count > 0,
-    "Error deleting file parent")
-
   def deleteBlob(uri: Uri): Attempt[Unit] = processDelete(
     uri,
+    // OPTIONAL MATCH so if there's no Workspace node pointing to it,
+    // we still delete the blob, and vice versa. (The vice versa would be
+    // unexpected but maybe you're clearing up a blob that was only partially deleted before).
     """
-      |MATCH (b: Blob:Resource { uri: { uri }}) DETACH DELETE b
+      |OPTIONAL MATCH (w: WorkspaceNode { uri: { uri }})
+      |OPTIONAL MATCH (b: Blob:Resource { uri: { uri }})-[:PARENT]->(f: File)
+      |DETACH DELETE b, f, w
       """.stripMargin,
     // We consider the deletion a success even if nothing has been deleted since the deletion may have been triggered
     // from a list of results coming back from Elasticsearch (which is eventually consistent so doesn't immediately

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -12,7 +12,7 @@ POST          /api/collections/:collection/:ingestion/verifyFiles           cont
 
 GET           /api/blobs                                                    controllers.api.Blobs.getBlobs
 POST          /api/blobs/:id/reprocess                                      controllers.api.Blobs.reprocess(id, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])
-DELETE        /api/blobs/:id                                                controllers.api.Blobs.delete(id, deleteFolders: Boolean, checkChildren: Boolean)
+DELETE        /api/blobs/:id                                                controllers.api.Blobs.delete(id, checkChildren: Boolean)
 
 GET           /api/filters                                                  controllers.api.Filters.getFilters
 

--- a/cli/src/main/scala/com/gu/pfi/cli/service/CliIngestionService.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/service/CliIngestionService.scala
@@ -73,12 +73,9 @@ class CliIngestionService(http: CliHttpClient)(implicit ec: ExecutionContext) ex
 
   def deleteBlob(id: String): Attempt[Unit] = {
 
-    // delete the blob. deleteFolders=false is a very confusing param which should be fixed in a future pr. It means
-    // "don't search for the parent of the blob and delete that" - which we don't need to do in this context as everything
-    // is being deleted. Likewise checkChildren is a fairly silly name - setting it to false means that we delete this blob
-    // regardless of whether or not it has children. Both of these params need better names following their introduction
-    // in https://github.com/guardian/giant/pull/42
-    http.delete(s"/api/blobs/${URLEncoder.encode(id, "UTF-8")}?deleteFolders=false&checkChildren=false").map { r =>
+    // Setting checkChildren to false means that we delete this blob
+    // regardless of whether or not it has children.
+    http.delete(s"/api/blobs/${URLEncoder.encode(id, "UTF-8")}?checkChildren=false").map { r =>
       if(r.code() == 204) {
         Attempt.Right(())
       } else {

--- a/frontend/src/js/services/BlobApi.ts
+++ b/frontend/src/js/services/BlobApi.ts
@@ -1,6 +1,6 @@
 import authFetch from '../util/auth/authFetch';
 
 export function deleteBlob(uri: string): Promise<Response> {
-
-    return authFetch(`/api/blobs/${uri}?deleteFolders=true&checkChildren=true`, {method: "DELETE"})
+    // Do not delete blob if it has children
+    return authFetch(`/api/blobs/${uri}?checkChildren=true`, {method: "DELETE"})
 }


### PR DESCRIPTION
I can't think of a case where we delete a blob - either from UI, or as part of collection/ingestion deletion - where we don't want to remove any workspace references to it and remove the dangling file parent.

You could argue it's slightly more efficient not to remove the file parent when later on you're going to wipe the whole ingestion, but I don't think this is worth the complication. You definitely want to remove the workspace references.