### PR TITLE
Batch S3 deletion requests

### DIFF
--- a/backend/app/commands/DeleteResource.scala
+++ b/backend/app/commands/DeleteResource.scala
@@ -47,10 +47,9 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
        val prefixesToDelete = legacyPagePreviewPrefixes ::: pagePreviewPrefixes
         logger.info(s"Deleting prefixes: ${prefixesToDelete.mkString(", ")}")
 
-       val listOfPagePreviewObjectsAttempts = prefixesToDelete.map { prefix =>
+       Attempt.traverse(prefixesToDelete) { prefix =>
          Attempt.fromEither(previewStorage.list(prefix))
-       }
-       Attempt.sequence(listOfPagePreviewObjectsAttempts).map(_.flatten.toSet)
+       }.map(_.flatten.toSet)
      }
 
      private def deleteResource(uri: Uri): Attempt[Unit] = timeAsync("Total to delete resource", {

--- a/backend/app/commands/DeleteResource.scala
+++ b/backend/app/commands/DeleteResource.scala
@@ -16,12 +16,18 @@ import scala.concurrent.ExecutionContext
 class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectStorage, objectStorage: ObjectStorage)  (implicit ec: ExecutionContext)
    extends Timing {
 
-     private def deletePagePreviewObjects(s3Objects: Set[String]): Attempt[Iterator[Unit]] = {
-       logger.info(s"Deleting ${s3Objects.size} objects")
-       Attempt.traverse(s3Objects.grouped(500))(x => Attempt.fromEither(previewStorage.deleteMultiple(x)))
+     private def deleteFromS3Preview(blobUri: Uri, pagePreviewKeys: Set[String]): Attempt[Iterator[Unit]] = {
+       // The full-document preview, as well as all the previews of individual pages
+       val keys = pagePreviewKeys + blobUri.toStoragePath
+       logger.info(s"Deleting ${keys.size} objects from preview storage")
+
+       // Group, just in case we have thousands of pages
+       Attempt.traverse(keys.grouped(500)) { batchOfS3Keys =>
+         Attempt.fromEither(previewStorage.deleteMultiple(batchOfS3Keys))
+       }
      }
 
-     private def deletePagePreviews(uri: Uri, ocrLanguages: List[Language]): Attempt[_] = {
+     private def getPagePreviewS3Keys(uri: Uri, ocrLanguages: List[Language]): Attempt[Set[String]] = {
        if (ocrLanguages.isEmpty) {
          // This typically means the blob was not processed by the OcrMyPdfExtractor,
          // either because it's not a PDF or because it was processed before
@@ -42,9 +48,7 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
        val listOfPagePreviewObjectsAttempts = prefixesToDelete.map { prefix =>
          Attempt.fromEither(previewStorage.list(prefix))
        }
-       val pagePreviewObjectsAttempt = Attempt.sequence(listOfPagePreviewObjectsAttempts).map(_.flatten.toSet)
-
-       pagePreviewObjectsAttempt.flatMap(deletePagePreviewObjects)
+       Attempt.sequence(listOfPagePreviewObjectsAttempts).map(_.flatten.toSet)
      }
 
      private def deleteResource(uri: Uri): Attempt[Unit] = timeAsync("Total to delete resource", {
@@ -53,9 +57,9 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
          // For blobs not processed by the OcrMyPdfExtractor, ocrLanguages will be an empty list
          ocrLanguages <- timeAsync("Getting langs from neo4j", manifest.getLanguagesProcessedByOcrMyPdf(uri))
          // Not everything has a preview but S3 returns success for deleting an object that doesn't exist so we're fine
-         _ <- timeAsync("Delete page previews", deletePagePreviews(uri, ocrLanguages))
-         _ <- Attempt.fromEither(timeSync("Preview S3 delete", previewStorage.delete(uri.toStoragePath)))
-         _ <- Attempt.fromEither(timeSync("Ingest S3 delete", objectStorage.delete(uri.toStoragePath)))
+         pagePreviewS3Keys <- timeAsync("Get page preview S3 keys", getPagePreviewS3Keys(uri, ocrLanguages))
+         _ <- timeAsync("Preview storage S3 delete", deleteFromS3Preview(uri, pagePreviewS3Keys))
+         _ <- Attempt.fromEither(timeSync("Ingest storage S3 delete", objectStorage.delete(uri.toStoragePath)))
          _ <- timeAsync("Delete blob from neo4j", manifest.deleteBlob(uri))
          // We use the index to determine what blobs are in a collection.
          // So we should delete from the index last, so that if any of the above

--- a/backend/app/commands/DeleteResource.scala
+++ b/backend/app/commands/DeleteResource.scala
@@ -21,7 +21,9 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
        val keys = pagePreviewKeys + blobUri.toStoragePath
        logger.info(s"Deleting ${keys.size} objects from preview storage")
 
-       // Group, just in case we have thousands of pages
+       // Group, just in case we have thousands of pages.
+       // 1000 objects is the limit for a batch:
+       // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
        Attempt.traverse(keys.grouped(500)) { batchOfS3Keys =>
          Attempt.fromEither(previewStorage.deleteMultiple(batchOfS3Keys))
        }

--- a/backend/app/services/ObjectStorage.scala
+++ b/backend/app/services/ObjectStorage.scala
@@ -16,6 +16,7 @@ trait ObjectStorage {
   def get(key: String): Either[Failure, InputStream]
   def getMetadata(key: String): Either[Failure, ObjectMetadata]
   def delete(key: String): Either[Failure, Unit]
+  def deleteMultiple(key: Set[String]): Either[Failure, Unit]
   def list(prefix: String): Either[Failure, List[String]]
 }
 
@@ -38,8 +39,8 @@ class S3ObjectStorage private(client: S3Client, bucket: String) extends ObjectSt
     run(client.aws.deleteObject(bucket, key))
   }
 
-  def delete(keys: List[String]): Either[Failure, Unit] = {
-    val request = new DeleteObjectsRequest(bucket).withKeys(keys: _*)
+  def deleteMultiple(keys: Set[String]): Either[Failure, Unit] = {
+    val request = new DeleteObjectsRequest(bucket).withKeys(keys.toSeq: _*)
     run(client.aws.deleteObjects(request))
   }
 

--- a/backend/test/extraction/WorkerTest.scala
+++ b/backend/test/extraction/WorkerTest.scala
@@ -87,6 +87,7 @@ class WorkerTest extends AnyFlatSpec with Matchers with EitherValues {
       override def getMetadata(key: String): Either[Failure, ObjectMetadata] = ???
       override def create(key: String, path: Path, mimeType: Option[String]): Either[Failure, Unit] = ???
       override def delete(key: String): Either[Failure, Unit] = ???
+      override def deleteMultiple(key: Set[String]): Either[Failure, Unit] = ???
       override def list(prefix: String): Either[Failure, List[String]] = ???
     }
 

--- a/backend/test/test/TestObjectStorage.scala
+++ b/backend/test/test/TestObjectStorage.scala
@@ -12,5 +12,6 @@ class TestObjectStorage extends ObjectStorage {
   override def get(key: String): Either[Failure, InputStream] = Left(UnsupportedOperationFailure(""))
   override def getMetadata(key: String): Either[Failure, ObjectMetadata] = Left(UnsupportedOperationFailure(""))
   override def delete(key: String): Either[Failure, Unit] = Left(UnsupportedOperationFailure(""))
+  override def deleteMultiple(key: Set[String]): Either[Failure, Unit] = Left(UnsupportedOperationFailure(""))
   override def list(prefix: String): Either[Failure, List[String]] = Left(UnsupportedOperationFailure(""))
 }


### PR DESCRIPTION
After an excellent pairing session with @rtyley, we realised that we could get some performance gains by sending multiple keys to delete in a single S3 call, rather than making multiple calls.

This means we make at most two delete requests to S3: one to delete everything from the preview bucket (page previews and the whole-document preview), and one the delete the blob from the ingest bucket.

The biggest gains would be in documents with many pages since before we were making at least one call per page, e.g. 324 requests become 2 requests.

But even for a document with one page, we still reduce the S3 requests from 3 to 2.

# local perf stats
## before (for 322 page "Functional Programming in Scala" book)
**900ms**
```
Delete page previews: took 0 minutes 0 seconds 780 milliseconds
Preview S3 delete: took 0 minutes 0 seconds 5 milliseconds
Ingest S3 delete: took 0 minutes 0 seconds 5 milliseconds
Delete blob from neo4j: took 0 minutes 0 seconds 59 milliseconds
Delete blob from elasticsearch: took 0 minutes 0 seconds 18 milliseconds
Total to delete resource: took 0 minutes 0 seconds 900 milliseconds
```

## after
**145ms**
```
Get page preview S3 keys: took 0 minutes 0 seconds 54 milliseconds
Deleting 323 objects from preview storage
Preview storage S3 delete: took 0 minutes 0 seconds 61 milliseconds
Ingest storage S3 delete: took 0 minutes 0 seconds 4 milliseconds
Delete blob from neo4j: took 0 minutes 0 seconds 12 milliseconds
Delete blob from elasticsearch: took 0 minutes 0 seconds 5 milliseconds
Total to delete resource: took 0 minutes 0 seconds 145 milliseconds
```

# prod perf stats
## before
Note: these may be distorted by certain subsets of the documents in the collection I'm deleting having different properties. I've seen periods in which deletions went much quicker, presumably because it had a run of documents that had no page previews. I don't understand the order in which documents come back from the elasticsearch so don't know how much this clustering will tend to occur.

Averaged [500 deletions](http://localhost:5601/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2022-10-25T07:36:58.871Z',to:'2022-10-25T09:36:27.579Z'))&_a=(columns:!(message),filters:!(),index:d2720940-0e30-11eb-a809-5706b391daea,interval:auto,query:(language:kuery,query:'%22Total%20to%20delete%20resource%22'),sort:!())): 263 ms total