### PR TITLE
Add count blobs endpoint

### DIFF
--- a/backend/app/controllers/api/Blobs.scala
+++ b/backend/app/controllers/api/Blobs.scala
@@ -41,6 +41,20 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
     }
   }
 
+  def countBlobs(collection: Option[String], ingestion: Option[String], inMultiple: Option[Boolean]) = ApiAction.attempt { req =>
+    checkPermission(CanPerformAdminOperations, req) {
+      (collection, ingestion, inMultiple) match {
+        case (Some(collection), maybeIngestion, maybeInMultiple) =>
+          index.countBlobs(collection, maybeIngestion, maybeInMultiple.getOrElse(false)).map(count =>
+            Ok(Json.obj("count" -> count))
+          )
+
+        case _ =>
+          Attempt.Right(BadRequest("Missing collection query parameter"))
+      }
+    }
+  }
+
   def reprocess(id: String, rerunSuccessfulParam: Option[Boolean], rerunFailedParam: Option[Boolean]) = ApiAction.attempt { req =>
     checkPermission(CanPerformAdminOperations, req) {
       val uri = Uri(id)

--- a/backend/app/services/index/Index.scala
+++ b/backend/app/services/index/Index.scala
@@ -30,6 +30,8 @@ trait Index {
 
   def getBlobs(collection: String, ingestion: Option[String], size: Int, inMultiple: Boolean): Attempt[Iterable[IndexedBlob]]
 
+  def countBlobs(collection: String, ingestion: Option[String], inMultiple: Boolean): Attempt[Long]
+
   def delete(id: String): Attempt[Unit]
 
   def anyWorkspaceOrCollectionContainsAnyResource(collectionUris: Set[String], workspaceIds: Set[String], resourceUris: Set[String]): Attempt[Boolean]

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -12,6 +12,7 @@ DELETE        /api/collections/:collection/:ingestion                       cont
 POST          /api/collections/:collection/:ingestion/verifyFiles           controllers.api.Collections.verifyFiles(collection, ingestion)
 
 GET           /api/blobs                                                    controllers.api.Blobs.getBlobs(collection: Option[String], ingestion: Option[String], inMultiple: Option[Boolean], size: Option[Int])
+GET           /api/blobs/count                                              controllers.api.Blobs.countBlobs(collection: Option[String], ingestion: Option[String], inMultiple: Option[Boolean])
 POST          /api/blobs/:id/reprocess                                      controllers.api.Blobs.reprocess(id, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])
 DELETE        /api/blobs/:id                                                controllers.api.Blobs.delete(id, checkChildren: Boolean)
 


### PR DESCRIPTION
Currently the `getBlobs` endpoint can only return up to 500 blobs due to limitations of the elasticsearch search API. We could page through to get more, though it's not really suitable for returning hundreds of thousands of results (there is an inbuilt limit of [10,000](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/paginate-search-results.html))

For that reason, it would be useful to have an endpoint for counting the number of blobs, so we can tell the user at the start of a deletion how much work there is to do, and track progress through it.