### PR TITLE
Adding retry in client for upload failures

### DIFF
--- a/backend/app/controllers/api/Collections.scala
+++ b/backend/app/controllers/api/Collections.scala
@@ -106,35 +106,38 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
   }
 
   def uploadIngestionFile(collection: String, ingestion: String) = ApiAction.attempt(parse.temporaryFile) { req =>
-    users.canSeeCollection(req.user.username, Uri(collection)).flatMap {
-      case true =>
-        (req.headers.get(CONTENT_LOCATION), req.headers.get("X-PFI-Upload-Id")) match {
-          case (Some(rawOriginalPath), Some(uploadId)) =>
-            val originalPath = URLDecoder.decode(rawOriginalPath, "UTF-8")
-            val lastModifiedTime = req.headers.get("X-PFI-Last-Modified")
-            val maybeWorkspaceContext = buildWorkspaceItemContext(req.headers)
+    {
+      Thread.sleep(60000)
+      users.canSeeCollection(req.user.username, Uri(collection)).flatMap {
+        case true =>
+          (req.headers.get(CONTENT_LOCATION), req.headers.get("X-PFI-Upload-Id")) match {
+            case (Some(rawOriginalPath), Some(uploadId)) =>
+              val originalPath = URLDecoder.decode(rawOriginalPath, "UTF-8")
+              val lastModifiedTime = req.headers.get("X-PFI-Last-Modified")
+              val maybeWorkspaceContext = buildWorkspaceItemContext(req.headers)
 
-            new IngestFile(
-              Uri(collection),
-              Uri(collection).chain(ingestion),
-              uploadId,
-              workspace = maybeWorkspaceContext,
-              req.user.username,
-              temporaryFilePath = req.body.path,
-              originalPath = Paths.get(originalPath),
-              lastModifiedTime,
-              manifest, esEvents, ingestionServices, annotations
-            ).process().map { result =>
-              Created(Json.toJson(result))
-            }
+              new IngestFile(
+                Uri(collection),
+                Uri(collection).chain(ingestion),
+                uploadId,
+                workspace = maybeWorkspaceContext,
+                req.user.username,
+                temporaryFilePath = req.body.path,
+                originalPath = Paths.get(originalPath),
+                lastModifiedTime,
+                manifest, esEvents, ingestionServices, annotations
+              ).process().map { result =>
+                Created(Json.toJson(result))
+              }
 
-          case _ =>
-            Attempt.Right(BadRequest(s"Missing $CONTENT_LOCATION or X-PFI-Upload-Id header"))
-        }
+            case _ =>
+              Attempt.Right(BadRequest(s"Missing $CONTENT_LOCATION or X-PFI-Upload-Id header"))
+          }
 
-      case false =>
-        // GitHub-style error - a thing exists but we can't see it so tell the user it doesn't exist
-        Attempt.Left(NotFoundFailure(s"$collection does not exist"))
+        case false =>
+          // GitHub-style error - a thing exists but we can't see it so tell the user it doesn't exist
+          Attempt.Left(NotFoundFailure(s"$collection does not exist"))
+      }
     }
   }
 

--- a/frontend/src/js/util/auth/authUploadWithProgress.ts
+++ b/frontend/src/js/util/auth/authUploadWithProgress.ts
@@ -18,9 +18,6 @@ export default function authUploadWithProgress(
     const retryInitialCount = 0;
 
     xhr.upload.onprogress = (e) => {
-      console.log(
-        `progress: loaded: ${e.loaded} from total: ${e.total} for url: ${url}`
-      );
       if (e.lengthComputable) {
         if (onProgress) {
           onProgress(e.loaded, e.total);
@@ -62,9 +59,6 @@ const processRequest = (
       resolve(xhr.response);
     } else {
       if (retryCount < RETRY_MAX_LIMIT) {
-        console.warn(
-          `retrying because request failed due to ${xhr.responseText} - status: ${xhr.status}, retry: ${retryCount} for url: ${url}`
-        );
         retryRequest(
           retryCount + 1,
           xhr,
@@ -85,7 +79,6 @@ const processRequest = (
     }
   };
 
-  console.log(`sending request: ${url} - retry: ${retryCount}`);
   sendRequest(xhr, url, file, path, uploadId, retryCount, workspace);
 };
 
@@ -102,7 +95,6 @@ const retryRequest = (
 ) => {
   const limit = retryCount ? Math.pow(2, retryCount - 1) * 1000 : 0;
   const pause = Math.random() * limit;
-  console.log(`delaying the next retry by ${pause / 1000} s - for url: ${url}`);
 
   setTimeout(() => {
     processRequest(

--- a/frontend/src/js/util/auth/authUploadWithProgress.ts
+++ b/frontend/src/js/util/auth/authUploadWithProgress.ts
@@ -1,57 +1,149 @@
-import store from './../store';
-import { handleResponseFromAuthRequest } from './handleResponseFromAuthRequest';
-import { WorkspaceUploadMetadata } from '../../components/Uploads/UploadFiles';
+import store from "./../store";
+import { handleResponseFromAuthRequest } from "./handleResponseFromAuthRequest";
+import { WorkspaceUploadMetadata } from "../../components/Uploads/UploadFiles";
 
-export type ProgressHandler = (loadedBytes: number, totalBytes: number) => void
+export type ProgressHandler = (loadedBytes: number, totalBytes: number) => void;
 
 export default function authUploadWithProgress(
-    url: string,
-    uploadId: string,
-    file: File,
-    path: string,
-    workspace?: WorkspaceUploadMetadata,
-    onProgress?: ProgressHandler
+  url: string,
+  uploadId: string,
+  file: File,
+  path: string,
+  workspace?: WorkspaceUploadMetadata,
+  onProgress?: ProgressHandler
 ) {
-    return new Promise((resolve, reject) => {
-        const xhr = new XMLHttpRequest();
-        xhr.upload.onprogress = (e) => {
-            if (e.lengthComputable) {
-                if(onProgress) {
-                    onProgress(e.loaded, e.total);
-                }
-            }
-        };
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    const retryInitialCount = 0;
 
-        xhr.onloadend = () => {
-            handleResponseFromAuthRequest(
-                xhr.status,
-                xhr.getResponseHeader('X-Offer-Authorization')
-            );
-            if (xhr.status >= 200 && xhr.status < 300) {
-                resolve(xhr.response);
-            } else {
-                reject(`${xhr.status} - ${xhr.responseText}`);
-            }
-        };
-
-        xhr.open('POST', url);
-
-        // this isn't nice, but I don't want to get bogged down typing all the redux stuff
-        const state = store.getState() as any;
-        xhr.setRequestHeader('Authorization', 'Bearer ' + state.auth.jwtToken);
-
-        xhr.setRequestHeader('Content-Type', file.type);
-        xhr.setRequestHeader('Content-Location', encodeURIComponent(path));
-        // TODO MRB: this is a lot of headers which is a bit silly and also potentially too 'custom'
-        // for the more intrusive firewalls of the world. Uploading as FormData is probably cleaner
-        // but we'd need to check it's still fine for big'ish files
-        xhr.setRequestHeader('X-PFI-Upload-Id', uploadId);
-        if(workspace) {
-            xhr.setRequestHeader('X-PFI-Workspace-Id', workspace.workspaceId);
-            xhr.setRequestHeader('X-PFI-Workspace-Parent-Node-Id', workspace.parentNodeId);
-            xhr.setRequestHeader('X-PFI-Workspace-Name', workspace.workspaceName);
+    xhr.upload.onprogress = (e) => {
+      console.log(`progress: loaded: ${e.loaded} from total: ${e.total}`);
+      if (e.lengthComputable) {
+        if (onProgress) {
+          onProgress(e.loaded, e.total);
         }
-        xhr.setRequestHeader('X-PFI-Last-Modified', file.lastModified.toString());
-        xhr.send(file);
-    });
+      }
+    };
+
+    processRequest(
+      xhr,
+      url,
+      file,
+      path,
+      uploadId,
+      retryInitialCount,
+      resolve,
+      reject,
+      workspace
+    );
+  });
 }
+
+const processRequest = (
+  xhr: XMLHttpRequest,
+  url: string,
+  file: File,
+  path: string,
+  uploadId: string,
+  retryCount: number,
+  resolve: (value: unknown) => void,
+  reject: (reason?: any) => void,
+  workspace?: WorkspaceUploadMetadata
+) => {
+  xhr.onloadend = () => {
+    handleResponseFromAuthRequest(
+      xhr.status,
+      xhr.getResponseHeader("X-Offer-Authorization")
+    );
+    if (xhr.status >= 200 && xhr.status < 300) {
+      resolve(xhr.response);
+    } else {
+      if (retryCount < 3) {
+        console.warn(
+          `retrying because request failed due to ${xhr.responseText} - status: ${xhr.status}, retry: ${retryCount}`
+        );
+        retryRequest(
+          retryCount,
+          xhr,
+          url,
+          file,
+          path,
+          uploadId,
+          resolve,
+          reject,
+          workspace
+        );
+      } else {
+        console.error(
+          `request failed due to ${xhr.responseText} - status: ${xhr.status}, retry: ${retryCount} `
+        );
+        reject(`${xhr.status} - ${xhr.responseText}`);
+      }
+    }
+  };
+
+  console.log(`sending request: ${url} - retry: ${retryCount}`);
+  sendRequest(xhr, url, file, path, uploadId, workspace);
+};
+
+const retryRequest = (
+  retryCount: number,
+  xhr: XMLHttpRequest,
+  url: string,
+  file: File,
+  path: string,
+  uploadId: string,
+  resolve: (value: unknown) => void,
+  reject: (reason?: any) => void,
+  workspace?: WorkspaceUploadMetadata
+) => {
+  const limit = retryCount ? Math.pow(2, retryCount - 1) * 1000 : 0;
+  const pause = Math.random() * limit;
+  console.log(`delaying the next retry by ${pause / 1000} s`);
+
+  setTimeout(() => {
+    processRequest(
+      xhr,
+      url,
+      file,
+      path,
+      uploadId,
+      retryCount + 1,
+      resolve,
+      reject,
+      workspace
+    );
+  }, pause);
+};
+
+const sendRequest = (
+  xhr: XMLHttpRequest,
+  url: string,
+  file: File,
+  path: string,
+  uploadId: string,
+  workspace?: WorkspaceUploadMetadata
+) => {
+  xhr.open("POST", url);
+
+  // this isn't nice, but I don't want to get bogged down typing all the redux stuff
+  const state = store.getState() as any;
+  xhr.setRequestHeader("Authorization", "Bearer " + state.auth.jwtToken);
+
+  xhr.setRequestHeader("Content-Type", file.type);
+  xhr.setRequestHeader("Content-Location", encodeURIComponent(path));
+  // TODO MRB: this is a lot of headers which is a bit silly and also potentially too 'custom'
+  // for the more intrusive firewalls of the world. Uploading as FormData is probably cleaner
+  // but we'd need to check it's still fine for big'ish files
+  xhr.setRequestHeader("X-PFI-Upload-Id", uploadId);
+  if (workspace) {
+    xhr.setRequestHeader("X-PFI-Workspace-Id", workspace.workspaceId);
+    xhr.setRequestHeader(
+      "X-PFI-Workspace-Parent-Node-Id",
+      workspace.parentNodeId
+    );
+    xhr.setRequestHeader("X-PFI-Workspace-Name", workspace.workspaceName);
+  }
+  xhr.setRequestHeader("X-PFI-Last-Modified", file.lastModified.toString());
+  xhr.send(file);
+};

--- a/frontend/src/js/util/auth/authUploadWithProgress.ts
+++ b/frontend/src/js/util/auth/authUploadWithProgress.ts
@@ -86,7 +86,7 @@ const processRequest = (
   };
 
   console.log(`sending request: ${url} - retry: ${retryCount}`);
-  sendRequest(xhr, url, file, path, uploadId, workspace);
+  sendRequest(xhr, url, file, path, uploadId, retryCount, workspace);
 };
 
 const retryRequest = (
@@ -125,6 +125,7 @@ const sendRequest = (
   file: File,
   path: string,
   uploadId: string,
+  retryCount: number,
   workspace?: WorkspaceUploadMetadata
 ) => {
   xhr.open("POST", url);
@@ -148,5 +149,6 @@ const sendRequest = (
     xhr.setRequestHeader("X-PFI-Workspace-Name", workspace.workspaceName);
   }
   xhr.setRequestHeader("X-PFI-Last-Modified", file.lastModified.toString());
+  xhr.setRequestHeader("X-PFI-Retry-Count", retryCount.toString());
   xhr.send(file);
 };

--- a/frontend/src/js/util/auth/authUploadWithProgress.ts
+++ b/frontend/src/js/util/auth/authUploadWithProgress.ts
@@ -3,6 +3,7 @@ import { handleResponseFromAuthRequest } from "./handleResponseFromAuthRequest";
 import { WorkspaceUploadMetadata } from "../../components/Uploads/UploadFiles";
 
 export type ProgressHandler = (loadedBytes: number, totalBytes: number) => void;
+const RETRY_MAX_LIMIT = 3;
 
 export default function authUploadWithProgress(
   url: string,
@@ -60,12 +61,12 @@ const processRequest = (
     if (xhr.status >= 200 && xhr.status < 300) {
       resolve(xhr.response);
     } else {
-      if (retryCount < 3) {
+      if (retryCount < RETRY_MAX_LIMIT) {
         console.warn(
           `retrying because request failed due to ${xhr.responseText} - status: ${xhr.status}, retry: ${retryCount} for url: ${url}`
         );
         retryRequest(
-          retryCount,
+          retryCount + 1,
           xhr,
           url,
           file,
@@ -110,7 +111,7 @@ const retryRequest = (
       file,
       path,
       uploadId,
-      retryCount + 1,
+      retryCount,
       resolve,
       reject,
       workspace

--- a/frontend/src/js/util/auth/authUploadWithProgress.ts
+++ b/frontend/src/js/util/auth/authUploadWithProgress.ts
@@ -17,7 +17,9 @@ export default function authUploadWithProgress(
     const retryInitialCount = 0;
 
     xhr.upload.onprogress = (e) => {
-      console.log(`progress: loaded: ${e.loaded} from total: ${e.total}`);
+      console.log(
+        `progress: loaded: ${e.loaded} from total: ${e.total} for url: ${url}`
+      );
       if (e.lengthComputable) {
         if (onProgress) {
           onProgress(e.loaded, e.total);
@@ -60,7 +62,7 @@ const processRequest = (
     } else {
       if (retryCount < 3) {
         console.warn(
-          `retrying because request failed due to ${xhr.responseText} - status: ${xhr.status}, retry: ${retryCount}`
+          `retrying because request failed due to ${xhr.responseText} - status: ${xhr.status}, retry: ${retryCount} for url: ${url}`
         );
         retryRequest(
           retryCount,
@@ -75,7 +77,7 @@ const processRequest = (
         );
       } else {
         console.error(
-          `request failed due to ${xhr.responseText} - status: ${xhr.status}, retry: ${retryCount} `
+          `request failed due to ${xhr.responseText} - status: ${xhr.status}, retry: ${retryCount} for url: ${url}`
         );
         reject(`${xhr.status} - ${xhr.responseText}`);
       }
@@ -99,7 +101,7 @@ const retryRequest = (
 ) => {
   const limit = retryCount ? Math.pow(2, retryCount - 1) * 1000 : 0;
   const pause = Math.random() * limit;
-  console.log(`delaying the next retry by ${pause / 1000} s`);
+  console.log(`delaying the next retry by ${pause / 1000} s - for url: ${url}`);
 
   setTimeout(() => {
     processRequest(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a retry (up to 3 retries) on file upload requests if they fail for any reason.  

### Delay between retries
There's a delay (gap) between the failure time and the retry. This delay starts at 1 second * random number between 0-1, and it increases on every retry. This increase is called **exponential backoff** which is a recommended strategy on retry mechanism because the more retries that fail, there's bigger chance that we're dealing with an outage that could take time, so we don't want to put too keep calling the server if it's experiencing an outage that could last longer. 

### Random time factor in delay between retries
There's also a randomness added to the backoff time in order to ensure that in the time of outage, if several clients are calling the server and encountering the error at the same time, they won't all re-send the request the server at the same time. 

Some client side logging have been added just for troubleshooting, they will be removed. 