### PR TITLE
Store current workspace, collection, and ingestion in URL of observability dashboards

### DIFF
--- a/frontend/src/js/actions/ingestEvents/updateCurrentWorkspace.ts
+++ b/frontend/src/js/actions/ingestEvents/updateCurrentWorkspace.ts
@@ -1,0 +1,8 @@
+import { UrlParamsActionType } from "../../types/redux/GiantActions"
+
+export function updateCurrentWorkspace(currentWorkspace: string) {
+    return {
+        type: UrlParamsActionType.SET_INGESTION_EVENTS_WORKSPACE_IN_URL,
+        currentWorkspace,
+    }
+}

--- a/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
@@ -54,9 +54,12 @@ export function AllIngestionEvents(
                 value: ingestion.path,
                 text: ingestion.display
             })).concat([{value: "all", text: "All ingestions"}]))
-            updateCurrentIngestion(undefined)
+            console.log("ingestions", sc?.ingestions)
+            if (sc?.ingestions.find((i) => i.display === currentIngestion) === undefined){
+                updateCurrentIngestion(undefined)
+            }
         }
-    }, [currentCollection, collections, updateCurrentIngestion])
+    }, [currentCollection, collections, currentIngestion, updateCurrentIngestion])
 
     const toggleFilterButtons = [
         { id: FilterState.All, label: 'all' },

--- a/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
@@ -35,7 +35,6 @@ export function AllIngestionEvents(
     }) {
 
     const [ingestOptions, setIngestOptions] = useState<EuiSelectOption[]>([])
-    const [ingestId, setIngestId] = useState<string>("all")
     const [toggleIdSelected, setToggleIdSelected] = useState<FilterState>(FilterState.All);
 
     useEffect(() => {
@@ -54,8 +53,7 @@ export function AllIngestionEvents(
                 value: ingestion.path,
                 text: ingestion.display
             })).concat([{value: "all", text: "All ingestions"}]))
-            console.log("ingestions", sc?.ingestions)
-            if (sc?.ingestions.find((i) => i.display === currentIngestion) === undefined){
+            if (sc?.ingestions && sc?.ingestions.find((i) => i.display === currentIngestion) === undefined){
                 updateCurrentIngestion(undefined)
             }
         }
@@ -88,8 +86,8 @@ export function AllIngestionEvents(
                         <EuiFlexItem grow={false}>
                         <EuiFormControlLayout  className={styles.dropdown} prepend={<EuiFormLabel htmlFor={"ingest-picker"}>Ingest</EuiFormLabel>}>
                             <EuiSelect
-                                value={ingestId}
-                                onChange={(e) => setIngestId(e.target.value)} options={ingestOptions}>
+                                value={currentIngestion}
+                                onChange={(e) => updateCurrentIngestion(e.target.value)} options={ingestOptions}>
                                 id={"ingest-picker"}
 
                             </EuiSelect>

--- a/frontend/src/js/components/IngestionEvents/MyUploads.tsx
+++ b/frontend/src/js/components/IngestionEvents/MyUploads.tsx
@@ -18,21 +18,27 @@ import {EuiFormControlLayout} from "@elastic/eui";
 import {EuiFormLabel} from "@elastic/eui";
 import { css } from "@emotion/react";
 import { FilterState } from "./types";
+import { updateCurrentWorkspace } from "../../actions/ingestEvents/updateCurrentWorkspace";
+
 
 function MyUploads(
-    {getCollections, getWorkspacesMetadata, collections, currentUser, workspacesMetadata}: {
+    {getCollections, getWorkspacesMetadata, updateCurrentWorkspace, collections, currentUser, workspacesMetadata, currentWorkspace = "all"}: {
         getCollections: (dispatch: any) => any,
         getWorkspacesMetadata: (dispatch: any) => any,
+        updateCurrentWorkspace: (dispatch: any) => any,
         collections: Collection[],
         currentUser?: PartialUser,
         workspacesMetadata: WorkspaceMetadata[],
+        currentWorkspace?: string
           }) {
 
     const [defaultCollection, setDefaultCollection] = useState<Collection>()
 
-    const [selectedWorkspace, setSelectedWorkspace] = useState<string>("all");
+    const [toggleIdSelected, setToggleIdSelected] = useState<FilterState>(FilterState.All);
 
-    const [toggleIdSelected, setToggleIdSelected] = useState<FilterState>(FilterState.All);      
+    useEffect(() => {
+        updateCurrentWorkspace(currentWorkspace)
+    }, [currentWorkspace, updateCurrentWorkspace])
 
     useEffect(() => {
         getCollections({})
@@ -41,7 +47,9 @@ function MyUploads(
 
     useEffect(() => {
         if (currentUser && collections.length > 0) {
-            setDefaultCollection(getDefaultCollection(currentUser.username, collections))
+            setDefaultCollection(
+                getDefaultCollection(currentUser.username, collections)
+            )
         }
     }, [collections, currentUser])
 
@@ -60,30 +68,30 @@ function MyUploads(
                 <EuiFlexGroup>
                     <EuiFormControlLayout prepend={<EuiFormLabel htmlFor={"workspace-picker"}>Workspace</EuiFormLabel>}>
                         <EuiSelect
-                            value={selectedWorkspace}
-                            onChange={(e) => setSelectedWorkspace(e.target.value)}
+                            value={currentWorkspace}
+                            onChange={(e) => updateCurrentWorkspace(e.target.value)}
                             id={"workspace-picker"}
                             options={
-                                [{value: "all", text: "All workspaces"}].concat(
-                                    workspacesMetadata.map((w: WorkspaceMetadata) =>
-                                        ({value: w.name, text: w.name}))
-                                )
-                            }>
-                        </EuiSelect>                     
+                            [{value: "all", text: "All workspaces"}].concat(
+                                workspacesMetadata.map((w: WorkspaceMetadata) =>
+                                    ({value: w.name, text: w.name}))
+                            )
+                        }>
+                        </EuiSelect>
                     </EuiFormControlLayout>
-                    <EuiButtonGroup 
+                    <EuiButtonGroup
                         css={css`border: none;`}
                         legend="selection group to show all events or just the errors"
-                        options={toggleFilterButtons} 
+                        options={toggleFilterButtons}
                         idSelected={toggleIdSelected}
                         onChange={(id) => setToggleIdSelected(id as FilterState)}
-                    >                                
-                    </EuiButtonGroup> 
+                    >
+                    </EuiButtonGroup>
                 </EuiFlexGroup>
                 }
                  <IngestionEvents
                      collectionId={defaultCollection.uri}
-                     workspaces={workspacesMetadata.filter((w) => selectedWorkspace === "all" || w.name === selectedWorkspace)}
+                     workspaces={workspacesMetadata.filter((w) => currentWorkspace === "all" || w.name === currentWorkspace)}
                      breakdownByWorkspace={true}
                      showErrorsOnly={toggleIdSelected === FilterState.ErrorsOnly}
                  ></IngestionEvents>
@@ -99,15 +107,23 @@ function mapStateToProps(state: GiantState) {
     return {
         workspacesMetadata: state.workspaces.workspacesMetadata,
         currentUser: state.auth.token?.user,
-        collections: state.collections
-    };
+        collections: state.collections,
+        currentWorkspace: state.urlParams.currentWorkspace,
+    }
 }
 
 function mapDispatchToProps(dispatch: GiantDispatch) {
     return {
         getCollections: bindActionCreators(getCollections, dispatch),
-        getWorkspacesMetadata: bindActionCreators(getWorkspacesMetadata, dispatch),
-    };
+        getWorkspacesMetadata: bindActionCreators(
+            getWorkspacesMetadata,
+            dispatch
+        ),
+        updateCurrentWorkspace: bindActionCreators(
+            updateCurrentWorkspace,
+            dispatch
+        ),
+    }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(MyUploads);
+export default connect(mapStateToProps, mapDispatchToProps)(MyUploads)

--- a/frontend/src/js/components/IngestionEvents/updateCurrentCollection.ts
+++ b/frontend/src/js/components/IngestionEvents/updateCurrentCollection.ts
@@ -1,0 +1,8 @@
+import { UrlParamsActionType } from "../../types/redux/GiantActions"
+
+export function updateCurrentCollection(currentCollection: string) {
+    return {
+        type: UrlParamsActionType.SET_INGESTION_EVENTS_COLLECTION_IN_URL,
+        currentCollection,
+    }
+}

--- a/frontend/src/js/components/IngestionEvents/updateCurrentIngestion.ts
+++ b/frontend/src/js/components/IngestionEvents/updateCurrentIngestion.ts
@@ -1,0 +1,8 @@
+import { UrlParamsActionType } from "../../types/redux/GiantActions"
+
+export function updateCurrentIngestion(currentIngestion: string) {
+    return {
+        type: UrlParamsActionType.SET_INGESTION_EVENTS_INGESTION_IN_URL,
+        currentIngestion,
+    }
+}

--- a/frontend/src/js/reducers/urlParamsReducer.ts
+++ b/frontend/src/js/reducers/urlParamsReducer.ts
@@ -10,6 +10,7 @@ export default function urlParams(state = {
     pageSize: undefined,
     sortBy: undefined,
     highlight: undefined,
+    currentWorkspace: undefined
 }, action: UrlParamsAction): UrlParamsState {
     switch (action.type) {
         case UrlParamsActionType.SEARCHQUERY_FILTERS_UPDATE:
@@ -59,6 +60,12 @@ export default function urlParams(state = {
                 ...state,
                 highlight: action.highlight
             };
+        case UrlParamsActionType.SET_INGESTION_EVENTS_WORKSPACE_IN_URL:
+            console.log(state, action)
+            return {
+                ...state,
+                currentWorkspace: action.currentWorkspace
+            }
 
         case UrlParamsActionType.URLPARAMS_UPDATE:
             return {

--- a/frontend/src/js/reducers/urlParamsReducer.ts
+++ b/frontend/src/js/reducers/urlParamsReducer.ts
@@ -10,7 +10,9 @@ export default function urlParams(state = {
     pageSize: undefined,
     sortBy: undefined,
     highlight: undefined,
-    currentWorkspace: undefined
+    currentWorkspace: undefined,
+    currentCollection: undefined,
+    currentIngestion: undefined
 }, action: UrlParamsAction): UrlParamsState {
     switch (action.type) {
         case UrlParamsActionType.SEARCHQUERY_FILTERS_UPDATE:
@@ -61,10 +63,19 @@ export default function urlParams(state = {
                 highlight: action.highlight
             };
         case UrlParamsActionType.SET_INGESTION_EVENTS_WORKSPACE_IN_URL:
-            console.log(state, action)
             return {
                 ...state,
                 currentWorkspace: action.currentWorkspace
+            }
+        case UrlParamsActionType.SET_INGESTION_EVENTS_COLLECTION_IN_URL:
+            return {
+                ...state,
+                currentCollection: action.currentCollection
+            }
+        case UrlParamsActionType.SET_INGESTION_EVENTS_INGESTION_IN_URL:
+            return {
+                ...state,
+                currentIngestion: action.currentIngestion
             }
 
         case UrlParamsActionType.URLPARAMS_UPDATE:

--- a/frontend/src/js/types/redux/GiantActions.ts
+++ b/frontend/src/js/types/redux/GiantActions.ts
@@ -97,7 +97,9 @@ export enum UrlParamsActionType {
     SET_DETAILS_VIEW = 'SET_DETAILS_VIEW',
     SET_CURRENT_HIGHLIGHT_IN_URL = 'SET_CURRENT_HIGHLIGHT_IN_URL',
     URLPARAMS_UPDATE = 'URLPARAMS_UPDATE',
-    SET_INGESTION_EVENTS_WORKSPACE_IN_URL = 'SET_INGESTION_EVENTS_WORKSPACE_IN_URL'
+    SET_INGESTION_EVENTS_WORKSPACE_IN_URL = 'SET_INGESTION_EVENTS_WORKSPACE_IN_URL',
+    SET_INGESTION_EVENTS_COLLECTION_IN_URL = 'SET_INGESTION_EVENTS_COLLECTION_IN_URL',
+    SET_INGESTION_EVENTS_INGESTION_IN_URL = 'SET_INGESTION_EVENTS_INGESTION_IN_URL'
 }
 
 interface SearchQueryFiltersUpdateType {
@@ -141,6 +143,16 @@ interface SetIngestionEventsWorkspaceInUrl {
     currentWorkspace: string
 }
 
+interface SetIngestionEventsCollectionInUrl {
+    type: UrlParamsActionType.SET_INGESTION_EVENTS_COLLECTION_IN_URL,
+    currentCollection: string
+}
+
+interface SetIngestionEventsIngestionInUrl {
+    type: UrlParamsActionType.SET_INGESTION_EVENTS_INGESTION_IN_URL,
+    currentIngestion: string
+}
+
 export enum HighlightsActionType {
     UPDATE_HIGHLIGHTS = 'UPDATE_HIGHLIGHTS',
 }
@@ -166,6 +178,8 @@ export type UrlParamsAction =
     | SetCurrentHighlightInUrl
     | UrlParamsUpdateType
     | SetIngestionEventsWorkspaceInUrl
+    | SetIngestionEventsCollectionInUrl
+    | SetIngestionEventsIngestionInUrl
 
 
 

--- a/frontend/src/js/types/redux/GiantActions.ts
+++ b/frontend/src/js/types/redux/GiantActions.ts
@@ -96,7 +96,8 @@ export enum UrlParamsActionType {
     SET_RESOURCE_VIEW = 'SET_RESOURCE_VIEW',
     SET_DETAILS_VIEW = 'SET_DETAILS_VIEW',
     SET_CURRENT_HIGHLIGHT_IN_URL = 'SET_CURRENT_HIGHLIGHT_IN_URL',
-    URLPARAMS_UPDATE = 'URLPARAMS_UPDATE'
+    URLPARAMS_UPDATE = 'URLPARAMS_UPDATE',
+    SET_INGESTION_EVENTS_WORKSPACE_IN_URL = 'SET_INGESTION_EVENTS_WORKSPACE_IN_URL'
 }
 
 interface SearchQueryFiltersUpdateType {
@@ -135,6 +136,10 @@ interface UrlParamsUpdateType {
     type: UrlParamsActionType.URLPARAMS_UPDATE,
     query: UrlParamsState
 }
+interface SetIngestionEventsWorkspaceInUrl {
+    type: UrlParamsActionType.SET_INGESTION_EVENTS_WORKSPACE_IN_URL,
+    currentWorkspace: string
+}
 
 export enum HighlightsActionType {
     UPDATE_HIGHLIGHTS = 'UPDATE_HIGHLIGHTS',
@@ -160,6 +165,7 @@ export type UrlParamsAction =
     | SetDetailsViewType
     | SetCurrentHighlightInUrl
     | UrlParamsUpdateType
+    | SetIngestionEventsWorkspaceInUrl
 
 
 

--- a/frontend/src/js/types/redux/GiantState.ts
+++ b/frontend/src/js/types/redux/GiantState.ts
@@ -42,6 +42,7 @@ export interface UrlParamsState {
     pageSize?: number,
     sortBy?: string,
     highlight?: string,
+    currentWorkspace?: string
 }
 
 export type ExpandedFiltersState = { [key: string]: boolean }
@@ -83,5 +84,5 @@ export interface GiantState {
     urlParams: UrlParamsState,
     search: SearchState,
     isLoadingResource: LoadingState,
-    pages: PagesState
+    pages: PagesState,
 }

--- a/frontend/src/js/types/redux/GiantState.ts
+++ b/frontend/src/js/types/redux/GiantState.ts
@@ -43,6 +43,8 @@ export interface UrlParamsState {
     sortBy?: string,
     highlight?: string,
     currentWorkspace?: string
+    currentCollection?: string
+    currentIngestion?: string
 }
 
 export type ExpandedFiltersState = { [key: string]: boolean }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Stores the current workspace in the url of the 'My uploads' observability dashboard and current collection and ingestion in the url of the 'All ingestion events' dashboard. These values are used to set the initial values of their respective dropdowns on the dashboard pages.

<img width="1440" alt="Screenshot 2023-09-06 at 14 21 06" src="https://github.com/guardian/giant/assets/17057932/19f68bbd-d7ed-4c0b-9696-58d61c47b4bc">

## Why
- after refreshing the page, the user won't lose the ingestion events they were searching for
- the ingestion events from a specific ingestion can be sent between developers or from a user to a developer