### PR TITLE
Do not fetch pages outside the total length of the doc

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "giant-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@data-ui/histogram": "0.0.62",
+        "@data-ui/histogram": "0.0.84",
         "@elastic/datemath": "^5.0.3",
         "@elastic/eui": "^27.1.0",
         "@types/pdfjs-dist": "^2.1.6",
@@ -4231,24 +4231,23 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@data-ui/histogram": {
-      "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/@data-ui/histogram/-/histogram-0.0.62.tgz",
-      "integrity": "sha512-ACu5WRA38YruBYf0pMIRcmPeCl7LIaLe1GpkC0qu9JIanjWhVLwiN3Uv9hofcQ3pVXSmwOkNszdhzoFmTFUg6Q==",
+      "version": "0.0.84",
+      "resolved": "https://registry.npmjs.org/@data-ui/histogram/-/histogram-0.0.84.tgz",
+      "integrity": "sha512-JuAUd3cgbDvXd1PKddB3L3SvZj5VFXTLG9za0RlqgbEsddR2dgUfJJQ5GacJ7a3o/SpmJ0zRGJVXb5VZozjj2Q==",
       "dependencies": {
-        "@data-ui/shared": "^0.0.62",
-        "@data-ui/theme": "^0.0.62",
-        "@vx/axis": "0.0.140",
-        "@vx/curve": "0.0.140",
-        "@vx/event": "0.0.140",
-        "@vx/glyph": "0.0.140",
-        "@vx/gradient": "0.0.140",
-        "@vx/group": "0.0.140",
-        "@vx/pattern": "0.0.140",
-        "@vx/responsive": "0.0.147",
-        "@vx/scale": "0.0.140",
-        "@vx/shape": "0.0.140",
-        "@vx/tooltip": "0.0.140",
-        "babel-runtime": "^6.26.0",
+        "@data-ui/shared": "^0.0.84",
+        "@data-ui/theme": "^0.0.84",
+        "@vx/axis": "^0.0.179",
+        "@vx/curve": "^0.0.165",
+        "@vx/event": "^0.0.179",
+        "@vx/glyph": "^0.0.179",
+        "@vx/gradient": "^0.0.165",
+        "@vx/group": "^0.0.170",
+        "@vx/pattern": "^0.0.179",
+        "@vx/responsive": "^0.0.192",
+        "@vx/scale": "^0.0.179",
+        "@vx/shape": "^0.0.179",
+        "@vx/tooltip": "0.0.179",
         "d3-array": "^1.2.0",
         "d3-scale": "^1.0.6",
         "prop-types": "^15.5.10",
@@ -4260,30 +4259,21 @@
       }
     },
     "node_modules/@data-ui/shared": {
-      "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/@data-ui/shared/-/shared-0.0.62.tgz",
-      "integrity": "sha512-JUV+Y7BhqyKpAhQYdFOTnWVBOM6F2ejtQ2Ntu5X92Q/fWEarrPWtl2HzCwjvkVeWf1svsp5oOJqZ5uAnjHEpow==",
+      "version": "0.0.84",
+      "resolved": "https://registry.npmjs.org/@data-ui/shared/-/shared-0.0.84.tgz",
+      "integrity": "sha512-MsDLsFzBHFEREr/eF2/RX1o/cXioEg+VQTsM8gViW5ywGQ7Xo5+EqUOaBSrwqKAkvp3e8PaEZVkchPC54IBhrA==",
       "dependencies": {
-        "@data-ui/theme": "^0.0.62",
+        "@data-ui/theme": "^0.0.84",
         "@vx/event": "^0.0.165",
         "@vx/group": "^0.0.165",
         "@vx/shape": "^0.0.168",
         "@vx/tooltip": "0.0.165",
-        "babel-runtime": "^6.26.0",
         "d3-array": "^1.2.1",
         "prop-types": "^15.5.10"
       },
       "peerDependencies": {
         "react": "^15.0.0-0 || ^16.0.0-0",
         "react-dom": "^15.0.0-0 || ^16.0.0-0"
-      }
-    },
-    "node_modules/@data-ui/shared/node_modules/@vx/curve": {
-      "version": "0.0.165",
-      "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.165.tgz",
-      "integrity": "sha512-fiQAGrKNGjJbL+eixUckJqIZDWXH/1NtIyyDbSz3J7ksk0QpYr5BgWcNJN76HLNt7wfcLwNzCHeNs4iVYyFGTg==",
-      "dependencies": {
-        "d3-shape": "^1.0.6"
       }
     },
     "node_modules/@data-ui/shared/node_modules/@vx/event": {
@@ -4336,12 +4326,9 @@
       }
     },
     "node_modules/@data-ui/theme": {
-      "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/@data-ui/theme/-/theme-0.0.62.tgz",
-      "integrity": "sha512-7L+sFc5q86vH6Mu0oTBOdNh7gX5XvcNz3XMlUCFufiRSvPYxcMqWkkHNWSeBWuo64V2NSqcWVw23W4BTArtOZw==",
-      "dependencies": {
-        "babel-runtime": "^6.26.0"
-      }
+      "version": "0.0.84",
+      "resolved": "https://registry.npmjs.org/@data-ui/theme/-/theme-0.0.84.tgz",
+      "integrity": "sha512-jIoHftC/5c/LVJYF4VSBjjVjrjc0yj4mLkGe8p0eVO7qUYKVvlWx7PrpM7ucyefvuAaKIwlr+Nh2xPGPdADjaA=="
     },
     "node_modules/@elastic/datemath": {
       "version": "5.0.3",
@@ -5793,32 +5780,19 @@
       }
     },
     "node_modules/@vx/axis": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/axis/-/axis-0.0.140.tgz",
-      "integrity": "sha1-qtVXwoHGzCHBUWl3MBVSxwUuUiQ=",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@vx/axis/-/axis-0.0.179.tgz",
+      "integrity": "sha512-FtUcdJxejYn5jgixSgSk9AdA96VwP9sCRATVfGvugEL0gtTKWYDbJEgSgqXfKqpeUdsDdf/JT7NVbLMc1hzrZg==",
       "dependencies": {
-        "@vx/group": "0.0.140",
-        "@vx/point": "0.0.136",
-        "@vx/shape": "0.0.140",
+        "@vx/group": "0.0.170",
+        "@vx/point": "0.0.165",
+        "@vx/shape": "0.0.179",
+        "@vx/text": "0.0.179",
         "classnames": "^2.2.5",
-        "prop-types": "15.5.10"
+        "prop-types": "^15.6.0"
       },
       "peerDependencies": {
         "react": "^15.0.0-0 || ^16.0.0-0"
-      }
-    },
-    "node_modules/@vx/axis/node_modules/@vx/point": {
-      "version": "0.0.136",
-      "resolved": "https://registry.npmjs.org/@vx/point/-/point-0.0.136.tgz",
-      "integrity": "sha1-k7MltLlcnVuW33QPQgQBf1c5ZVk="
-    },
-    "node_modules/@vx/axis/node_modules/prop-types": {
-      "version": "15.5.10",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
-      "dependencies": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1"
       }
     },
     "node_modules/@vx/bounds": {
@@ -5834,43 +5808,39 @@
       }
     },
     "node_modules/@vx/curve": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.140.tgz",
-      "integrity": "sha1-Ke84jos3GCE9ZqiW1WncHryO34k=",
+      "version": "0.0.165",
+      "resolved": "https://registry.npmjs.org/@vx/curve/-/curve-0.0.165.tgz",
+      "integrity": "sha512-fiQAGrKNGjJbL+eixUckJqIZDWXH/1NtIyyDbSz3J7ksk0QpYr5BgWcNJN76HLNt7wfcLwNzCHeNs4iVYyFGTg==",
       "dependencies": {
         "d3-shape": "^1.0.6"
       }
     },
     "node_modules/@vx/event": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/event/-/event-0.0.140.tgz",
-      "integrity": "sha1-ZY7E3pLNYd9AuIMpYWjU4IJAFb8=",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@vx/event/-/event-0.0.179.tgz",
+      "integrity": "sha512-wEwqKsxrzoRV/A9Va/f/CHPmV9asrTH/kW/f88jCydsVXd5W/nrJZiVpozN2Zr1Ernv0i1gW5896FWo/LHRg0A==",
       "dependencies": {
-        "@vx/point": "0.0.136"
+        "@vx/point": "0.0.165"
       }
     },
-    "node_modules/@vx/event/node_modules/@vx/point": {
-      "version": "0.0.136",
-      "resolved": "https://registry.npmjs.org/@vx/point/-/point-0.0.136.tgz",
-      "integrity": "sha1-k7MltLlcnVuW33QPQgQBf1c5ZVk="
-    },
     "node_modules/@vx/glyph": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/glyph/-/glyph-0.0.140.tgz",
-      "integrity": "sha1-+DI/gq7iIZK2db7yV4m7t9dGkbo=",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@vx/glyph/-/glyph-0.0.179.tgz",
+      "integrity": "sha512-RO7adwyG+9gGzjFdfmplrojgWCT+gsOnIFcRgJNJjx41+P6hWdI9X4OpsLx8VVqNhp7g+hxBDZWte8AxTvLQGw==",
       "dependencies": {
-        "@vx/group": "0.0.140",
+        "@vx/group": "0.0.170",
         "classnames": "^2.2.5",
-        "d3-shape": "^1.2.0"
+        "d3-shape": "^1.2.0",
+        "prop-types": "^15.6.2"
       },
       "peerDependencies": {
         "react": "^15.0.0-0 || ^16.0.0-0"
       }
     },
     "node_modules/@vx/gradient": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/gradient/-/gradient-0.0.140.tgz",
-      "integrity": "sha1-VrQhAWy64NywAZDP/7noYKKP6/Q=",
+      "version": "0.0.165",
+      "resolved": "https://registry.npmjs.org/@vx/gradient/-/gradient-0.0.165.tgz",
+      "integrity": "sha512-FjRXMTmcy7k0TWsfDzWWXw6T9WXKP+6LS/GRgnguq271pab/P+AdOJThsVxtBgUc8ZOAPbub3/2Gggz9d8tocg==",
       "dependencies": {
         "classnames": "^2.2.5",
         "prop-types": "^15.5.7"
@@ -5880,9 +5850,9 @@
       }
     },
     "node_modules/@vx/group": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/group/-/group-0.0.140.tgz",
-      "integrity": "sha1-y6mws/LwB+W+c0bzyG9z9w4DiiM=",
+      "version": "0.0.170",
+      "resolved": "https://registry.npmjs.org/@vx/group/-/group-0.0.170.tgz",
+      "integrity": "sha512-RnDdRoy0YI5hokk+YWXc8t39Kp51i4BdCpiwkDJU4YypGycTYnDFjicam6jigUmZ/6wyMirDf/aQboWviFLt2Q==",
       "dependencies": {
         "classnames": "^2.2.5"
       },
@@ -5891,9 +5861,9 @@
       }
     },
     "node_modules/@vx/pattern": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/pattern/-/pattern-0.0.140.tgz",
-      "integrity": "sha1-9J9XxvE8tbO6qlu+wXTF06p4Lac=",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@vx/pattern/-/pattern-0.0.179.tgz",
+      "integrity": "sha512-qvJsK07oUnSbuzj9jo7b/1Up13DknIeTlj9FDIhg0UNmz90ikVN2CZIWtdJyc2I1AFDEg0odOqYXzUx9aEBRfg==",
       "dependencies": {
         "classnames": "^2.2.5",
         "prop-types": "^15.5.10"
@@ -5908,34 +5878,49 @@
       "integrity": "sha512-spoHilhjcWNgccrSzBUPw+PXV81tYxeyEWBkgr35aGVU4m7YT86Ywvfemwp7AVVGPn+XJHrhB0ujAhDoyqFPoA=="
     },
     "node_modules/@vx/responsive": {
-      "version": "0.0.147",
-      "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.147.tgz",
-      "integrity": "sha1-yUrbtBrR4htdHr3iQbAEY5A/x5w=",
+      "version": "0.0.192",
+      "resolved": "https://registry.npmjs.org/@vx/responsive/-/responsive-0.0.192.tgz",
+      "integrity": "sha512-HaXVwhSJXUfRbzRV+glxsX0ki2Hi1mdpz42iuGArVQgDPJEmBHjkXyoiXU8U6v66M7FAH+OyKgtc5j2bfhyYzA==",
       "dependencies": {
-        "lodash": "^4.0.8",
-        "resize-observer-polyfill": "1.4.2"
+        "lodash": "^4.17.10",
+        "prop-types": "^15.6.1",
+        "resize-observer-polyfill": "1.5.0"
       },
       "peerDependencies": {
         "react": "^15.0.0-0 || ^16.0.0-0"
       }
     },
     "node_modules/@vx/scale": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/scale/-/scale-0.0.140.tgz",
-      "integrity": "sha1-HrCH0R0AALJQws3EBhueIhLtsQ0=",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@vx/scale/-/scale-0.0.179.tgz",
+      "integrity": "sha512-j40WiGu4VcHZdaSQAl12ig2w5c4Q9EVn7qqYf9PX7uoS5PbxRYNnHeKZ7e5Bf8O6b57iv5jFTfUV7HkpNF4vvg==",
       "dependencies": {
-        "d3-scale": "^1.0.5"
+        "d3-scale": "^2.0.0"
+      }
+    },
+    "node_modules/@vx/scale/node_modules/d3-scale": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
+      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
       }
     },
     "node_modules/@vx/shape": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/shape/-/shape-0.0.140.tgz",
-      "integrity": "sha1-aigtX986V1K26Ti7Pevpg+if9tM=",
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@vx/shape/-/shape-0.0.179.tgz",
+      "integrity": "sha512-YHVNx4xGpbjolkW3Lb5pEgJB0+u349vfnLI976DJlinY0hRNa4TZbWXOB4ywLIrYzQEXXPMUR8WtdubNxg6g0w==",
       "dependencies": {
-        "@vx/curve": "0.0.140",
-        "@vx/group": "0.0.140",
-        "@vx/point": "0.0.136",
+        "@vx/curve": "0.0.165",
+        "@vx/group": "0.0.170",
+        "@vx/point": "0.0.165",
         "classnames": "^2.2.5",
+        "d3-path": "^1.0.5",
         "d3-shape": "^1.2.0",
         "prop-types": "^15.5.10"
       },
@@ -5943,34 +5928,32 @@
         "react": "^15.0.0-0 || ^16.0.0-0"
       }
     },
-    "node_modules/@vx/shape/node_modules/@vx/point": {
-      "version": "0.0.136",
-      "resolved": "https://registry.npmjs.org/@vx/point/-/point-0.0.136.tgz",
-      "integrity": "sha1-k7MltLlcnVuW33QPQgQBf1c5ZVk="
-    },
-    "node_modules/@vx/tooltip": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/tooltip/-/tooltip-0.0.140.tgz",
-      "integrity": "sha1-xcgwYnKHfBu9TotHjqUpHxAZ/+M=",
+    "node_modules/@vx/text": {
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@vx/text/-/text-0.0.179.tgz",
+      "integrity": "sha512-UD3/8o15+AQfjDI8LQ1Zj3EdQCwA3cfuQMR/M2F/Le4+JXQNMheeWz4xGyF4ZDs6r7c5cUI9Cd1RaPmGhYsX9g==",
       "dependencies": {
-        "@vx/bounds": "0.0.140",
+        "babel-plugin-lodash": "^3.3.2",
         "classnames": "^2.2.5",
-        "prop-types": "^15.5.10"
+        "lodash": "^4.17.4",
+        "prop-types": "^15.6.2",
+        "reduce-css-calc": "^1.3.0"
       },
       "peerDependencies": {
         "react": "^15.0.0-0 || ^16.0.0-0"
       }
     },
-    "node_modules/@vx/tooltip/node_modules/@vx/bounds": {
-      "version": "0.0.140",
-      "resolved": "https://registry.npmjs.org/@vx/bounds/-/bounds-0.0.140.tgz",
-      "integrity": "sha1-Tt6XZqq7QbeRpPv0wn/MGe2D+RA=",
+    "node_modules/@vx/tooltip": {
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@vx/tooltip/-/tooltip-0.0.179.tgz",
+      "integrity": "sha512-BjMURtNpc1g3Li00iHt4bA9lbhk1FnsxCemYI1OF5tSSKHHal2ZAdxRS7o1sR9+jIa3RyD9flfIa1ibtrJh2Ew==",
       "dependencies": {
+        "@vx/bounds": "0.0.165",
+        "classnames": "^2.2.5",
         "prop-types": "^15.5.10"
       },
       "peerDependencies": {
-        "react": "^15.0.0-0 || ^16.0.0-0",
-        "react-dom": "^15.0.0-0 || ^16.0.0-0"
+        "react": "^15.0.0-0 || ^16.0.0-0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -7349,6 +7332,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/babel-plugin-lodash": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -15273,6 +15268,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/math-expression-evaluator": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.4.0.tgz",
+      "integrity": "sha512-4vRUvPyxdO8cWULGTh9dZWL2tZK6LDBvj+OGHBER7poH9Qdt7kXEoj20wiz4lQUbUXQZFjPbe5mVDo9nutizCw=="
+    },
     "node_modules/md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -19628,6 +19628,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha512-0dVfwYVOlf/LBA2ec4OwQ6p3X9mYxn/wOl2xTcLwjnPYrkgEfPx3VI4eGCH3rQLlPISG5v9I9bkZosKsNRTRKA==",
+      "dependencies": {
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
+      }
+    },
+    "node_modules/reduce-css-calc/node_modules/balanced-match": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg=="
+    },
+    "node_modules/reduce-function-call": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.3.tgz",
+      "integrity": "sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/redux": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
@@ -20000,15 +20023,20 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
+    "node_modules/require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q=="
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "node_modules/resize-observer-polyfill": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.4.2.tgz",
-      "integrity": "sha1-o3GY5iCeiIrLFTKplo4G04tniOU="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
+      "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
     },
     "node_modules/resolve": {
       "version": "1.15.0",
@@ -35880,9 +35908,9 @@
       }
     },
     "math-expression-evaluator": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.3.8.tgz",
-      "integrity": "sha512-9FbRY3i6U+CbHgrdNbAUaisjWTozkm1ZfupYQJiZ87NtYHk2Zh9DvxMgp/fifxVhqTLpd5fCCLossUbpZxGeKw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.4.0.tgz",
+      "integrity": "sha512-4vRUvPyxdO8cWULGTh9dZWL2tZK6LDBvj+OGHBER7poH9Qdt7kXEoj20wiz4lQUbUXQZFjPbe5mVDo9nutizCw=="
     },
     "md5": {
       "version": "2.2.1",
@@ -39331,7 +39359,7 @@
     "reduce-css-calc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "integrity": "sha512-0dVfwYVOlf/LBA2ec4OwQ6p3X9mYxn/wOl2xTcLwjnPYrkgEfPx3VI4eGCH3rQLlPISG5v9I9bkZosKsNRTRKA==",
       "requires": {
         "balanced-match": "^0.4.2",
         "math-expression-evaluator": "^1.2.14",
@@ -39341,7 +39369,7 @@
         "balanced-match": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+          "integrity": "sha512-STw03mQKnGUYtoNjmowo4F2cRmIIxYEGiMsjjwla/u5P1lxadj/05WkNaFjNiKTgJkj8KiXbgAiRTmcQRwQNtg=="
         }
       }
     },
@@ -39637,7 +39665,7 @@
     "require-package-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
-      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk="
+      "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q=="
     },
     "requires-port": {
       "version": "1.0.0",

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -93,7 +93,11 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     });
   }, [findQuery, pageCache]);
 
-  const [pageRange, setPageRange] = useState<PageRange>({bottom: 1 + PRELOAD_PAGES, middle: 1, top: 1});
+  const [pageRange, setPageRange] = useState<PageRange>({
+    bottom: Math.min(1 + PRELOAD_PAGES, totalPages),
+    middle: 1,
+    top: 1
+  });
   const debouncedSetPageRange = useMemo(() => debounce(setPageRange, 150), [setPageRange]);
 
   const setPageRangeFromScrollPosition = useCallback(() => {
@@ -102,8 +106,8 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
         const v = viewport.current;
 
         const currentMid = v.scrollTop + v.clientHeight / 2;
-        const topEdge = currentMid - PRELOAD_PAGES * pageHeight;
-        const botEdge = currentMid + PRELOAD_PAGES * pageHeight;
+        const topEdge = currentMid - (PRELOAD_PAGES * pageHeight);
+        const botEdge = currentMid + (PRELOAD_PAGES * pageHeight);
 
         const newPageRange = {
           bottom: Math.min(Math.ceil(botEdge / pageHeight), totalPages),


### PR DESCRIPTION
## Before
For a one-page doc, it would attempt to load pages 2 and 3:

![Screenshot 2023-03-20 at 18 00 02](https://user-images.githubusercontent.com/5122968/226427802-10204063-ebdf-43e5-a04a-5c5308c0209a.png)

It fails, causing cascading errors in pdf.js:

![Screenshot 2023-03-20 at 18 00 56](https://user-images.githubusercontent.com/5122968/226427806-b9277889-40cc-42f7-867f-ee440ca4bbc9.png)

And, for some reason, when running locally this results in a massive iframe covering the page and making it unusable:

![Screenshot 2023-03-20 at 18 01 32](https://user-images.githubusercontent.com/5122968/226427810-58d71b11-f9cf-4de0-ad0c-c9033ed1cb01.png)

In prod, it stills spews errors because of trying to fetch pages 2 and 3 which don't exist, but for some reason the iframe doesn't appear.

## After
It loads just one page, and there's no iframe:

![Screenshot 2023-03-20 at 18 06 18](https://user-images.githubusercontent.com/5122968/226428506-3e1e64dc-b16e-44b2-af8b-8a4dd63a4707.png)

