### PR TITLE
Bump jsoup to version 1.14.2 to fix vulnerability

### DIFF
--- a/backend/app/utils/HtmlToPlainText.scala
+++ b/backend/app/utils/HtmlToPlainText.scala
@@ -1,7 +1,7 @@
 package utils
 
 import org.jsoup.Jsoup
-import org.jsoup.helper.StringUtil
+import org.jsoup.internal.StringUtil
 import org.jsoup.nodes.{Element, Node, TextNode}
 import org.jsoup.select.NodeFilter.FilterResult
 import org.jsoup.select.{NodeFilter, NodeTraversor}

--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ lazy val backend = (project in file("backend"))
       "com.beachape" %% "enumeratum-play" % "1.7.2",
       "com.iheart" %% "ficus" % "1.5.2",
       "com.sun.mail" % "javax.mail" % "1.6.2",
-      "org.jsoup" % "jsoup" % "1.11.3",
+      "org.jsoup" % "jsoup" % "1.14.2",
       "com.gu" %% "pan-domain-auth-verification" % "1.2.0",
 
       // this is needed to override the 2.11.4 version of jackson-module used in various play libraries (including jwt-play)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This resolves https://app.snyk.io/vuln/SNYK-JAVA-ORGJSOUP-1567345 with a minor version bump of jsoup. 

## How to test
Tested on playground