### PR TITLE
Purge observability events older than 2 weeks

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -96,7 +96,7 @@ class AppComponents(context: Context, config: Config)
     val blobStorage = S3ObjectStorage(s3Client, config.s3.buckets.collections).valueOr(failure => throw new Exception(failure.msg))
 
     val postgresClient = config.postgres match {
-      case Some(postgresConfig) =>  new PostgresClientImpl(postgresConfig)
+      case Some(postgresConfig) =>  new PostgresClientImpl(postgresConfig, eventRetentionDays = 14)
       case None =>
         logger.warn("Postgres config not found, using dummy postgres client!")
         new PostgresClientDoNothing

--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -96,7 +96,7 @@ class AppComponents(context: Context, config: Config)
     val blobStorage = S3ObjectStorage(s3Client, config.s3.buckets.collections).valueOr(failure => throw new Exception(failure.msg))
 
     val postgresClient = config.postgres match {
-      case Some(postgresConfig) =>  new PostgresClientImpl(postgresConfig, eventRetentionDays = 14)
+      case Some(postgresConfig) =>  new PostgresClientImpl(postgresConfig, eventRetentionDays = 28)
       case None =>
         logger.warn("Postgres config not found, using dummy postgres client!")
         new PostgresClientDoNothing

--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -33,7 +33,7 @@ import services.events.ElasticsearchEvents
 import services.index.{ElasticsearchPages, ElasticsearchResources, Pages2}
 import services.ingestion.IngestionServices
 import services.manifest.Neo4jManifest
-import services.observability.{ObservabilityCleaner, PostgresClientDoNothing, PostgresClientImpl}
+import services.observability.{ObservabilityPurger, PostgresClientDoNothing, PostgresClientImpl}
 import services.previewing.PreviewService
 import services.table.ElasticsearchTable
 import services.users.Neo4jUserManagement
@@ -228,8 +228,8 @@ class AppComponents(context: Context, config: Config)
       workerControl.start(pekkoActorSystem.scheduler)(workerExecutionContext)
       applicationLifecycle.addStopHook(() => workerControl.stop())
     }
-    val observabilityCleaner = new ObservabilityCleaner(pekkoActorSystem, postgresClient)
-    observabilityCleaner.start()
+    val observabilityPurger = new ObservabilityPurger(pekkoActorSystem, postgresClient)
+    observabilityPurger.start()
 
     // Router
     new Routes(

--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -33,7 +33,7 @@ import services.events.ElasticsearchEvents
 import services.index.{ElasticsearchPages, ElasticsearchResources, Pages2}
 import services.ingestion.IngestionServices
 import services.manifest.Neo4jManifest
-import services.observability.{PostgresClientDoNothing, PostgresClientImpl}
+import services.observability.{ObservabilityCleaner, PostgresClientDoNothing, PostgresClientImpl}
 import services.previewing.PreviewService
 import services.table.ElasticsearchTable
 import services.users.Neo4jUserManagement
@@ -228,6 +228,8 @@ class AppComponents(context: Context, config: Config)
       workerControl.start(pekkoActorSystem.scheduler)(workerExecutionContext)
       applicationLifecycle.addStopHook(() => workerControl.stop())
     }
+    val observabilityCleaner = new ObservabilityCleaner(pekkoActorSystem, postgresClient)
+    observabilityCleaner.start()
 
     // Router
     new Routes(

--- a/backend/app/services/observability/ObservabilityCleaner.scala
+++ b/backend/app/services/observability/ObservabilityCleaner.scala
@@ -1,0 +1,42 @@
+package services.observability
+
+import org.apache.pekko.actor.{ActorSystem, Cancellable}
+import utils.Logging
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Observability events are only needed for debugging/verification purposes. This service makes sure observability data
+  * is deleted after a certain time period
+  */
+class ObservabilityCleaner(actorSystem: ActorSystem, postgresClient: PostgresClient)(implicit ec: ExecutionContext) extends Logging {
+  var cancellable:Option[Cancellable] = None
+
+  def start(): Unit = {
+    cancellable = Some(actorSystem.scheduler.scheduleOnce(Duration(10, TimeUnit.SECONDS)) { go() })
+  }
+
+  def stop(): Future[Unit] = {
+    Future.successful(cancellable.foreach(_.cancel()))
+  }
+
+  def go(): Unit = {
+    logger.info("Starting postgres events cleaner")
+    postgresClient.cleanOldEvents() match {
+      case Right(rowsCleaned) =>
+        logger.info(s"Cleaned ${rowsCleaned} ingestion events from postgres")
+      case Left(failure) =>
+        logger.error(s"Failed to clean ingestion events", failure.toThrowable)
+    }
+    postgresClient.cleanOldBlobMetadata() match {
+      case Right(rowsCleaned) =>
+        logger.info(s"Cleaned ${rowsCleaned} blob metadata rows from postgres")
+      case Left(failure) =>
+        logger.error(s"Failed to clean blob metadata events", failure.toThrowable)
+    }
+    cancellable = Some(actorSystem.scheduler.scheduleOnce(Duration(30, TimeUnit.MINUTES)) { go() })
+  }
+
+}

--- a/backend/app/services/observability/ObservabilityPurger.scala
+++ b/backend/app/services/observability/ObservabilityPurger.scala
@@ -24,7 +24,7 @@ class ObservabilityPurger(actorSystem: ActorSystem, postgresClient: PostgresClie
 
   def go(): Unit = {
     logger.info("Starting postgres events cleaner")
-    postgresClient.deleteOldEvents() match {
+    postgresClient.anonymiseOldEvents() match {
       case Right(rowsCleaned) =>
         logger.info(s"Purged ${rowsCleaned} ingestion events from postgres")
       case Left(failure) =>

--- a/backend/app/services/observability/ObservabilityPurger.scala
+++ b/backend/app/services/observability/ObservabilityPurger.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * Observability events are only needed for debugging/verification purposes. This service makes sure observability data
   * is deleted after a certain time period
   */
-class ObservabilityCleaner(actorSystem: ActorSystem, postgresClient: PostgresClient)(implicit ec: ExecutionContext) extends Logging {
+class ObservabilityPurger(actorSystem: ActorSystem, postgresClient: PostgresClient)(implicit ec: ExecutionContext) extends Logging {
   var cancellable:Option[Cancellable] = None
 
   def start(): Unit = {
@@ -24,13 +24,13 @@ class ObservabilityCleaner(actorSystem: ActorSystem, postgresClient: PostgresCli
 
   def go(): Unit = {
     logger.info("Starting postgres events cleaner")
-    postgresClient.cleanOldEvents() match {
+    postgresClient.deleteOldEvents() match {
       case Right(rowsCleaned) =>
         logger.info(s"Cleaned ${rowsCleaned} ingestion events from postgres")
       case Left(failure) =>
         logger.error(s"Failed to clean ingestion events", failure.toThrowable)
     }
-    postgresClient.cleanOldBlobMetadata() match {
+    postgresClient.deleteOldBlobMetadata() match {
       case Right(rowsCleaned) =>
         logger.info(s"Cleaned ${rowsCleaned} blob metadata rows from postgres")
       case Left(failure) =>

--- a/backend/app/services/observability/ObservabilityPurger.scala
+++ b/backend/app/services/observability/ObservabilityPurger.scala
@@ -26,15 +26,15 @@ class ObservabilityPurger(actorSystem: ActorSystem, postgresClient: PostgresClie
     logger.info("Starting postgres events cleaner")
     postgresClient.deleteOldEvents() match {
       case Right(rowsCleaned) =>
-        logger.info(s"Cleaned ${rowsCleaned} ingestion events from postgres")
+        logger.info(s"Purged ${rowsCleaned} ingestion events from postgres")
       case Left(failure) =>
-        logger.error(s"Failed to clean ingestion events", failure.toThrowable)
+        logger.error(s"Failed to purge ingestion events", failure.toThrowable)
     }
     postgresClient.deleteOldBlobMetadata() match {
       case Right(rowsCleaned) =>
-        logger.info(s"Cleaned ${rowsCleaned} blob metadata rows from postgres")
+        logger.info(s"Purged ${rowsCleaned} blob metadata rows from postgres")
       case Left(failure) =>
-        logger.error(s"Failed to clean blob metadata events", failure.toThrowable)
+        logger.error(s"Failed to purge blob metadata events", failure.toThrowable)
     }
     cancellable = Some(actorSystem.scheduler.scheduleOnce(Duration(30, TimeUnit.MINUTES)) { go() })
   }

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -12,9 +12,9 @@ trait PostgresClient {
     def insertEvent(event: IngestionEvent): Either[GiantFailure, Unit]
     def insertMetadata(metaData: BlobMetadata): Either[GiantFailure, Unit]
     def getEvents (ingestId: String, ingestIdIsPrefix: Boolean): Either[GiantFailure, List[BlobStatus]]
-  def cleanOldEvents(): Either[GiantFailure, Long]
+  def deleteOldEvents(): Either[GiantFailure, Long]
 
-  def cleanOldBlobMetadata(): Either[GiantFailure, Long]
+  def deleteOldBlobMetadata(): Either[GiantFailure, Long]
 }
 
 class PostgresClientDoNothing extends PostgresClient {
@@ -24,9 +24,9 @@ class PostgresClientDoNothing extends PostgresClient {
 
     override def getEvents (ingestId: String, ingestIdIsPrefix: Boolean): Either[GiantFailure, List[BlobStatus]] = Right(List())
 
-    override def cleanOldEvents(): Either[GiantFailure, Long] = Right(0)
+    override def deleteOldEvents(): Either[GiantFailure, Long] = Right(0)
 
-    override def cleanOldBlobMetadata(): Either[GiantFailure, Long] = Right(0)
+    override def deleteOldBlobMetadata(): Either[GiantFailure, Long] = Right(0)
 }
 
 class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient with Logging {
@@ -193,7 +193,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
         }
     }
 
-  override def cleanOldEvents(): Either[GiantFailure, Long] = {
+  override def deleteOldEvents(): Either[GiantFailure, Long] = {
     Try {
       sql"""
         DELETE FROM ingestion_events WHERE event_time < (now() - interval '14 days')
@@ -206,7 +206,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
     }
   }
 
-  override def cleanOldBlobMetadata(): Either[GiantFailure, Long] = {
+  override def deleteOldBlobMetadata(): Either[GiantFailure, Long] = {
     Try {
       sql"""
         DELETE FROM blob_metadata WHERE insert_time < (now() - interval '14 days')

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -29,7 +29,7 @@ class PostgresClientDoNothing extends PostgresClient {
     override def deleteOldBlobMetadata(): Either[GiantFailure, Long] = Right(0)
 }
 
-class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient with Logging {
+class PostgresClientImpl(postgresConfig: PostgresConfig, eventRetentionDays: Int) extends PostgresClient with Logging {
     val dbHost = s"jdbc:postgresql://${postgresConfig.host}:${postgresConfig.port}/giant"
     // initialize JDBC driver & connection pool
     Class.forName("org.postgresql.Driver")
@@ -196,7 +196,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
   override def deleteOldEvents(): Either[GiantFailure, Long] = {
     Try {
       sql"""
-        DELETE FROM ingestion_events WHERE event_time < (now() - interval '14 days')
+        DELETE FROM ingestion_events WHERE event_time < (now() - interval '${eventRetentionDays} days')
            """.executeUpdate().apply()
 
     } match {
@@ -209,7 +209,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
   override def deleteOldBlobMetadata(): Either[GiantFailure, Long] = {
     Try {
       sql"""
-        DELETE FROM blob_metadata WHERE insert_time < (now() - interval '14 days')
+        DELETE FROM blob_metadata WHERE insert_time < (now() - interval '${eventRetentionDays} days')
            """.executeUpdate().apply()
 
     } match {

--- a/backend/test/test/TestPostgresClient.scala
+++ b/backend/test/test/TestPostgresClient.scala
@@ -10,7 +10,7 @@ class TestPostgresClient extends PostgresClient{
 
   def getEvents (ingestId: String, ingestIdIsPrefix: Boolean): Either[Failure, List[BlobStatus]] = Right(List())
 
-  override def cleanOldEvents(): Either[Failure, Long] = Right(0)
+  override def deleteOldEvents(): Either[Failure, Long] = Right(0)
 
-  override def cleanOldBlobMetadata(): Either[Failure, Long] = Right(0)
+  override def deleteOldBlobMetadata(): Either[Failure, Long] = Right(0)
 }

--- a/backend/test/test/TestPostgresClient.scala
+++ b/backend/test/test/TestPostgresClient.scala
@@ -10,7 +10,7 @@ class TestPostgresClient extends PostgresClient{
 
   def getEvents (ingestId: String, ingestIdIsPrefix: Boolean): Either[Failure, List[BlobStatus]] = Right(List())
 
-  override def deleteOldEvents(): Either[Failure, Long] = Right(0)
+  override def anonymiseOldEvents(): Either[Failure, Long] = Right(0)
 
   override def deleteOldBlobMetadata(): Either[Failure, Long] = Right(0)
 }

--- a/backend/test/test/TestPostgresClient.scala
+++ b/backend/test/test/TestPostgresClient.scala
@@ -9,4 +9,8 @@ class TestPostgresClient extends PostgresClient{
   override def insertMetadata(metaData: BlobMetadata): Either[Failure, Unit] = Right(())
 
   def getEvents (ingestId: String, ingestIdIsPrefix: Boolean): Either[Failure, List[BlobStatus]] = Right(List())
+
+  override def cleanOldEvents(): Either[Failure, Long] = Right(0)
+
+  override def cleanOldBlobMetadata(): Either[Failure, Long] = Right(0)
 }

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -58,7 +58,13 @@ const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
         truncateText: true,
         render: (paths: string[]) =>
             // throw away everything after last / to get the filename from a path
-            paths.map(p => p.split("/").slice(-1)).join("\n")
+            paths.length > 0 ? paths.map(p => p.split("/").slice(-1)).join("\n") : <>unknown<EuiIconTip
+                aria-label="Info"
+                size="m"
+                type="iInCircle"
+                color="primary"
+                content={"Filenames are removed after 28 days"}
+            /></>
     },
     {
         field: 'paths',


### PR DESCRIPTION
## What does this change?
This introduces a 'purge' job to delete the observability events initially introduced in https://github.com/guardian/giant/pull/117 after 2 weeks. These events are intended to help debug/understand what's happened with an ingest, but are of limited or no utility otherwise, so there's no reason to keep them long term.

## How to test
Events older than 14 days should be automatically deleted. We don't actually have any events older than 14 days at the moment though, so this is what I propose to check the feature is working:
 - deploy to playground
 - search the logs for the word 'purged' - should include the number of events purged **it should be 0**
 - Deploy to PROD if happy with the above
 - (in a few weeks) check again - some events should have been deleted at some point. Also check the DB - there should be no events older than two weeks, but events within the last 2 weeks should be unaffected

## How can we measure success?
Not keeping unnecessary data

## Have we considered potential risks?
If I've done something wrong here we could accidentally delete all our observability data. In this scenario we would have to re-run ingests to get the data back.
