### PR TITLE
Move elasticsearch onto arm64 AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -32,7 +32,7 @@ deployments:
     parameters:
       amiEncrypted: true
       amiTags:
-        Recipe: investigations-elasticsearch-7
+        Recipe: investigations-elasticsearch-7-arm64
         AmigoStage: PROD
         Encrypted: pfi-playground
 


### PR DESCRIPTION
Following from https://github.com/guardian/investigations-platform/pull/436 this is the change to tell Giant to use an ARM64 AMI baked in amigo (https://amigo.gutools.co.uk/recipes/investigations-elasticsearch-7-arm64) for elasticsearch