### PR TITLE
Upgrade redux 3.7.2 -> 4.2.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,7 @@
         "react-scripts": "3.4.4",
         "react-select": "^1.3.0",
         "react-tooltip": "^4.2.21",
-        "redux": "^3.7.2",
+        "redux": "^4.2.1",
         "redux-thunk": "^2.3.0",
         "sass": "^1.44.0",
         "semantic-ui-css": "^2.4.1",
@@ -5541,16 +5541,6 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
-      }
-    },
-    "node_modules/@types/react-redux/node_modules/redux": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
       }
     },
     "node_modules/@types/react-router": {
@@ -15083,11 +15073,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
-    },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -18906,15 +18891,6 @@
         "react-dom": "^16.8.5"
       }
     },
-    "node_modules/react-beautiful-dnd/node_modules/redux": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
-      }
-    },
     "node_modules/react-clientside-effect": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
@@ -19652,14 +19628,11 @@
       }
     },
     "node_modules/redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/redux-thunk": {
@@ -21897,14 +21870,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -28242,18 +28207,6 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
-      },
-      "dependencies": {
-        "redux": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-          "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "symbol-observable": "^1.2.0"
-          }
-        }
       }
     },
     "@types/react-router": {
@@ -35749,11 +35702,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
-    "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -38800,17 +38748,6 @@
         "react-redux": "^7.1.1",
         "redux": "^4.0.4",
         "use-memo-one": "^1.1.1"
-      },
-      "dependencies": {
-        "redux": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-          "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "symbol-observable": "^1.2.0"
-          }
-        }
       }
     },
     "react-clientside-effect": {
@@ -39382,14 +39319,11 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "redux-thunk": {
@@ -41140,11 +41074,6 @@
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "react-scripts": "3.4.4",
     "react-select": "^1.3.0",
     "react-tooltip": "^4.2.21",
-    "redux": "^3.7.2",
+    "redux": "^4.2.1",
     "redux-thunk": "^2.3.0",
     "sass": "^1.44.0",
     "semantic-ui-css": "^2.4.1",

--- a/frontend/src/js/util/auth/authFetch.ts
+++ b/frontend/src/js/util/auth/authFetch.ts
@@ -5,7 +5,7 @@ import { GiantState } from '../../types/redux/GiantState';
 
 export default function authFetch(url: RequestInfo, init?: RequestInit): Promise<Response> {
     const request = new Request(url, init);
-    const { auth } = (store.getState() as GiantState);
+    const { auth } = (store.getState() as unknown as GiantState);
 
     if(auth.token && auth.token.exp < (Date.now() / 1000)) {
         logOutTheUserLocally();

--- a/frontend/src/js/util/store.js
+++ b/frontend/src/js/util/store.js
@@ -1,4 +1,4 @@
-import {applyMiddleware, compose, createStore} from 'redux';
+import {applyMiddleware, compose, legacy_createStore as createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import createRootReducer from '../reducers';
 import { routerMiddleware } from 'connected-react-router';


### PR DESCRIPTION
## What does this change?
Upgrades `redux` from version 3.7.2 to 4.2.1, fixing [a vulnerability](https://app.snyk.io/org/guardian-investigations/project/5b846eac-6418-4ca9-ae1b-f1cded91cfd6#issue-SNYK-JS-LODASHES-2434283).

## How to test
Run Giant locally and do a search