### PR TITLE
Fix observability dashboard when no extractor events

### DIFF
--- a/backend/app/services/observability/Models.scala
+++ b/backend/app/services/observability/Models.scala
@@ -91,7 +91,7 @@ object EventMetadata {
 }
 
 case class IngestionEvent(
-                           metaData: EventMetadata,
+                           metadata: EventMetadata,
                            eventType: IngestionEventType,
                            status: EventStatus = EventStatus.Success,
                            details: Option[EventDetails] = None
@@ -143,9 +143,9 @@ object ExtractorStatus {
 }
 
 case class BlobStatus(
-                       metaData: EventMetadata,
+                       metadata: EventMetadata,
                        paths: List[String],
-                       fileSize: Long,
+                       fileSize: Option[Long],
                        workspaceName: Option[String],
                        ingestStart: DateTime,
                        mostRecentEvent: DateTime,

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -70,8 +70,8 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
                 details,
                 event_time
             ) VALUES (
-                ${event.metaData.blobId},
-                ${event.metaData.ingestId},
+                ${event.metadata.blobId},
+                ${event.metadata.ingestId},
                 ${event.eventType.toString()},
                 ${event.status.toString()},
                 $detailsJson::JSONB,
@@ -82,7 +82,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
             case Failure(exception) =>
                 logger.warn(s"""
           An exception occurred while inserting ingestion event
-          blobId: ${event.metaData.blobId}, ingestId: ${event.metaData.ingestId} eventType: ${event.eventType.toString()}
+          blobId: ${event.metadata.blobId}, ingestId: ${event.metadata.ingestId} eventType: ${event.eventType.toString()}
           exception: ${exception.getMessage()}"""
                 )
                 Left(PostgresWriteFailure(exception))
@@ -161,7 +161,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
                         rs.string("ingest_id")
                     ),
                     rs.array("paths").getArray().asInstanceOf[Array[String]].toList,
-                    rs.long("fileSize"),
+                    rs.longOpt("fileSize"),
                     rs.stringOpt("workspaceName"),
                     new DateTime(rs.dateTime("ingest_start").toInstant.toEpochMilli, DateTimeZone.UTC),
                     new DateTime(rs.dateTime("most_recent_event").toInstant.toEpochMilli, DateTimeZone.UTC),

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -146,7 +146,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
                 MIN(event_time) AS ingest_start,
                 Max(event_time) AS most_recent_event,
                 ARRAY_AGG(details -> 'errors') as errors,
-                (ARRAY_AGG(details ->> 'workspaceName'))[1] AS workspace_name
+                (ARRAY_AGG(details ->> 'workspaceName')  FILTER (WHERE details ->> 'workspaceName' IS NOT NULL))[1] as workspace_name
               FROM ingestion_events
               WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId}
               GROUP BY 1,2

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -106,20 +106,30 @@ const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
         field: 'extractorStatuses',
         name: 'Extractors',
         render: (statuses: ExtractorStatus[]) => {
-            return <ul>
+            return statuses.length > 0 ? (<ul>
                 {statuses.map(status => {
                     const mostRecent = status.statusUpdates.length > 0 ? status.statusUpdates[status.statusUpdates.length - 1] : undefined
-                    const allUpdatesTooltip = <p><b>All {status.extractorType} events</b> <br /> {status.statusUpdates.map(u => <>{`${moment(u.eventTime).format("DD MMM HH:mm:ss")} ${u.status}`}<br/></>)}</p>
-                    return <li><EuiFlexGroup>
+                    const statusUpdateStrings = status.statusUpdates.map(u => `${moment(u.eventTime).format("DD MMM HH:mm:ss")} ${u.status}`)
+                    const allUpdatesTooltip = status.statusUpdates.length > 0 ? <p>
+                        <b>All {status.extractorType} events</b> <br />
+                        <ul>
+                            {statusUpdateStrings.map(s => <li key={s}>{s}</li>)}
+                        </ul>
+                    </p> : <p>No events so far</p>
+                    return <li key={status.extractorType}><EuiFlexGroup>
                         <EuiFlexItem>{status.extractorType.replace("Extractor", "")}</EuiFlexItem>
                         <EuiFlexItem grow={false}>
-                            <EuiToolTip content={allUpdatesTooltip}>
-                                {mostRecent?.status && <EuiBadge color={statusToColor(mostRecent.status)}>{mostRecent.status} ({moment(mostRecent.eventTime).format("HH:mm:ss")  })</EuiBadge>}
-                            </EuiToolTip>
+                            {mostRecent?.status ?
+                                (<EuiToolTip content = {allUpdatesTooltip}>
+                                    <EuiBadge color={statusToColor(mostRecent.status)}>
+                                        {mostRecent.status} ({moment(mostRecent.eventTime).format("HH:mm:ss")  })
+                                    </EuiBadge>
+                            </EuiToolTip>) : <>No updates</>
+                            }
                         </EuiFlexItem>
                     </EuiFlexGroup></li>
             })}
-            </ul>
+            </ul>) : <></>
 
         },
         width: "300"
@@ -185,18 +195,18 @@ export function IngestionEvents(
     return (
         <>
         {tableData.map((t: IngestionTable) =>
-            <>
+            <div key={t.title}>
             <EuiSpacer size={"m"}/>
             <h1>{t.title}</h1>
             <EuiInMemoryTable
                 tableCaption="ingestion events"
                 items={t.blobs}
-                itemId="metadata.blobId"
-                loading={blobs === undefined}
+                itemId={(row: BlobStatus) => `${row.metadata.ingestUri}-${row.metadata.blobId}`}
+                loading={t.blobs === undefined}
                 columns={columns}
                 sorting={true}
             />
-            </>
+            </div>
         )}
         </>
     )

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -63,6 +63,16 @@ const getBlobStatus = (statuses: ExtractorStatus[]) => {
     return failures.length > 0 ? blobStatusIcons.completeWithErrors : inProgress.length > 0 ? blobStatusIcons.inProgress : blobStatusIcons.complete
 }
 
+const extractorStatusTooltip = (status: ExtractorStatus) => {
+    const statusUpdateStrings = status.statusUpdates.map(u => `${moment(u.eventTime).format("DD MMM HH:mm:ss")} ${u.status}`)
+    return status.statusUpdates.length > 0 ? <>
+        <b>All {status.extractorType} events</b> <br />
+        <ul>
+            {statusUpdateStrings.map(s => <li key={s}>{s}</li>)}
+        </ul>
+    </> : "No events so far"
+}
+
 const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
     {
         field: 'extractorStatuses',
@@ -109,18 +119,11 @@ const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
             return statuses.length > 0 ? (<ul>
                 {statuses.map(status => {
                     const mostRecent = status.statusUpdates.length > 0 ? status.statusUpdates[status.statusUpdates.length - 1] : undefined
-                    const statusUpdateStrings = status.statusUpdates.map(u => `${moment(u.eventTime).format("DD MMM HH:mm:ss")} ${u.status}`)
-                    const allUpdatesTooltip = status.statusUpdates.length > 0 ? <p>
-                        <b>All {status.extractorType} events</b> <br />
-                        <ul>
-                            {statusUpdateStrings.map(s => <li key={s}>{s}</li>)}
-                        </ul>
-                    </p> : <p>No events so far</p>
                     return <li key={status.extractorType}><EuiFlexGroup>
                         <EuiFlexItem>{status.extractorType.replace("Extractor", "")}</EuiFlexItem>
                         <EuiFlexItem grow={false}>
                             {mostRecent?.status ?
-                                (<EuiToolTip content = {allUpdatesTooltip}>
+                                (<EuiToolTip content = {extractorStatusTooltip(status)}>
                                     <EuiBadge color={statusToColor(mostRecent.status)}>
                                         {mostRecent.status} ({moment(mostRecent.eventTime).format("HH:mm:ss")  })
                                     </EuiBadge>

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -17,7 +17,7 @@ type Metadata = {
 type BlobStatus =  {
     metadata: Metadata;
     paths: string[];
-    fileSize: number;
+    fileSize?: number;
     ingestStart: Date;
     mostRecentEvent: Date;
     extractorStatuses: ExtractorStatus[];
@@ -70,7 +70,6 @@ const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
         render: (statuses: ExtractorStatus[]) => {
             return getBlobStatus(statuses)
         }
-
     },
     {
         field: 'paths',


### PR DESCRIPTION
## What does this change?
There is currently a bug the observability dashboard where if a file has been hashed but no extractor events have started then the whole dashboard crashes. This resolves that by adding a few ternaries.

At the same time I discovered an issue where fileSize isn't defined - currently in our postgres query there is no default, it can just be NULL. So I made it optional.

This PR also adds a 'key' property to all our lists/repeated divs to avoid the [unique key prop warning](https://sentry.io/answers/unique-key-prop/).

At the same time I fixed our itemId in the EUI table to include the ingest ID (no user facing benefit here, just seems more accurate).

There's also silly pedantic change to rename metaData to metadata.

## How to test
Tested on playground, it appears to fix the main bug described above.

## How can we measure success?
Fewer blank and screens and client side errors on the ingest dashboard.