### PR TITLE
Zoom in and zoom out pdf 

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 16.8.0
+nodejs 16.16.0
 java corretto-11.0.16.8.1

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -128,7 +128,6 @@ export const Controls: FC<ControlsProps> = ({
 
   return (
     <div className={styles.bar}>
-      
       {fixedQuery === undefined &&
         <>
           <div>

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -128,23 +128,26 @@ export const Controls: FC<ControlsProps> = ({
 
   return (
     <div className={styles.bar}>
-      <div>
-        <button onClick={zoomIn} >
-          <ZoomInIcon />
-        </button>
-        <button onClick={zoomOut}  >
-          <ZoomOutIcon />
-        </button>
-      </div>
+      
       {fixedQuery === undefined &&
-        <div>
-          <button onClick={rotateAnticlockwise} >
-            <RotateLeft />
-          </button>
-          <button onClick={rotateClockwise}  >
-            <RotateRight />
-          </button>
-        </div>
+        <>
+          <div>
+            <button onClick={zoomIn} >
+              <ZoomInIcon />
+            </button>
+            <button onClick={zoomOut}  >
+              <ZoomOutIcon />
+            </button>
+          </div>
+          <div>
+            <button onClick={rotateAnticlockwise} >
+              <RotateLeft />
+            </button>
+            <button onClick={rotateClockwise}  >
+              <RotateRight />
+            </button>
+          </div>
+        </>
       }
 
       <FindInput

--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -1,6 +1,8 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import RotateLeft from 'react-icons/lib/md/rotate-left';
 import RotateRight from 'react-icons/lib/md/rotate-right';
+import ZoomInIcon from 'react-icons/lib/md/zoom-in';
+import ZoomOutIcon from 'react-icons/lib/md/zoom-out';
 import styles from './Controls.module.css';
 import { FindInput } from './FindInput';
 import { HighlightForSearchNavigation } from './model';
@@ -8,10 +10,13 @@ import { removeLastUnmatchedQuote } from '../../util/stringUtils';
 import authFetch from '../../util/auth/authFetch';
 import { HighlightsState } from './PageViewer';
 
+
 type ControlsProps = {
   // Rotation
   rotateClockwise: () => void;
   rotateAnticlockwise: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
 
   fixedQuery?: string;
   uri: string;
@@ -25,7 +30,9 @@ export const Controls: FC<ControlsProps> = ({
   fixedQuery,
   uri,
   onHighlightStateChange,
-  onQueryChange
+  onQueryChange,
+  zoomIn,
+  zoomOut
 }) => {
   const [focusedFindHighlightIndex, setFocusedFindHighlightIndex] = useState<number | null>(null);
   const [findHighlights, setFindHighlights] = useState<HighlightForSearchNavigation[]>([]);
@@ -121,6 +128,14 @@ export const Controls: FC<ControlsProps> = ({
 
   return (
     <div className={styles.bar}>
+      <div>
+        <button onClick={zoomIn} >
+          <ZoomInIcon />
+        </button>
+        <button onClick={zoomOut}  >
+          <ZoomOutIcon />
+        </button>
+      </div>
       {fixedQuery === undefined &&
         <div>
           <button onClick={rotateAnticlockwise} >

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -40,19 +40,22 @@ export const Page: FC<PageProps> = ({
     }
   };
 
-  useEffect(() => {
-    console.log('useEffect getPagePreview');
+  useEffect(() => {    
     if (containerRef.current) {
       getPagePreview
         .then((preview) => {
-          console.log('Render page preview into DOM');
           // Have to recheck here because the component may have dismounted
           const node = containerRef.current;
           if (node) {
             setScale(preview.scale);
-            // TODO DANGEROUS: this might completely mess up multi-page docs
-            node.innerHTML = '';
-            node.appendChild(preview.canvas);
+            if (node.hasChildNodes()) {
+              const oldCanvas = node.getElementsByTagName('canvas');
+              if (oldCanvas.length > 0) {
+                node.replaceChild(preview.canvas, oldCanvas[0]);
+              }                      
+            } else {
+              node.appendChild(preview.canvas);
+            }                        
           }
           setPreviewMounted(true);
           return preview;
@@ -67,7 +70,6 @@ export const Page: FC<PageProps> = ({
 
   useEffect(() => {
     getPageData.then((text) => {
-      console.log('Refresh page data');
       setPageText(text);
     }).catch(handleAbort);
   }, [containerRef, getPageData]);

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -49,10 +49,10 @@ export const Page: FC<PageProps> = ({
           if (node) {
             setScale(preview.scale);
 
-            const oldCanvas = node.getElementsByTagName('canvas');
+            const oldCanvas = node.querySelector('canvas');
 
-            if (oldCanvas.length > 0) {
-              node.replaceChild(preview.canvas, oldCanvas[0]);
+            if (oldCanvas) {
+              node.replaceChild(preview.canvas, oldCanvas);
             } else {
               node.appendChild(preview.canvas);
             }

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -48,14 +48,14 @@ export const Page: FC<PageProps> = ({
           const node = containerRef.current;
           if (node) {
             setScale(preview.scale);
-            if (node.hasChildNodes()) {
-              const oldCanvas = node.getElementsByTagName('canvas');
-              if (oldCanvas.length > 0) {
-                node.replaceChild(preview.canvas, oldCanvas[0]);
-              }                      
+
+            const oldCanvas = node.getElementsByTagName('canvas');
+
+            if (oldCanvas.length > 0) {
+              node.replaceChild(preview.canvas, oldCanvas[0]);
             } else {
               node.appendChild(preview.canvas);
-            }                        
+            }
           }
           setPreviewMounted(true);
           return preview;

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -40,7 +40,7 @@ export const Page: FC<PageProps> = ({
     }
   };
 
-  useEffect(() => {    
+  useEffect(() => {
     if (containerRef.current) {
       getPagePreview
         .then((preview) => {

--- a/frontend/src/js/components/PageViewer/Page.tsx
+++ b/frontend/src/js/components/PageViewer/Page.tsx
@@ -11,6 +11,7 @@ type PageProps = {
   pageNumber: number;
   getPagePreview: Promise<CachedPreview>;
   getPageData: Promise<PageData>;
+  pageHeight: number;
 };
 
 export const Page: FC<PageProps> = ({
@@ -19,6 +20,7 @@ export const Page: FC<PageProps> = ({
   pageNumber,
   getPagePreview,
   getPageData,
+  pageHeight,
 }) => {
   const [pageText, setPageText] = useState<PageData | null>(null);
   const [scale, setScale] = useState<number | null>(null);
@@ -39,13 +41,17 @@ export const Page: FC<PageProps> = ({
   };
 
   useEffect(() => {
+    console.log('useEffect getPagePreview');
     if (containerRef.current) {
       getPagePreview
         .then((preview) => {
+          console.log('Render page preview into DOM');
           // Have to recheck here because the component may have dismounted
           const node = containerRef.current;
           if (node) {
             setScale(preview.scale);
+            // TODO DANGEROUS: this might completely mess up multi-page docs
+            node.innerHTML = '';
             node.appendChild(preview.canvas);
           }
           setPreviewMounted(true);
@@ -57,10 +63,13 @@ export const Page: FC<PageProps> = ({
         })
         .catch(handleAbort);
     }
-  }, [getPagePreview]);
+  }, [getPagePreview, pageHeight]);
 
   useEffect(() => {
-    getPageData.then(setPageText).catch(handleAbort);
+    getPageData.then((text) => {
+      console.log('Refresh page data');
+      setPageText(text);
+    }).catch(handleAbort);
   }, [containerRef, getPageData]);
 
   return (

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -8,6 +8,7 @@ import {PDFWorker} from "pdfjs-dist";
 export type CachedPage = {
   previewAbortController: AbortController;
   preview: Promise<CachedPreview>;
+  previewContainerSize: number;
   dataAbortController: AbortController;
   data: Promise<PageData>;
 };
@@ -15,6 +16,7 @@ export type CachedPage = {
 export type CachedPreviewData = {
   previewAbortController: AbortController;
   preview: Promise<CachedPreview>;
+  previewContainerSize: number;
 };
 
 export type CachedPageData = {
@@ -80,6 +82,7 @@ export class PageCache {
     return {
       previewAbortController,
       preview,
+      previewContainerSize: this.containerSize,
     };
   };
 
@@ -128,12 +131,13 @@ export class PageCache {
   };
 
   refreshPreview = (pageNumber: number, preview: Promise<CachedPreview>, containerSize: number): CachedPage => {  
-    this.setContainerSize(containerSize);  
+    this.setContainerSize(containerSize);
     const originalPreviewData = this.previewCache.get(pageNumber);
     const newPreview = updatePreview(preview, containerSize);
     const newPreviewCache = {
       previewAbortController: originalPreviewData.previewAbortController,
       preview: newPreview,
+      previewContainerSize: this.containerSize    
     };  
 
     const data = this.dataCache.get(pageNumber);

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -69,6 +69,8 @@ export class PageCache {
   };
 
   private onPreviewCacheMiss = (pageNumber: number): CachedPreviewData => {
+    console.log('onPreviewCacheMiss');
+
     const previewAbortController = new AbortController();
     const preview = authFetch(`/api/pages2/${this.uri}/${pageNumber}/preview`, {
       signal: previewAbortController.signal,
@@ -118,6 +120,18 @@ export class PageCache {
 
   getPage = (pageNumber: number): CachedPage => {
     const preview = this.previewCache.get(pageNumber);
+    const data = this.dataCache.get(pageNumber);
+
+    return {
+      ...preview,
+      ...data,
+    };
+  };
+
+  getPageAndRefreshPreview = (pageNumber: number): CachedPage => {
+    const preview = this.previewCache.getAndForceRefresh(pageNumber);
+
+    // TODO: we may need to refresh the data too, if we need a new server call to get new highlight positions
     const data = this.dataCache.get(pageNumber);
 
     return {

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -1,7 +1,7 @@
 import authFetch from "../../util/auth/authFetch";
 import { LruCache } from "../../util/LruCache";
 import { CachedPreview, PageData } from "./model";
-import { renderPdfPreview } from "./PdfHelpers";
+import { renderPdfPreview, updatePreview } from "./PdfHelpers";
 import { removeLastUnmatchedQuote } from '../../util/stringUtils';
 import {PDFWorker} from "pdfjs-dist";
 
@@ -123,6 +123,26 @@ export class PageCache {
 
     return {
       ...preview,
+      ...data,
+    };
+  };
+
+  refreshPreview = (pageNumber: number, preview: Promise<CachedPreview>, containerSize: number): CachedPage => {    
+    const originalPreviewData = this.previewCache.get(pageNumber);
+    const newPreview = updatePreview(preview, containerSize);
+    const cachedPreviewCache = {
+      previewAbortController: originalPreviewData.previewAbortController,
+      preview: newPreview,
+    };  
+    // TODO: we may need to refresh the data too, if we need a new server call to get new highlight positions
+    const data = this.dataCache.get(pageNumber);
+
+    this.previewCache.replace(pageNumber, cachedPreviewCache);
+
+    const newPreviewData = this.previewCache.get(pageNumber);
+
+    return {
+      ...newPreviewData,
       ...data,
     };
   };

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -152,18 +152,6 @@ export class PageCache {
     };
   };
 
-  getPageAndRefreshPreview = (pageNumber: number): CachedPage => {
-    const preview = this.previewCache.getAndForceRefresh(pageNumber);
-
-    // TODO: we may need to refresh the data too, if we need a new server call to get new highlight positions
-    const data = this.dataCache.get(pageNumber);
-
-    return {
-      ...preview,
-      ...data,
-    };
-  };
-
   getPageAndRefreshHighlights = (pageNumber: number): CachedPage => {
     if (this.findQuery) {
       const preview = this.previewCache.get(pageNumber);

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -69,7 +69,6 @@ export class PageCache {
   };
 
   private onPreviewCacheMiss = (pageNumber: number): CachedPreviewData => {
-    console.log('onPreviewCacheMiss');
 
     const previewAbortController = new AbortController();
     const preview = authFetch(`/api/pages2/${this.uri}/${pageNumber}/preview`, {

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -130,7 +130,7 @@ export class PageCache {
     };
   };
 
-  refreshPreview = (pageNumber: number, preview: Promise<CachedPreview>, containerSize: number): CachedPage => {  
+  reRenderPagePreview = (pageNumber: number, preview: Promise<CachedPreview>, containerSize: number): CachedPage => {  
     this.setContainerSize(containerSize);
     const originalPreviewData = this.previewCache.get(pageNumber);
     const newPreview = updatePreview(preview, containerSize);

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -29,6 +29,8 @@ export class PageCache {
   // within document
   findQuery?: string;
 
+  containerSize: number;
+
   pdfWorker: PDFWorker;
 
   // Arrived at by testing with Chrome on Ubuntu.
@@ -41,7 +43,8 @@ export class PageCache {
   private previewCache: LruCache<number, CachedPreviewData>;
   private dataCache: LruCache<number, CachedPageData>;
 
-  constructor(uri: string, query?: string) {
+  constructor(uri: string, containerSize: number, query?: string) {
+    this.containerSize = containerSize;
     this.uri = uri;
     this.searchQuery = query;
     this.previewCache = new LruCache(
@@ -61,13 +64,17 @@ export class PageCache {
     this.findQuery = q;
   };
 
+  setContainerSize = (sizeInPixels: number) => {
+    this.containerSize = sizeInPixels;
+  };
+
   private onPreviewCacheMiss = (pageNumber: number): CachedPreviewData => {
     const previewAbortController = new AbortController();
     const preview = authFetch(`/api/pages2/${this.uri}/${pageNumber}/preview`, {
       signal: previewAbortController.signal,
     })
       .then((res) => res.arrayBuffer())
-      .then((buf) => renderPdfPreview(buf, this.pdfWorker));
+      .then((buf) => renderPdfPreview(buf, this.pdfWorker, this.containerSize));
 
     return {
       previewAbortController,

--- a/frontend/src/js/components/PageViewer/PageCache.ts
+++ b/frontend/src/js/components/PageViewer/PageCache.ts
@@ -127,17 +127,18 @@ export class PageCache {
     };
   };
 
-  refreshPreview = (pageNumber: number, preview: Promise<CachedPreview>, containerSize: number): CachedPage => {    
+  refreshPreview = (pageNumber: number, preview: Promise<CachedPreview>, containerSize: number): CachedPage => {  
+    this.setContainerSize(containerSize);  
     const originalPreviewData = this.previewCache.get(pageNumber);
     const newPreview = updatePreview(preview, containerSize);
-    const cachedPreviewCache = {
+    const newPreviewCache = {
       previewAbortController: originalPreviewData.previewAbortController,
       preview: newPreview,
     };  
-    // TODO: we may need to refresh the data too, if we need a new server call to get new highlight positions
+
     const data = this.dataCache.get(pageNumber);
 
-    this.previewCache.replace(pageNumber, cachedPreviewCache);
+    this.previewCache.replace(pageNumber, newPreviewCache);
 
     const newPreviewData = this.previewCache.get(pageNumber);
 

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -68,6 +68,7 @@ export const PageViewer: FC<PageViewerProps> = ({uri, totalPages}) => {
 
   const [pageNumbersToPreload, setPageNumbersToPreload] = useState<number[]>([]);
   const [rotation, setRotation] = useState(0);
+  const [scale, setScale] = useState(1);
 
   useEffect(() => {
     const findHighlightsPreloadPages = getPreloadPages(findHighlightsState);
@@ -107,6 +108,14 @@ export const PageViewer: FC<PageViewerProps> = ({uri, totalPages}) => {
           <Controls
             rotateAnticlockwise={() => setRotation((r) => r - 90)}
             rotateClockwise={() => setRotation((r) => r + 90)}
+            zoomIn={() => {
+              console.log('zoom in');
+              setScale((currentScale) => currentScale + 0.75);
+            }}
+            zoomOut={() => {
+              console.log('zoom out');
+              setScale((currentScale) => currentScale - 0.75);
+            }}
             uri={uri}
             onHighlightStateChange={onSearchHighlightStateChange}
             onQueryChange={onSearchQueryChange}
@@ -116,6 +125,14 @@ export const PageViewer: FC<PageViewerProps> = ({uri, totalPages}) => {
         <Controls
           rotateAnticlockwise={() => setRotation((r) => r - 90)}
           rotateClockwise={() => setRotation((r) => r + 90)}
+          zoomIn={() => {
+            console.log('zoom in');
+            setScale((currentScale) => currentScale + 0.75);
+          }}
+          zoomOut={() => {
+            console.log('zoom out');
+            setScale((currentScale) => currentScale - 0.75);
+          }}
           uri={uri}
           onHighlightStateChange={onFindHighlightStateChange}
           onQueryChange={onFindQueryChange}
@@ -131,6 +148,7 @@ export const PageViewer: FC<PageViewerProps> = ({uri, totalPages}) => {
           totalPages={totalPages}
           pageNumbersToPreload={pageNumbersToPreload}
           rotation={rotation}
+          scale={scale}
         />
       ) : null}
     </main>

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -109,11 +109,9 @@ export const PageViewer: FC<PageViewerProps> = ({uri, totalPages}) => {
             rotateAnticlockwise={() => setRotation((r) => r - 90)}
             rotateClockwise={() => setRotation((r) => r + 90)}
             zoomIn={() => {
-              console.log('zoom in');
               setScale((currentScale) => currentScale + 0.75);
             }}
             zoomOut={() => {
-              console.log('zoom out');
               setScale((currentScale) => currentScale - 0.75);
             }}
             uri={uri}
@@ -126,11 +124,9 @@ export const PageViewer: FC<PageViewerProps> = ({uri, totalPages}) => {
           rotateAnticlockwise={() => setRotation((r) => r - 90)}
           rotateClockwise={() => setRotation((r) => r + 90)}
           zoomIn={() => {
-            console.log('zoom in');
             setScale((currentScale) => currentScale + 0.75);
           }}
           zoomOut={() => {
-            console.log('zoom out');
             setScale((currentScale) => currentScale - 0.75);
           }}
           uri={uri}

--- a/frontend/src/js/components/PageViewer/PdfHelpers.ts
+++ b/frontend/src/js/components/PageViewer/PdfHelpers.ts
@@ -1,5 +1,5 @@
 
-import { CachedPreview, CONTAINER_SIZE, PdfText } from "./model";
+import { CachedPreview, PdfText } from "./model";
 import {getDocument, GlobalWorkerOptions, PDFWorker, renderTextLayer} from "pdfjs-dist";
 
 // PDFjs has webpack config built-in but it uses worker-loader which seems
@@ -9,7 +9,8 @@ import {getDocument, GlobalWorkerOptions, PDFWorker, renderTextLayer} from "pdfj
 GlobalWorkerOptions.workerSrc = '/third-party/pdf.worker.min.js';
 export const renderPdfPreview = async (
   buffer: ArrayBuffer,
-  pdfWorker: PDFWorker
+  pdfWorker: PDFWorker,
+  containerSize: number
 ): Promise<CachedPreview> => {
   const doc = await getDocument({
     data: new Uint8Array(buffer),
@@ -26,8 +27,8 @@ export const renderPdfPreview = async (
   const unscaledViewport = pdfPage.getViewport({ scale: 1.0 });
   const isLandscape = unscaledViewport.width > unscaledViewport.height;
 
-  const widthScale = CONTAINER_SIZE / unscaledViewport.width;
-  const heightScale = CONTAINER_SIZE / unscaledViewport.height;
+  const widthScale = containerSize / unscaledViewport.width;
+  const heightScale = containerSize / unscaledViewport.height;
 
   const scale = isLandscape ? widthScale : heightScale;
 

--- a/frontend/src/js/components/PageViewer/PdfHelpers.ts
+++ b/frontend/src/js/components/PageViewer/PdfHelpers.ts
@@ -12,7 +12,6 @@ export const renderPdfPreview = async (
   pdfWorker: PDFWorker,
   containerSize: number
 ): Promise<CachedPreview> => {
-  console.log('render pdf preview! containerSize: ', containerSize);
 
   const doc = await getDocument({
     data: new Uint8Array(buffer),
@@ -44,8 +43,7 @@ export const renderPdfPreview = async (
     canvasContext,
     viewport,
   });
-
-  console.log('rendered!');
+  
   return { pdfPage, canvas, scale };
 };
 

--- a/frontend/src/js/components/PageViewer/PdfHelpers.ts
+++ b/frontend/src/js/components/PageViewer/PdfHelpers.ts
@@ -80,11 +80,11 @@ const renderPagePreview = async (pdfPage: PDFPageProxy, containerSize: number) =
   canvas.width = viewport.width;
   canvas.height = viewport.height;
 
-    // Render
-    await pdfPage.render({
-      canvasContext,
-      viewport,
-    });
+  // Render
+  await pdfPage.render({
+    canvasContext,
+    viewport,
+  });
     
-    return { pdfPage, canvas, scale };
+  return { pdfPage, canvas, scale };
 }

--- a/frontend/src/js/components/PageViewer/PdfHelpers.ts
+++ b/frontend/src/js/components/PageViewer/PdfHelpers.ts
@@ -12,6 +12,8 @@ export const renderPdfPreview = async (
   pdfWorker: PDFWorker,
   containerSize: number
 ): Promise<CachedPreview> => {
+  console.log('render pdf preview! containerSize: ', containerSize);
+
   const doc = await getDocument({
     data: new Uint8Array(buffer),
     // Use the same web worker for all pages
@@ -43,6 +45,7 @@ export const renderPdfPreview = async (
     viewport,
   });
 
+  console.log('rendered!');
   return { pdfPage, canvas, scale };
 };
 

--- a/frontend/src/js/components/PageViewer/VirtualScroll.module.css
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.module.css
@@ -18,8 +18,8 @@
 
   min-width: 1000px;
   min-height: 1000px;
-  max-width: 1000px;
-  max-height: 1000px;
+  max-width: 10000px;
+  max-height: 10000px;
 
   display: flex;
   align-items: center;

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -68,9 +68,12 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   // rendered pages which allows us to swap out stale pages without flickering pages
   const [renderedPages, setRenderedPages] = useState<RenderedPage[]>([]);
 
-
-  useEffect(() => {    
-    pageCache.setContainerSize(containerSize);
+  // denounce is used to avoid multiple re-rendering when user clicks on zoom 
+  // buttons several times and container size changes too quickly 
+  const debouncedRefreshPreview = React.useMemo(
+    () =>
+      debounce((pageCache: PageCache, containerSize: number) => {
+        pageCache.setContainerSize(containerSize);
 
       setRenderedPages((currentPages) => {
         const newPages: RenderedPage[] = currentPages.map((page) => {
@@ -87,8 +90,14 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
         });
 
         return newPages;
-      });
-  }, [pageCache, containerSize]);
+      })
+      }, 500),
+    []
+  );
+
+  useEffect(() => {
+    debouncedRefreshPreview(pageCache, containerSize);
+  }, [pageCache, containerSize, debouncedRefreshPreview]);
 
   useEffect(() => {
     pageCache.setFindQuery(findQuery);

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -1,8 +1,8 @@
-import {debounce, range} from 'lodash';
-import React, {FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
-import {CachedPreview, HighlightForSearchNavigation, PageData} from './model';
-import {Page} from './Page';
-import {PageCache} from './PageCache';
+import { debounce, range } from 'lodash';
+import React, { FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { CachedPreview, HighlightForSearchNavigation, PageData } from './model';
+import { Page } from './Page';
+import { PageCache } from './PageCache';
 import styles from './VirtualScroll.module.css';
 import throttle from 'lodash/throttle';
 
@@ -56,12 +56,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   // This must be the same as the margin CSS of .pageContainer
   const MARGIN = 10;
 
-  // const [containerSize, setContainerSize] = useState<number>(1000);
-  // const [pageHeight, setPageHeight] = useState<number>(1000 + (MARGIN * 2));
-  //
-  // useEffect(() => {
-  //   setPageHeight(containerSize + (MARGIN * 2));
-  // }, [containerSize])
   const containerSize = 1000 * scale;
   const pageHeight = containerSize + (MARGIN * 2);
 
@@ -81,7 +75,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     if (containerSize !== 1000) {
       setRenderedPages((currentPages) => {
         const newPages: RenderedPage[] = currentPages.map((page) => {
-          // TODO: is there a way to avoid re-fetching the preview from the server?
           const refreshedPage = pageCache.refreshPreview(
             page.pageNumber,
             page.getPagePreview,
@@ -94,24 +87,10 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
           }
         });
 
-        // TODO: do we need this for zoom? maybe not because we don't care about data of non-visible pages
-        // // Once we've refreshed all visible pages go and refresh the cached pages too
-        // // Will this work inside a setState callback?? It seems so...
-        // Promise.all(newPages.map((page) => page.getPagePreview)).then(() => {
-        //   pageCache
-        //       .getAllPageNumbers()
-        //       .filter((cachedPageNumber) =>
-        //           !newPages.some((newPage) => newPage.pageNumber === cachedPageNumber)
-        //       )
-        //       .forEach((pageNumberToRefresh) =>
-        //           pageCache.getPageAndRefreshPreview(pageNumberToRefresh)
-        //       );
-        // });
-
         return newPages;
       });
     }
-  }, [pageCache, containerSize])
+  }, [pageCache, containerSize]);
 
   useEffect(() => {
     pageCache.setFindQuery(findQuery);
@@ -222,7 +201,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
         getPagePreview: cachedPage.preview,
         getPageData: cachedPage.data,
       };
-    });    
+    });
 
     setRenderedPages(renderedPages);
   }, [pageRange.top, pageRange.bottom, pageCache, setRenderedPages]);
@@ -234,25 +213,25 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   return (
     <div ref={viewport} className={styles.scrollContainer} onScroll={throttledSetPageRangeFromScrollPosition}>
       <div className={styles.pages} style={{ height: totalPages * pageHeight }}>
-        {renderedPages.map((page) => {          
-          return (<div
+        {renderedPages.map((page) => (
+            <div
               key={page.pageNumber}
               style={{
                 top: (page.pageNumber - 1) * pageHeight,
                 transform: `rotate(${rotation}deg)`,
               }}
               className={styles.pageContainer}
-          >
-            <Page
+            >
+              <Page
                 focusedFindHighlightId={focusedFindHighlight?.id}
                 focusedSearchHighlightId={focusedSearchHighlight?.id}
                 pageNumber={page.pageNumber}
                 getPagePreview={page.getPagePreview}
                 getPageData={page.getPageData}
                 pageHeight={pageHeight}
-            />
-          </div>);
-        })}
+              />
+            </div>
+          ))}
       </div>
     </div>
   );

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -72,7 +72,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   // rendered pages which allows us to swap out stale pages without flickering pages
   const [renderedPages, setRenderedPages] = useState<RenderedPage[]>([]);
 
-  // denounce is used to avoid multiple re-rendering when user clicks on zoom 
+  // debounce is used to avoid multiple re-rendering when user clicks on zoom 
   // buttons several times and container size changes too quickly 
   const debouncedRefreshPreview = React.useMemo(
     () =>
@@ -83,13 +83,13 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
             const refreshedPage = pageCache.reRenderPagePreview(
               page.pageNumber,
               page.getPagePreview,
-              containerSize          
-            ); 
+              containerSize
+            );
             return {
               pageNumber: page.pageNumber,
               getPagePreview: refreshedPage.preview,
               getPageData: refreshedPage.data,
-            }
+            };
           });
 
           setLeftScrollToMiddle();
@@ -112,7 +112,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
       }
 
     }, 1000);
-  }
+  };
 
   useEffect(() => {
     if (!isInitialRender.current && containerSize !== pageCache.containerSize) {

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -74,20 +74,23 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   // rendered pages which allows us to swap out stale pages without flickering pages
   const [renderedPages, setRenderedPages] = useState<RenderedPage[]>([]);
 
-  useEffect(() => {
+
+  useEffect(() => {    
     pageCache.setContainerSize(containerSize);
 
     if (containerSize !== 1000) {
       setRenderedPages((currentPages) => {
         const newPages: RenderedPage[] = currentPages.map((page) => {
           // TODO: is there a way to avoid re-fetching the preview from the server?
-          const refreshedPage = pageCache.getPageAndRefreshPreview(
-              page.pageNumber
-          );
+          const refreshedPage = pageCache.refreshPreview(
+            page.pageNumber,
+            page.getPagePreview,
+            containerSize          
+          ); 
           return {
             pageNumber: page.pageNumber,
             getPagePreview: refreshedPage.preview,
-            getPageData: page.getPageData,
+            getPageData: refreshedPage.data,
           }
         });
 

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -217,6 +217,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
               style={{
                 top: (page.pageNumber - 1) * pageHeight,
                 transform: `rotate(${rotation}deg)`,
+                left: `${scale > 1 ? '0' : ''}`,  
               }}
               className={styles.pageContainer}
             >

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -64,6 +64,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   // Used too avoid rendering the page un-necessarily as a result of 
   // useEffects that are dependant on containerSize & findQuery
   const isInitialRender = useRef<boolean>(true);
+  const pageScrollHeight = useRef<number>(pageHeight * totalPages);
 
   // TODO: move pageCache up?
   const [pageCache] = useState(() => new PageCache(uri, containerSize, searchQuery));
@@ -116,10 +117,21 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
 
   useEffect(() => {
     if (!isInitialRender.current && containerSize !== pageCache.containerSize) {
-      debouncedRefreshPreview(pageCache, containerSize);      
+      debouncedRefreshPreview(pageCache, containerSize);
     }
 
   }, [pageCache, containerSize, debouncedRefreshPreview]);
+
+  // Adjusting the scroll to stay in the same position that it currently is
+  // considering the change in the page height
+  useLayoutEffect(() => {
+      if (viewport.current && pageScrollHeight.current) {
+        const currentScrollPosition = viewport.current.scrollTop / pageScrollHeight.current;
+        const newScrollPosition = currentScrollPosition * viewport.current.scrollHeight;
+        pageScrollHeight.current = viewport.current.scrollHeight;
+        viewport.current.scrollTop = newScrollPosition;
+      }
+  }, [containerSize, pageHeight]);
 
   useEffect(() => {
     if (!isInitialRender.current) {

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -193,11 +193,21 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     }
   }, [pageHeight, focusedSearchHighlight, scale]);
 
+  const getCachedPage = useCallback((pageNumber: number) => {
+    const cachedPage = pageCache.getPage(pageNumber);
+    if (cachedPage.previewContainerSize === pageCache.containerSize){
+      return cachedPage;
+    } else {
+      return pageCache.refreshPreview(pageNumber, cachedPage.preview, containerSize);
+    }
+  }, [pageCache, containerSize]);
+
   useEffect(() => {
     const renderedPages = range(pageRange.top, pageRange.bottom + 1).map((pageNumber) => {
-      const cachedPage = pageCache.getPage(pageNumber);
-      return {
 
+      const cachedPage = getCachedPage(pageNumber);
+
+      return {
         pageNumber,
         getPagePreview: cachedPage.preview,
         getPageData: cachedPage.data,
@@ -205,7 +215,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     });
 
     setRenderedPages(renderedPages);
-  }, [pageRange.top, pageRange.bottom, pageCache, setRenderedPages]);
+  }, [pageRange.top, pageRange.bottom, pageCache, setRenderedPages, getCachedPage]);
 
   useEffect(() => {
     pageNumbersToPreload.forEach((pageNumber) => pageCache.getPage(pageNumber));

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -48,7 +48,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   rotation,
   scale
 }) => {
-  console.log(`scale inside VirtualScroll is ${scale}`);
   // Tweaked this and 2 seems to be a good amount on a regular monitor
   // The fewer pages we preload the faster the initial paint will be
   // Could possibly make it dynamic based on the visible of the container
@@ -76,7 +75,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   const [renderedPages, setRenderedPages] = useState<RenderedPage[]>([]);
 
   useEffect(() => {
-    console.log('containerSize is now ', containerSize);
     pageCache.setContainerSize(containerSize);
 
     if (containerSize !== 1000) {
@@ -197,8 +195,10 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
 
   useLayoutEffect(() => {
     if (viewport?.current && focusedFindHighlight) {
-      const topOfHighlightPage = (pageHeight * (focusedFindHighlight.pageNumber - 1));
-      viewport.current.scrollTop = topOfHighlightPage;
+      const highlightYPos = focusedFindHighlight.firstSpan?.y || 0;
+      const topOfHighlightPage = (pageHeight * (focusedFindHighlight.pageNumber - 1)) + highlightYPos;
+      
+      viewport.current.scrollTop = topOfHighlightPage;      
     }
   }, [pageHeight, focusedFindHighlight]);
   useLayoutEffect(() => {
@@ -229,8 +229,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   return (
     <div ref={viewport} className={styles.scrollContainer} onScroll={throttledSetPageRangeFromScrollPosition}>
       <div className={styles.pages} style={{ height: totalPages * pageHeight }}>
-        {renderedPages.map((page) => {
-          console.log('Re-rendering page: ', page);
+        {renderedPages.map((page) => {          
           return (<div
               key={page.pageNumber}
               style={{

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -80,7 +80,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
         pageCache.setContainerSize(containerSize);
         setRenderedPages((currentPages) => {
           const newPages: RenderedPage[] = currentPages.map((page) => {
-            const refreshedPage = pageCache.refreshPreview(
+            const refreshedPage = pageCache.reRenderPagePreview(
               page.pageNumber,
               page.getPagePreview,
               containerSize          
@@ -231,7 +231,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     if (cachedPage.previewContainerSize === pageCache.containerSize){
       return cachedPage;
     } else {
-      return pageCache.refreshPreview(pageNumber, cachedPage.preview, containerSize);
+      return pageCache.reRenderPagePreview(pageNumber, cachedPage.preview, containerSize);
     }
   }, [pageCache, containerSize]);
 

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -64,7 +64,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   const viewport = useRef<HTMLDivElement>(null);
 
   // TODO: move pageCache up?
-  const [pageCache] = useState(() => new PageCache(uri, searchQuery));
+  const [pageCache] = useState(() => new PageCache(uri, containerSize, searchQuery));
 
   // We have a second tier cache tied to the React component lifecycle for storing
   // rendered pages which allows us to swap out stale pages without flickering pages

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -1,8 +1,8 @@
-import { debounce, range } from 'lodash';
-import React, { FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { CachedPreview, CONTAINER_AND_MARGIN_SIZE, HighlightForSearchNavigation, PageData } from './model';
-import { Page } from './Page';
-import { PageCache } from './PageCache';
+import {debounce, range} from 'lodash';
+import React, {FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {CachedPreview, HighlightForSearchNavigation, PageData} from './model';
+import {Page} from './Page';
+import {PageCache} from './PageCache';
 import styles from './VirtualScroll.module.css';
 import throttle from 'lodash/throttle';
 
@@ -51,7 +51,15 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   // Could possibly make it dynamic based on the visible of the container
   const PRELOAD_PAGES = 2;
 
-  const pageHeight = CONTAINER_AND_MARGIN_SIZE;
+  // This must be the same as the margin CSS of .pageContainer
+  const MARGIN = 10;
+
+  const [containerSize, setContainerSize] = useState<number>(1000);
+  const [pageHeight, setPageHeight] = useState<number>(1000 + (MARGIN * 2));
+
+  useEffect(() => {
+    setPageHeight(containerSize + (MARGIN * 2));
+  }, [containerSize])
 
   const viewport = useRef<HTMLDivElement>(null);
 

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -93,27 +93,11 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
             };
           });
 
-          setLeftScrollToMiddle();
-
           return newPages;
         });
       }, 500),
     []
   );
-
-  const setLeftScrollToMiddle = () => {
-    // a 1 second delay is used to make sure the pdf page is rendered 
-    // and the new canvas element has been added    
-    setTimeout(() => {
-      if (viewport.current) {
-        const width = viewport.current.scrollWidth - viewport.current.offsetWidth;
-        if (width > 0) {          
-          viewport.current.scrollLeft = width / 2;
-        }
-      }
-
-    }, 1000);
-  };
 
   useEffect(() => {
     if (!isInitialRender.current && containerSize !== pageCache.containerSize) {
@@ -275,7 +259,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
               style={{
                 top: (page.pageNumber - 1) * pageHeight,
                 transform: `rotate(${rotation}deg)`,
-                left: 0,
+                left: `${scale > 1 ? '0' : ''}`,
               }}
               className={styles.pageContainer}
             >

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -72,7 +72,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   useEffect(() => {    
     pageCache.setContainerSize(containerSize);
 
-    if (containerSize !== 1000) {
       setRenderedPages((currentPages) => {
         const newPages: RenderedPage[] = currentPages.map((page) => {
           const refreshedPage = pageCache.refreshPreview(
@@ -89,7 +88,6 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
 
         return newPages;
       });
-    }
   }, [pageCache, containerSize]);
 
   useEffect(() => {

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -196,11 +196,13 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   useLayoutEffect(() => {
     if (viewport?.current && focusedFindHighlight) {
       const highlightYPos = focusedFindHighlight.firstSpan?.y || 0;
-      const topOfHighlightPage = (pageHeight * (focusedFindHighlight.pageNumber - 1)) + highlightYPos;
+
+      const topOfHighlightPage = (pageHeight * (focusedFindHighlight.pageNumber - 1)) + (highlightYPos * scale);    
       
-      viewport.current.scrollTop = topOfHighlightPage;      
+      viewport.current.scrollTop = topOfHighlightPage;
     }
-  }, [pageHeight, focusedFindHighlight]);
+  }, [pageHeight, focusedFindHighlight, scale]);
+
   useLayoutEffect(() => {
     if (viewport?.current && focusedSearchHighlight) {
       const topOfHighlightPage = (pageHeight * (focusedSearchHighlight.pageNumber - 1));
@@ -217,7 +219,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
         getPagePreview: cachedPage.preview,
         getPageData: cachedPage.data,
       };
-    });
+    });    
 
     setRenderedPages(renderedPages);
   }, [pageRange.top, pageRange.bottom, pageCache, setRenderedPages]);

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -185,10 +185,13 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
 
   useLayoutEffect(() => {
     if (viewport?.current && focusedSearchHighlight) {
-      const topOfHighlightPage = (pageHeight * (focusedSearchHighlight.pageNumber - 1));
+      const highlightYPos = focusedSearchHighlight.firstSpan?.y || 0;
+
+      const topOfHighlightPage = (pageHeight * (focusedSearchHighlight.pageNumber - 1)) + (highlightYPos * scale);
+      
       viewport.current.scrollTop = topOfHighlightPage;
     }
-  }, [pageHeight, focusedSearchHighlight]);
+  }, [pageHeight, focusedSearchHighlight, scale]);
 
   useEffect(() => {
     const renderedPages = range(pageRange.top, pageRange.bottom + 1).map((pageNumber) => {

--- a/frontend/src/js/components/PageViewer/model.ts
+++ b/frontend/src/js/components/PageViewer/model.ts
@@ -1,8 +1,5 @@
 import {PDFPageProxy} from "pdfjs-dist";
 
-// Hardcoded container sizes - should make these dynamic but that can wait for now...
-export const CONTAINER_SIZE = 1000;
-
 // Copy-pasta from the old reducer
 export type PageDimensions = {
   width: number;

--- a/frontend/src/js/components/PageViewer/model.ts
+++ b/frontend/src/js/components/PageViewer/model.ts
@@ -2,7 +2,6 @@ import {PDFPageProxy} from "pdfjs-dist";
 
 // Hardcoded container sizes - should make these dynamic but that can wait for now...
 export const CONTAINER_SIZE = 1000;
-export const CONTAINER_AND_MARGIN_SIZE = 1020;
 
 // Copy-pasta from the old reducer
 export type PageDimensions = {

--- a/frontend/src/js/util/LruCache.ts
+++ b/frontend/src/js/util/LruCache.ts
@@ -72,6 +72,7 @@ export class LruCache<K extends string | number, V> {
   };
 
   getAndForceRefresh = (k: K): V => {
+    console.log('getAndForceRefresh');
     const oldValue = this.entries[k];
     const newValue = this.onMiss(k);
 

--- a/frontend/src/js/util/LruCache.ts
+++ b/frontend/src/js/util/LruCache.ts
@@ -85,16 +85,11 @@ export class LruCache<K extends string | number, V> {
   };
 
   replace = (k: K, v: V): void => {
-    this.entries[k] = v;
-    this.bumpRecency(k);
-
-    if (this.recencyQueue.length > this.maxEntries) {
-      const evictedEntryKey = this.recencyQueue.shift();
-      if (evictedEntryKey) {
-        const evictedEntry = this.entries[evictedEntryKey];
-        this.onEvict(evictedEntryKey, evictedEntry);
-        delete this.entries[evictedEntryKey];
-      }
+    if (this.entries[k]) {
+      this.entries[k] = v;
+      this.bumpRecency(k);
+    } else {
+      this.addToCache(k, v);
     }
   }
 }

--- a/frontend/src/js/util/LruCache.ts
+++ b/frontend/src/js/util/LruCache.ts
@@ -72,7 +72,6 @@ export class LruCache<K extends string | number, V> {
   };
 
   getAndForceRefresh = (k: K): V => {
-    console.log('getAndForceRefresh');
     const oldValue = this.entries[k];
     const newValue = this.onMiss(k);
 

--- a/frontend/src/js/util/LruCache.ts
+++ b/frontend/src/js/util/LruCache.ts
@@ -89,6 +89,7 @@ export class LruCache<K extends string | number, V> {
       this.entries[k] = v;
       this.bumpRecency(k);
     } else {
+      console.warn(`Cannot replace cache for page ${k} that doesn't exist`);
       this.addToCache(k, v);
     }
   }

--- a/frontend/src/js/util/LruCache.ts
+++ b/frontend/src/js/util/LruCache.ts
@@ -85,6 +85,16 @@ export class LruCache<K extends string | number, V> {
   };
 
   replace = (k: K, v: V): void => {
-    this.addToCache(k, v);
+    this.entries[k] = v;
+    this.bumpRecency(k);
+
+    if (this.recencyQueue.length > this.maxEntries) {
+      const evictedEntryKey = this.recencyQueue.shift();
+      if (evictedEntryKey) {
+        const evictedEntry = this.entries[evictedEntryKey];
+        this.onEvict(evictedEntryKey, evictedEntry);
+        delete this.entries[evictedEntryKey];
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
This PR is a collaboration with @philmcmahon and @joelochlann 

## What does this change?
This PR updates the pdf viewer with zoom-in/zoom-out functionality. It adds a `scale` state to the `PageViewer` which is used to control the container size and as a result controls how big or small the page should be rendered.

A new function `refreshPreview` is added in the  in PageCache class, that is responsible to update the existing preview in cache by rendering a new page and replacing the current preview in cache with the new preview. This way we avoid calling the server to retrieve preview for the page number.

In PdfHelpers, a new function `updatePreview` is implemented and when given the preview and a container size it renders a new page for that container size.

In the Page component, the `pageHeight` added to the component properties, is used to trigger updating the existing canvas with the canvas of the new preview. 

Because we always render only 3 pages at a time (for performance reasons), it was made sure that when the page range changes, the page in the new range is re-rendered if the scale (container size) has changed.

Below is demoing a long vertical page pdf and how the zooming and finding works.

![multi-page-long](https://github.com/guardian/giant/assets/15894063/fe892589-3ff4-46ec-b798-91f94a6a38e2)

Below is demoing a landscape page pdf and how the zooming and finding works.
![landscape-zoom](https://github.com/guardian/giant/assets/15894063/70e4ba99-d188-4547-aa64-5e1d9b77ddc3)

Below is demoing how the zooming works with search query. 
![search-query](https://github.com/guardian/giant/assets/15894063/ceaf6e87-ac8a-4cf8-86b0-6d44d01dcea8)


TODO in future PRs:
- ~~When using the zoom with search query avaiable, it's responding more slowly. Also, some pages could be left un-rendered!!~~ this was resolved
- ~~when clicking on zoom for several times e.g. 3 time, the page is rendered 3 times. For optimisation, we could maybe cancel the previous rendering tasks!?~~ this is now resolved by using debounce & useMemo 
- We could give user control on the scale of zooming e.g. 100%, 150%, etc. 
- Currently a new function is created in PageCache in order to refresh and re-render the relevant pdf page based on the container size. But this is not fully optimised, because it's replacing the existing cache, while it's best if we could just add to the cache in case the old preview size is needed again in the future. Since this optimisation needs change in the cache logic, and needs extra care, I will create a ticket to do this work separately. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
