### PR TITLE
Fix Apache Tikka vulnerability

### DIFF
--- a/backend/app/extraction/tables/CsvTableExtractor.scala
+++ b/backend/app/extraction/tables/CsvTableExtractor.scala
@@ -26,7 +26,7 @@ class CsvTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: Ex
 
   override def priority: Int = 5
 
-  private val format = CSVFormat.RFC4180.withHeader()
+  private val format = CSVFormat.RFC4180.builder().setHeader().build()
 
   override def extract(blob: Blob, file: File, params: ExtractionParams): Either[Failure, Unit] = {
     // TODO assume charset?? BAD???

--- a/backend/app/utils/HtmlToPlainText.scala
+++ b/backend/app/utils/HtmlToPlainText.scala
@@ -1,7 +1,7 @@
 package utils
 
 import org.jsoup.Jsoup
-import org.jsoup.internal.StringUtil
+import org.jsoup.helper.StringUtil
 import org.jsoup.nodes.{Element, Node, TextNode}
 import org.jsoup.select.NodeFilter.FilterResult
 import org.jsoup.select.{NodeFilter, NodeTraversor}

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val compilerFlags = Seq(
   "-Xfatal-warnings"
 )
 
-val awsVersion = "1.11.566"
+val awsVersion = "1.12.428"
 val log4jVersion = "2.17.0"
 // To match what the main app gets from scalatestplus-play transitively
 val scalatestVersion = "3.1.1"
@@ -82,7 +82,7 @@ lazy val common = (project in file("common"))
     scalacOptions := compilerFlags,
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.2.0",
-      "com.typesafe.play" %% "play-json" % "2.9.0",
+      "com.typesafe.play" %% "play-json" % "2.9.4",
       "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
       "org.slf4j" % "slf4j-api" % "1.7.25",
       "org.scalatest" %% "scalatest" % scalatestVersion
@@ -111,29 +111,34 @@ lazy val backend = (project in file("backend"))
       "commons-io" % "commons-io" % "2.6",
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.9.1",
       "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "7.9.2",
-      "com.typesafe.akka" %% "akka-cluster-typed" % "2.6.5", // should match what we get transitively from Play
+      "com.typesafe.akka" %% "akka-cluster-typed" % "2.6.20", // should match what we get transitively from Play
       "org.neo4j.driver" % "neo4j-java-driver" % "1.6.3",
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the
       // conf/org/apache/tika/mimecustom-mimetypes.xml file
-      "org.apache.tika" % "tika-parsers" % "1.25" exclude("javax.ws.rs", "javax.ws.rs-api"),
+      "org.apache.tika" % "tika-parsers" % "1.28.5" exclude("javax.ws.rs", "javax.ws.rs-api"),
       // Daft workaround due to https://github.com/sbt/sbt/issues/3618#issuecomment-454528463
       "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.5",
       "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
       "net.logstash.logback" % "logstash-logback-encoder" % "6.3",
-      "com.pauldijou" %% "jwt-play" % "4.3.0",
+      "com.pauldijou" %% "jwt-play" % "5.0.0",
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ssm" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatchmetrics" % awsVersion,
-      "com.beachape" %% "enumeratum-play" % "1.6.1",
+      "com.beachape" %% "enumeratum-play" % "1.7.2",
       "com.iheart" %% "ficus" % "1.5.2",
       "com.sun.mail" % "javax.mail" % "1.6.2",
       "org.jsoup" % "jsoup" % "1.11.3",
       "com.gu" %% "pan-domain-auth-verification" % "1.2.0",
+
+      // this is needed to override the 2.11.4 version of jackson-module used in various play libraries (including jwt-play)
+      // as 2.11.4 is only compatible with versions of jackson databind up to 2.12.0 - and we're using 2.12.7 (Phil thinks
+      // because of the version of tikka-parsers we're using)
+      "com.fasterxml.jackson.module" % "jackson-module-scala_2.13" % "2.14.2",
 
       // Libraries whose use are potentially contentious
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 


### PR DESCRIPTION
## What does this change?

This PR started of as an effort to fix https://security.snyk.io/vuln/SNYK-JAVA-ORGJDOM-1309669 by simply bumping apache-tikka-parsers. All the code changes in this PR are related to that single version bump of apache-tikka-parsers from 1.25 to 1.28.5

Changing this dependency brought in a more recent version of jackson databind, which was incompatible with the version of com.fasterxml.jackson.module that other dependencies in the project brought in, leading to the error below, so I ended up bumping a load of other play and akka related libraries and, when that didn't appear to break everything, leaving those changes in. The actual fix for the error was to override the version of com.fasterxml.jackson.module we are using (see comment in build.sbt)

## How to test
Tested on playground - I ingested 50 PDFs via the UI and checked that search was still working
