### PR TITLE
Delete blob descendants from neo4j when deleting the blob

### DIFF
--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -1006,10 +1006,15 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
       |  WHERE descendant.uri STARTS WITH {uri}
       |DETACH DELETE b, f, w, descendant
       """.stripMargin,
-    // We consider the deletion a success even if nothing has been deleted since the deletion may have been triggered
-    // from a list of results coming back from Elasticsearch (which is eventually consistent so doesn't immediately
-    // show that the delete happened). TODO MRB: handle this more gracefully at a higher level, it's a hack down here
-    count => count == 0 || count == 1,
+    // Always consider the deletion a success.
+    // We can't set a lower bound, because if nothing has been deleted,
+    // the deletion may have been triggered from a list of results coming
+    // back from Elasticsearch (which is eventually consistent so doesn't
+    // immediately show that the delete happened).
+    // TODO MRB: handle the above more gracefully at a higher level, it's a hack down here
+    // And we can't set an upper bound, because there will be an indeterminate
+    // number of descendants deleted.
+    count => true,
     "Error deleting blob")
 
   def deleteIngestion(uri: Uri): Attempt[Unit] = attemptTransaction { tx =>

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -1002,9 +1002,9 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
     """
       |OPTIONAL MATCH (w: WorkspaceNode { uri: { uri }})
       |OPTIONAL MATCH (b: Blob:Resource { uri: { uri }})-[:PARENT]->(f: File)
-      |OPTIONAL MATCH (children :Resource)
-      |  WHERE r.uri STARTS WITH {uri}
-      |DETACH DELETE b, f, w, children
+      |OPTIONAL MATCH (descendant :Resource)
+      |  WHERE descendant.uri STARTS WITH {uri}
+      |DETACH DELETE b, f, w, descendant
       """.stripMargin,
     // We consider the deletion a success even if nothing has been deleted since the deletion may have been triggered
     // from a list of results coming back from Elasticsearch (which is eventually consistent so doesn't immediately

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -987,6 +987,13 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
     }
   }
 
+  // If this blob has children, the neo4j structure beneath it (down to
+  // the next :Blob descendant) will be deleted. This leaves orphaned blobs
+  // in neo4j, elasticsearch and S3, but it is expected that it will be called either:
+  //   1. from the UI, in which case the operation is disallowed if it has children
+  //   2. as part of deleting an ingestion or collection, in which case those
+  //      orphaned blobs will have been returned from the initial getBlobs ES query
+  //      and will therefore be deleted separately as we loop through them.
   def deleteBlob(uri: Uri): Attempt[Unit] = processDelete(
     uri,
     // OPTIONAL MATCH so if there's no Workspace node pointing to it,
@@ -995,7 +1002,9 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
     """
       |OPTIONAL MATCH (w: WorkspaceNode { uri: { uri }})
       |OPTIONAL MATCH (b: Blob:Resource { uri: { uri }})-[:PARENT]->(f: File)
-      |DETACH DELETE b, f, w
+      |OPTIONAL MATCH (children :Resource)
+      |  WHERE r.uri STARTS WITH {uri}
+      |DETACH DELETE b, f, w, children
       """.stripMargin,
     // We consider the deletion a success even if nothing has been deleted since the deletion may have been triggered
     // from a list of results coming back from Elasticsearch (which is eventually consistent so doesn't immediately


### PR DESCRIPTION
Since [deletion was introduced](https://github.com/guardian/pfi/pull/441), we've never been cleaning up the neo4j structures underneath blobs. (This is relevant only for blobs with children, i.e. files containing other files such as zips, archives, mailboxes, etc.).

When we delete the ingestion at the end of the process, we delete all resources whose URI starts with the ingestion name:

https://github.com/guardian/giant/blob/512006051e4fc1e0fca4c545bf61713fd59fa3df/backend/app/services/manifest/Neo4jManifest.scala#L1017-L1036

However, URIs start again when there is an intervening blob, e.g.

1. collection
2. collection/ingestion
3. collection/ingestion/directory
4. collection/ingestion/directory/zipfile
5. zipfile/directory
6. zipfile/directory/file

(See [The Giant File System](https://docs.google.com/document/d/1obN21_zUF0iNKyLO60XGfvBtx2B2zaFxX1C--uhp2bA/edit#) for more information on this.)

This means the `STARTS WITH` from the ingestion won't match numbers 5 and 6 in the above list.

As Michael said at the time:

> - I think it would be possible to use the same STARTS WITH deletion technique using the blob ID as the prefix

It is, but we need to do it at a point where we've got the blob ID. Typically `deleteIngestion` is called after having deleted all the blobs under that ingestion. So we need to delete blob descendants when we're deleting the blob itself. That's what this PR does.

## Example
The highlighted pink directory node is the child of a blob representing a zip file. 
Before this change, when deleting the ingestion (dark blue), we loop through all blobs (light blue) that are descended from it, removing the blobs along with their parents that are files (green). This left nodes like the highlighted directory node orphaned.
After the change, in addition to the above deletions, we remove non-blob descendants of each blob, (e.g. the highlighted node).

<img width="500" alt="giant deletion example" src="https://user-images.githubusercontent.com/17057932/195653909-b772d73d-1d78-4b18-8b86-18ef58964a15.png">


## What about blobs within this blob? Doesn't the URL start again at that point?
Yes it does, and as a result this change will not delete the entire tree underneath a given blob. It only deletes the structure down to the next `:Blob` descendant.

But it is expected that `deleteBlob` will be called either:
  1. from the UI, in which case the operation is disallowed if it has children
  2. as part of deleting an ingestion or collection, in which case those
     orphaned blobs will have been returned from the initial getBlobs ES query
     and will therefore be deleted separately as we loop through them.

## Does this mean that previous deletions have left orphaned file trees in neo4j?
Yes!

Have a look at [this section of the Giant File System doc](https://docs.google.com/document/d/1obN21_zUF0iNKyLO60XGfvBtx2B2zaFxX1C--uhp2bA/edit#heading=h.4zpxwax6d02y) for queries that can find such orphans and counts of the orphaned nodes