### PR TITLE
Fix scala cli - use list instead of lazylist

### DIFF
--- a/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliFileWalker.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliFileWalker.scala
@@ -21,7 +21,7 @@ class CliFileWalker(enrich: Path => IngestionFile) extends Logging {
         Try {
           val fileStream = Files.list(thisPath)
           // eagerly evaluate the file stream; allowing it to be closed to avoid resource exhaustion
-          val evaluated = fileStream.toScala(LazyList).toList
+          val evaluated = LazyList.from(fileStream.toScala(List))
           fileStream.close()
           evaluated
         }.map(_.flatMap(p => walk(p, parents.head.chain(p.getFileName.toString) :: parents, root, languages))).getOrElse {

--- a/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliFileWalker.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/ingestion/CliFileWalker.scala
@@ -1,7 +1,6 @@
 package com.gu.pfi.cli.ingestion
 
 import java.nio.file.{Files, Path}
-
 import model.{Language, Uri}
 import model.ingestion.{IngestionFile, OnDiskFileContext}
 import utils.Logging
@@ -10,27 +9,27 @@ import scala.jdk.StreamConverters._
 import scala.util.Try
 
 class CliFileWalker(enrich: Path => IngestionFile) extends Logging {
-  def walk(path: Path, root: Uri, languages: List[Language]): LazyList[OnDiskFileContext] = {
+  def walk(path: Path, root: Uri, languages: List[Language]): List[OnDiskFileContext] = {
     walk(path, List(root.chain(path.getFileName.toString), root), root, languages)
   }
 
-  private def walk(thisPath: Path, parents: List[Uri], root: Uri, languages: List[Language]): LazyList[OnDiskFileContext] = {
+  private def walk(thisPath: Path, parents: List[Uri], root: Uri, languages: List[Language]): List[OnDiskFileContext] = {
     val enrichedPath = enrich(thisPath)
 
-    OnDiskFileContext(enrichedPath, parents, root.value, languages, thisPath) #:: {
+    OnDiskFileContext(enrichedPath, parents, root.value, languages, thisPath) +: {
       if (Files.isDirectory(thisPath)) {
         Try {
           val fileStream = Files.list(thisPath)
           // eagerly evaluate the file stream; allowing it to be closed to avoid resource exhaustion
-          val evaluated = fileStream.toScala(LazyList)
+          val evaluated = fileStream.toScala(LazyList).toList
           fileStream.close()
           evaluated
         }.map(_.flatMap(p => walk(p, parents.head.chain(p.getFileName.toString) :: parents, root, languages))).getOrElse {
           logger.error(s"IO error reading '$thisPath'")
-          LazyList.empty[OnDiskFileContext]
+          List.empty[OnDiskFileContext]
         }
       } else {
-        LazyList.empty[OnDiskFileContext]
+        List.empty[OnDiskFileContext]
       }
     }
   }


### PR DESCRIPTION
## What does this change?
In order to fix the scala cli, this somewhat reverts some of the changes made in https://github.com/guardian/giant/pull/75/files#diff-458af680964b84c1a157d7485ffa9b0a5a4ab961148a632b3fb6c3507f65db3c 

In Scala 2.13, Streams went away, replaced by LazyLists. The file linked to above shows the changes implemented by @mbarton in his heroic scala 2.13 upgrade. Unfortunately this had the effect of breaking the scala cli - it runs succesfully but doesn't detect any of the files in the directory being ingested.


### Out of date context below!
This change fixes that issue, by just using a conventional `List` to store the big list of files. I'm not much of an expert on scala streams/lazy lists/iterators etc. I _think_  that since we were already deliberately eagerly evaluating the file list this change won't have an enormous memory impact - note that in the pre scala 2.13 world we were also using a `List` which we then converted to a `Stream`. Very happy to be put right on this though, I guess there is a risk that for a really really big dataset the file list could be so long that it doesn't fit in memory (we'd probably have other $$$bezos$$ shaped problems at that point though).


## How to test
Ingest something using the cli! I have succesfully performed an ingest following this change. 


## Notes
https://github.com/guardian/giant-utils is a thing, all lovely rust, but that had some problems last time I run it so I'm keen to get ye olde trusty scala cli working - and in any case we should either fix it or remove entirely