### PR TITLE
Count Mailbox messages

### DIFF
--- a/backend/app/extraction/email/mbox/MBoxEmailDetector.scala
+++ b/backend/app/extraction/email/mbox/MBoxEmailDetector.scala
@@ -19,11 +19,9 @@ object MBoxEmailDetector extends CustomTikaDetector {
       val mbox = JavaMail.openStore(url)
 
       try {
-        // If it's got more than one messages, lets call it an mbox!
-        // Yes they are 1-indexed.
-        val mensajes = mbox.getMessages(1, 2)
+        val messageCount = mbox.getMessageCount()
 
-        if(mensajes.length == 2) {
+        if(messageCount >= 2) {
           Some(MediaType.parse(MBOX_MIME_TYPE))
         } else {
           None


### PR DESCRIPTION
## What does this change?

Changes the way we check the number of messages in a mailbox.
Using  `getMessages` specifying a start and end index occasionally throws exceptions.
Using `getMessageCount` is a more specific way of determining the number of messages in the mailbox.