### PR TITLE
`inMultiple` flag to get only those blobs that are in multiple collections

### DIFF
--- a/backend/app/services/index/HitReaders.scala
+++ b/backend/app/services/index/HitReaders.scala
@@ -147,7 +147,7 @@ object HitReaders {
     override def read(hit: Hit): Try[IndexedBlob] = try {
       val ingestion = hit.setField[String](IndexFields.ingestion)
       val collection = hit.setField[String](IndexFields.collection)
-      Success(IndexedBlob(uri = hit.id, collection = collection, ingestion = ingestion))
+      Success(IndexedBlob(uri = hit.id, collections = collection, ingestions = ingestion))
     } catch {
       case NonFatal(e) => Failure(e)
     }

--- a/backend/app/services/index/HitReaders.scala
+++ b/backend/app/services/index/HitReaders.scala
@@ -146,7 +146,8 @@ object HitReaders {
   implicit object IndexedBlobHitReader extends HitReader[IndexedBlob] {
     override def read(hit: Hit): Try[IndexedBlob] = try {
       val ingestion = hit.setField[String](IndexFields.ingestion)
-      Success(IndexedBlob(hit.id, ingestion))
+      val collection = hit.setField[String](IndexFields.collection)
+      Success(IndexedBlob(uri = hit.id, collection = collection, ingestion = ingestion))
     } catch {
       case NonFatal(e) => Failure(e)
     }

--- a/backend/app/services/index/Index.scala
+++ b/backend/app/services/index/Index.scala
@@ -28,7 +28,7 @@ trait Index {
 
   def flag(uri: Uri, flagValue: String): Attempt[Unit]
 
-  def getBlobs(collection: String, ingestion: Option[String], size: Int): Attempt[Iterable[IndexedBlob]]
+  def getBlobs(collection: String, ingestion: Option[String], size: Int, inMultiple: Boolean): Attempt[Iterable[IndexedBlob]]
 
   def delete(id: String): Attempt[Unit]
 

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -10,7 +10,7 @@ POST          /api/collections/:collection/:ingestion                       cont
 DELETE        /api/collections/:collection/:ingestion                       controllers.api.Collections.deleteIngestion(collection, ingestion)
 POST          /api/collections/:collection/:ingestion/verifyFiles           controllers.api.Collections.verifyFiles(collection, ingestion)
 
-GET           /api/blobs                                                    controllers.api.Blobs.getBlobs
+GET           /api/blobs                                                    controllers.api.Blobs.getBlobs(collection: Option[String], ingestion: Option[String], inMultiple: Option[Boolean], size: Option[Int])
 POST          /api/blobs/:id/reprocess                                      controllers.api.Blobs.reprocess(id, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])
 DELETE        /api/blobs/:id                                                controllers.api.Blobs.delete(id, checkChildren: Boolean)
 

--- a/cli/src/main/scala/com/gu/pfi/cli/DeleteIngestions.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/DeleteIngestions.scala
@@ -38,7 +38,7 @@ class DeleteIngestions(ingestions: List[(String, String)], ingestionService: Cli
   }
 
   private def deleteBlob(b: IndexedBlob): Attempt[Unit] = {
-    val conflictingIngestions = b.ingestion.filterNot(ingestionUris.contains)
+    val conflictingIngestions = b.ingestions.filterNot(ingestionUris.contains)
 
     if(conflictingIngestions.nonEmpty) {
       conflictBehaviour.getOrElse(Stop) match {
@@ -49,17 +49,17 @@ class DeleteIngestions(ingestions: List[(String, String)], ingestionService: Cli
           )
         case Skip =>
           logger.warn(
-            s"""${b.uri} in [${b.ingestion.mkString(", ")}] is also present in [${conflictingIngestions.mkString(" ")}].
+            s"""${b.uri} in [${b.ingestions.mkString(", ")}] is also present in [${conflictingIngestions.mkString(" ")}].
            Skipping for now.""".stripMargin)
           Attempt.Right(Unit)
         case Delete =>
               logger.warn(
-                s"""${b.uri} in [${b.ingestion.mkString(", ")}] is also present in [${conflictingIngestions.mkString(" ")}].
+                s"""${b.uri} in [${b.ingestions.mkString(", ")}] is also present in [${conflictingIngestions.mkString(" ")}].
                    Deleting it from all locations.""".stripMargin)
               ingestionService.deleteBlob(b.uri)
       }
     } else {
-      logger.info(s"Deleting ${b.uri} from [${b.ingestion.mkString(", ")}]")
+      logger.info(s"Deleting ${b.uri} from [${b.ingestions.mkString(", ")}]")
       ingestionService.deleteBlob(b.uri)
     }
   }

--- a/common/src/main/scala/model/index/IndexedBlob.scala
+++ b/common/src/main/scala/model/index/IndexedBlob.scala
@@ -2,7 +2,7 @@ package model.index
 
 import play.api.libs.json.{Format, Json}
 
-case class IndexedBlob(uri: String, ingestion: Set[String])
+case class IndexedBlob(uri: String, collection: Set[String], ingestion: Set[String])
 object IndexedBlob {
   implicit val format: Format[IndexedBlob] = Json.format[IndexedBlob]
 }

--- a/common/src/main/scala/model/index/IndexedBlob.scala
+++ b/common/src/main/scala/model/index/IndexedBlob.scala
@@ -2,7 +2,7 @@ package model.index
 
 import play.api.libs.json.{Format, Json}
 
-case class IndexedBlob(uri: String, collection: Set[String], ingestion: Set[String])
+case class IndexedBlob(uri: String, collections: Set[String], ingestions: Set[String])
 object IndexedBlob {
   implicit val format: Format[IndexedBlob] = Json.format[IndexedBlob]
 }


### PR DESCRIPTION
## `inMultiple` flag
When fetching blobs, you can now pass `inMultiple=true` to get only blobs that are also in other collections/ingestions than those supplied.

This is useful to do before deleting a collection, so you can check that blobs also exist in other collections are safe to delete.

### For instance
```url
?collection=c&inMultiple=true
```
 returns blobs in collection c and at least one other collection
 
```url
?collection=c&ingestion=i&inMultiple=true
```
returns blobs in ingestion c/i and at least one other ingestion

## Rename `collection` => `collections` and `ingestion` => `ingestions`
Because they're arrays

## Return `collections` property with blobs
Because it's in elasticsearch anyway and it's useful not to have to compute this from the ingestions when consuming the API.

```json
{
  "blobs": [
    {
      "uri": "MVGTRpihjQaCY3Rfn3RJIuXOwseGAPVo3ITre4Svc_oArVwofwBya0cGIJqYF8sdFOzP30Lb3u_4nS-qqVH6cQ",
      "collections": [
        "joe Documents"
      ],
      "ingestions": [
        "joe Documents/Upload 2022-10-12T14:54:20.113Z",
        "joe Documents/Upload 2022-10-12T15:17:03.146Z"
      ]
    }
  ]
}
```