### PR TITLE
Delete collection endpoint

### DIFF
--- a/backend/app/controllers/api/Collections.scala
+++ b/backend/app/controllers/api/Collections.scala
@@ -181,15 +181,13 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
     }
   }
 
-  def deleteCollection(collection: String) = ApiAction.attempt { req =>
+  def deleteCollection(collection: Uri) = ApiAction.attempt { req =>
     checkPermission(CanPerformAdminOperations, req) {
-      val uri = Uri(collection)
-
       for {
         // Confirm this thing is actually a collection first,
         // since the delete operation operates on any :Resource
-        _ <- manifest.getCollection(uri)
-        _ <- manifest.deleteResourceAndDescendants(uri)
+        _ <- manifest.getCollection(collection)
+        _ <- manifest.deleteResourceAndDescendants(collection)
       } yield {
         NoContent
       }

--- a/backend/app/controllers/api/Collections.scala
+++ b/backend/app/controllers/api/Collections.scala
@@ -171,8 +171,25 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
       val uri = Uri(collection).chain(ingestion)
 
       for {
+        // Confirm this thing is actually an ingestion first,
+        // since the delete operation operates on any :Resource
         _ <- manifest.getIngestion(uri)
-        _ <- manifest.deleteIngestion(uri)
+        _ <- manifest.deleteResourceAndDescendants(uri)
+      } yield {
+        NoContent
+      }
+    }
+  }
+
+  def deleteCollection(collection: String) = ApiAction.attempt { req =>
+    checkPermission(CanPerformAdminOperations, req) {
+      val uri = Uri(collection)
+
+      for {
+        // Confirm this thing is actually a collection first,
+        // since the delete operation operates on any :Resource
+        _ <- manifest.getCollection(uri)
+        _ <- manifest.deleteResourceAndDescendants(uri)
       } yield {
         NoContent
       }

--- a/backend/app/services/manifest/Manifest.scala
+++ b/backend/app/services/manifest/Manifest.scala
@@ -84,5 +84,5 @@ trait Manifest extends WorkerManifest {
 
   def deleteBlob(uri: Uri): Attempt[Unit]
 
-  def deleteIngestion(uri: Uri): Attempt[Unit]
+  def deleteResourceAndDescendants(uri: Uri): Attempt[Unit]
 }

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -1003,7 +1003,9 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
     count => count == 0 || count == 1,
     "Error deleting blob")
 
-  def deleteIngestion(uri: Uri): Attempt[Unit] = attemptTransaction { tx =>
+  // This will delete descendants down to the next blobs,
+  // at which point the URL pattern starts again.
+  def deleteResourceAndDescendants(uri: Uri): Attempt[Unit] = attemptTransaction { tx =>
     tx.run(
       """
         |MATCH (r: Resource)

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -5,6 +5,7 @@ GET           /api/collections                                              cont
 GET           /api/collections/:collection                                  controllers.api.Collections.getCollection(collection: model.Uri)
 
 POST          /api/collections                                              controllers.api.Collections.newCollection
+DELETE        /api/collections/:collection                                  controllers.api.Collections.deleteCollection(collection: model.Uri)
 POST          /api/collections/:collection                                  controllers.api.Collections.newIngestion(collection: model.Uri)
 POST          /api/collections/:collection/:ingestion                       controllers.api.Collections.uploadIngestionFile(collection, ingestion)
 DELETE        /api/collections/:collection/:ingestion                       controllers.api.Collections.deleteIngestion(collection, ingestion)


### PR DESCRIPTION
The deletion functionality I'm adding to https://github.com/guardian/giant-utils deletes by collection, not ingestion (since that's always what we've done in practice).

For that to work, I need a "delete collection" endpoint to call once all the blobs have been deleted.