### PR TITLE
In riff-raff.yaml, use ssm for artifact buckets

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -57,16 +57,14 @@ deployments:
   pfi-cli:
     type: aws-s3
     parameters:
-      bucketSsmKey: /pfi-playground/artifact.bucket
-      bucketSsmLookup: true
+      bucket: pfi-playground-dist
       cacheControl: private
       publicReadAcl: false
 
   pfi-public-downloads:
     type: aws-s3
     parameters:
-      bucketSsmKey: /account/services/public.download.bucket
-      bucketSsmLookup: true
+      bucket: investigations-public-dist
       cacheControl: private
       # This is the default but if you specify it explictly Riff-Raff issues a warning
       publicReadAcl: true

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -39,14 +39,16 @@ deployments:
   pfi:
     type: autoscaling
     parameters:
-      bucket: pfi-playground-dist
+      bucketSsmKey: /pfi-playground/artifact.bucket
+      bucketSsmLookup: true
     dependencies:
       - pfi-ami-update
 
   pfi-worker:
     type: autoscaling
     parameters:
-      bucket: pfi-playground-dist
+      bucketSsmKey: /pfi-playground/artifact.bucket
+      bucketSsmLookup: true
     actions:
       - deploy
     dependencies:
@@ -55,14 +57,16 @@ deployments:
   pfi-cli:
     type: aws-s3
     parameters:
-      bucket: pfi-playground-dist
+      bucketSsmKey: /pfi-playground/artifact.bucket
+      bucketSsmLookup: true
       cacheControl: private
       publicReadAcl: false
 
   pfi-public-downloads:
     type: aws-s3
     parameters:
-      bucket: investigations-public-dist
+      bucketSsmKey: /account/services/public.download.bucket
+      bucketSsmLookup: true
       cacheControl: private
       # This is the default but if you specify it explictly Riff-Raff issues a warning
       publicReadAcl: true


### PR DESCRIPTION
## What does this change?
Following the request from DevX (see email 'riff-raff.yaml and bucket names') to stop hard coding the names of our infrastructure buckets (this is also in line with [guardian recommendations](https://github.com/guardian/recommendations/blob/main/github.md#repository-contents)), this pulls the various giant ones into SSM. I've already created all the relevant parameter store parameters.

Note that this doesn't add much benefit for us because we've got two aws-s3 deploy steps which are still hard coding the bucket. I'm going to ask DevX to support SSM lookup for `aws-s3` deploys as well