### PR TITLE
Bump tika-parsers to 1.25 in an attempt to fix snyk vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ lazy val backend = (project in file("backend"))
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the
       // conf/org/apache/tika/mimecustom-mimetypes.xml file
-      "org.apache.tika" % "tika-parsers" % "1.22" exclude("javax.ws.rs", "javax.ws.rs-api"),
+      "org.apache.tika" % "tika-parsers" % "1.28.5" exclude("javax.ws.rs", "javax.ws.rs-api"),
       // Daft workaround due to https://github.com/sbt/sbt/issues/3618#issuecomment-454528463
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.5",
       "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ lazy val backend = (project in file("backend"))
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the
       // conf/org/apache/tika/mimecustom-mimetypes.xml file
-      "org.apache.tika" % "tika-parsers" % "1.28.5" exclude("javax.ws.rs", "javax.ws.rs-api"),
+      "org.apache.tika" % "tika-parsers" % "1.25" exclude("javax.ws.rs", "javax.ws.rs-api"),
       // Daft workaround due to https://github.com/sbt/sbt/issues/3618#issuecomment-454528463
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.5",
       "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,


### PR DESCRIPTION
## What does this change?
Snyk is reporting two critical vulnerabilities in Giant related to tika-parser - see https://app.snyk.io/org/guardian-investigations/project/a40df7ee-382f-42d9-b182-53f7f515cca4

I'm not certain that this will resolve them but it's the highest version of tika-parser we can move to without hitting a jackson-databind dependency clash as later versions of apache-tika increase the version of the jackson-core library above 2.12.0 - which clashes with other dependencies (I didn't look into this too deeply - the error was `An exception or error caused a run to abort: Scala module 2.11.2 requires Jackson Databind version >= 2.11.0 and < 2.12.0 ` and you can see that version [1.26](https://mvnrepository.com/artifact/org.apache.tika/tika-parsers/1.26) of tika-parsers introduces a version about 2.12.0). This is fixable, but I'm hoping this lazier option will do the job. 

I've tested this on playground - I did a search and uploaded two different documents via the UI