### PR TITLE
Add explicit bouncycastle util library dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,7 @@ lazy val backend = (project in file("backend"))
       ws,
       "commons-codec" % "commons-codec" % "1.11",
       "org.bouncycastle" % "bcprov-jdk15on" % "1.70",
+      "org.bouncycastle" % "bcutil-jdk15on" % "1.70",
       "commons-io" % "commons-io" % "2.6",
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.9.1",
       "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "7.9.2",

--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ lazy val backend = (project in file("backend"))
     libraryDependencies ++= Seq(
       ws,
       "commons-codec" % "commons-codec" % "1.11",
-      "org.bouncycastle" % "bcprov-jdk15on" % "1.60",
+      "org.bouncycastle" % "bcprov-jdk15on" % "1.70",
       "commons-io" % "commons-io" % "2.6",
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.9.1",
       "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "7.9.2",

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,9 @@ lazy val backend = (project in file("backend"))
       ws,
       "commons-codec" % "commons-codec" % "1.11",
       "org.bouncycastle" % "bcprov-jdk15on" % "1.70",
+      // required by tikka, used to be part of bcprov-jdk15on, pulled out into a separate library from 1.69 onwards
+      // see https://github.com/guardian/giant/pull/92 for details - may be removable if it gets added as an explicit
+      // dependency to tikka or another library
       "org.bouncycastle" % "bcutil-jdk15on" % "1.70",
       "commons-io" % "commons-io" % "2.6",
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.9.1",


### PR DESCRIPTION
## What does this change?
During a recent ingest we noticed giant workers failing with the error `Uncaught error from thread [pfi-work-context-28]: org/bouncycastle/asn1/bsi/BSIObjectIdentifiers, shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[pfi]` - with the specific error being `java.lang.NoClassDefFoundError: org/bouncycastle/asn1/bsi/BSIObjectIdentifiers`

My initial attempt to fix this was to just bump the version of bouncycastle up to the latest (1.70) as I'd spotted in the dependency tree that older versions of the  bouncycastle library were being evicted by version 1.69. This didn't solve the problem, but I've left in the change.

What I think the actual issue was is that the class in question - BSIObjectIdentifiers - has been pulled out into a [separate bcutil library](https://mvnrepository.com/artifact/org.bouncycastle/bcutil-jdk15on) - see [here](https://www.bouncycastle.org/latest_releases.html) for the changelog.

Adding this library fixed the errors - I think it's likely it will be added explicity as a dependency to apache tikka at some point (or might be already - though I couldn't find evidence of this). 

Full stack trace for posterity:
```
java.lang.NoClassDefFoundError: org/bouncycastle/asn1/bsi/BSIObjectIdentifiers
	at org.bouncycastle.operator.jcajce.OperatorHelper.<clinit>(Unknown Source)
	at org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder.<init>(Unknown Source)
	at org.apache.tika.parser.crypto.Pkcs7Parser.parse(Pkcs7Parser.java:66)
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280)
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280)
	at org.apache.tika.parser.AutoDetectParser.parse(AutoDetectParser.java:143)
	at org.apache.tika.parser.DelegatingParser.parse(DelegatingParser.java:72)
	at org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor.parseEmbedded(ParsingEmbeddedDocumentExtractor.java:104)
	at org.apache.tika.parser.pkg.PackageParser.parseEntry(PackageParser.java:426)
	at org.apache.tika.parser.pkg.PackageParser.parseEntries(PackageParser.java:355)
	at org.apache.tika.parser.pkg.PackageParser.parse(PackageParser.java:305)
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280)
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280)
	at org.apache.tika.parser.AutoDetectParser.parse(AutoDetectParser.java:143)
	at org.apache.tika.parser.DelegatingParser.parse(DelegatingParser.java:72)
	at org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor.parseEmbedded(ParsingEmbeddedDocumentExtractor.java:104)
	at org.apache.tika.parser.pkg.PackageParser.parseEntry(PackageParser.java:426)
	at org.apache.tika.parser.pkg.PackageParser.parseEntries(PackageParser.java:355)
	at org.apache.tika.parser.pkg.PackageParser.parse(PackageParser.java:305)
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280)
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280)
	at org.apache.tika.parser.AutoDetectParser.parse(AutoDetectParser.java:143)
	at org.apache.tika.parser.DelegatingParser.parse(DelegatingParser.java:72)
	at org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor.parseEmbedded(ParsingEmbeddedDocumentExtractor.java:104)
	at org.apache.tika.parser.microsoft.ooxml.AbstractOOXMLExtractor.handleEmbeddedOLE(AbstractOOXMLExtractor.java:348)
	at org.apache.tika.parser.microsoft.ooxml.AbstractOOXMLExtractor.handleEmbeddedPart(AbstractOOXMLExtractor.java:256)
	at org.apache.tika.parser.microsoft.ooxml.AbstractOOXMLExtractor.handleEmbeddedParts(AbstractOOXMLExtractor.java:208)
	at org.apache.tika.parser.microsoft.ooxml.AbstractOOXMLExtractor.getXHTML(AbstractOOXMLExtractor.java:139)
	at org.apache.tika.parser.microsoft.ooxml.XSSFExcelExtractorDecorator.getXHTML(XSSFExcelExtractorDecorator.java:126)
	at org.apache.tika.parser.microsoft.ooxml.OOXMLExtractorFactory.parse(OOXMLExtractorFactory.java:210)
	at org.apache.tika.parser.microsoft.ooxml.OOXMLParser.parse(OOXMLParser.java:113)
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280)
	at org.apache.tika.parser.CompositeParser.parse(CompositeParser.java:280)
	at org.apache.tika.parser.AutoDetectParser.parse(AutoDetectParser.java:143)
	at services.Tika.$anonfun$parse$1(Tika.scala:60)
	at cats.syntax.EitherObjectOps$.catchNonFatal$extension(either.scala:370)
	at services.Tika.parse(Tika.scala:59)
	at extraction.DocumentBodyExtractor.extract(DocumentBodyExtractor.scala:51)
	at extraction.Worker.safeInvokeExtractor(Worker.scala:102)
	at extraction.Worker.$anonfun$executeBatch$2(Worker.scala:75)
	at scala.util.Either.flatMap(Either.scala:352)
	at extraction.Worker.$anonfun$executeBatch$1(Worker.scala:75)
	at extraction.Worker.$anonfun$executeBatch$1$adapted(Worker.scala:71)
	at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
	at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
	at scala.collection.immutable.List.foldLeft(List.scala:79)
	at extraction.Worker.executeBatch(Worker.scala:71)
	at extraction.Worker.$anonfun$pollAndExecute$1(Worker.scala:33)
	at extraction.Worker.$anonfun$pollAndExecute$1$adapted(Worker.scala:32)
	at utils.attempt.Attempt.$anonfun$map$1(Attempt.scala:20)
	at utils.attempt.Attempt.$anonfun$flatMap$1(Attempt.scala:24)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:470)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:48)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.lang.ClassNotFoundException: org.bouncycastle.asn1.bsi.BSIObjectIdentifiers
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 59 common frames omitted
```