### PR TITLE
Bump apache tika from 1.25 to 1.28.5

### DIFF
--- a/backend/app/extraction/tables/CsvTableExtractor.scala
+++ b/backend/app/extraction/tables/CsvTableExtractor.scala
@@ -26,7 +26,7 @@ class CsvTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: Ex
 
   override def priority: Int = 5
 
-  private val format = CSVFormat.RFC4180.withHeader()
+  private val format = CSVFormat.RFC4180.builder().setHeader().build()
 
   override def extract(blob: Blob, file: File, params: ExtractionParams): Either[Failure, Unit] = {
     // TODO assume charset?? BAD???

--- a/backend/app/utils/HtmlToPlainText.scala
+++ b/backend/app/utils/HtmlToPlainText.scala
@@ -1,7 +1,7 @@
 package utils
 
 import org.jsoup.Jsoup
-import org.jsoup.internal.StringUtil
+import org.jsoup.helper.StringUtil
 import org.jsoup.nodes.{Element, Node, TextNode}
 import org.jsoup.select.NodeFilter.FilterResult
 import org.jsoup.select.{NodeFilter, NodeTraversor}

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,7 @@ lazy val backend = (project in file("backend"))
       "commons-io" % "commons-io" % "2.6",
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.9.1",
       "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "7.9.2",
-      "com.typesafe.akka" %% "akka-cluster-typed" % "2.6.5", // should match what we get transitively from Play
+      "com.typesafe.akka" %% "akka-cluster-typed" % "2.6.20", // should match what we get transitively from Play
       "org.neo4j.driver" % "neo4j-java-driver" % "1.6.3",
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ lazy val backend = (project in file("backend"))
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the
       // conf/org/apache/tika/mimecustom-mimetypes.xml file
-      "org.apache.tika" % "tika-parsers" % "1.25" exclude("javax.ws.rs", "javax.ws.rs-api"),
+      "org.apache.tika" % "tika-parsers" % "1.28.5" exclude("javax.ws.rs", "javax.ws.rs-api"),
       // Daft workaround due to https://github.com/sbt/sbt/issues/3618#issuecomment-454528463
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.5",
       "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 


### PR DESCRIPTION
## What does this change?
Another dependency upgrade, this time with a few associated code changes to deal with moved imports/deprecated methods. 

## How to test
Tika is used for ingests so needs to be tested on playground with some kind of ingest job.