### PR TITLE
Add filter on dashboard for showing all or only errors 

### DIFF
--- a/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
@@ -10,10 +10,11 @@ import {bindActionCreators} from "redux";
 import {getCollections} from "../../actions/collections/getCollections";
 import {Collection, Ingestion} from "../../types/Collection";
 import {IngestionEvents} from "./IngestionEvents";
-import {EuiFlexGroup, EuiFlexItem, EuiFormControlLayout, EuiFormLabel, EuiProvider} from "@elastic/eui";
+import {EuiButtonGroup, EuiFlexGroup, EuiFlexItem, EuiFormControlLayout, EuiFormLabel, EuiProvider} from "@elastic/eui";
 import {EuiSelect} from "@elastic/eui";
 import {EuiSelectOption} from "@elastic/eui";
 import styles from "./IngestionEvents.module.css";
+import { css } from "@emotion/react";
 
 function getCollection(collectionId: string, collections: Collection[]) {
     return collections.find((collection: Collection) => collection.uri === collectionId)
@@ -29,6 +30,7 @@ export function AllIngestionEvents(
     const [selectedCollectionId, setSelectedCollectionId] = useState<string>("")
     const [ingestOptions, setIngestOptions] = useState<EuiSelectOption[]>([])
     const [ingestId, setIngestId] = useState<string>("all")
+    const [toggleIdSelected, setToggleIdSelected] = useState(`all__0`);
 
     useEffect(() => {
         getCollections({})
@@ -47,43 +49,66 @@ export function AllIngestionEvents(
         })).concat([{value: "all", text: "All ingestions"}]))
     }, [selectedCollectionId, collections])
 
+    const toggleFilterButtons = [
+        { id: `all__0`, label: 'all' },
+        { id: `errors__1`, label: 'errors only' },
+      ];
 
-    return             <div className='app__main-content'>
-        <h1 className='page-title'>
-            All ingestion events</h1>
+    return (
+        <div className='app__main-content'>
+            <h1 className='page-title'>All ingestion events</h1>
             <EuiProvider globalStyles={false} colorMode="light">
+                <EuiFlexGroup wrap alignItems={"flexStart"} >
+                    {collections.length > 0 && <EuiFlexItem grow={false}>
+                        <EuiFormControlLayout className={styles.dropdown} prepend={<EuiFormLabel htmlFor={"collection-picker"}>Collection</EuiFormLabel>}>
+                            <EuiSelect
+                                hasNoInitialSelection={true}
+                                value={selectedCollectionId}
+                                onChange={(e) => setSelectedCollectionId(e.target.value)}
+                                options={collectionOptions}>
+                                id={"collection-picker"}
+                            </EuiSelect>
+                        </EuiFormControlLayout>
+                    </EuiFlexItem>
+                    }
 
-            <EuiFlexGroup alignItems={"flexStart"} >
-        {collections.length > 0 && <EuiFlexItem grow={false}>
-            <EuiFormControlLayout className={styles.dropdown} prepend={<EuiFormLabel htmlFor={"collection-picker"}>Collection</EuiFormLabel>}>
-                <EuiSelect
-                    hasNoInitialSelection={true}
-                    value={selectedCollectionId}
-                    onChange={(e) => setSelectedCollectionId(e.target.value)}
-                    options={collectionOptions}>
-                    id={"collection-picker"}
-                </EuiSelect>
-            </EuiFormControlLayout>
-        </EuiFlexItem>
-        }
+                    {ingestOptions &&
+                        <EuiFlexItem grow={false}>
+                        <EuiFormControlLayout  className={styles.dropdown} prepend={<EuiFormLabel htmlFor={"ingest-picker"}>Ingest</EuiFormLabel>}>
+                            <EuiSelect
+                                value={ingestId}
+                                onChange={(e) => setIngestId(e.target.value)} options={ingestOptions}>
+                                id={"ingest-picker"}
 
-        {ingestOptions &&
-            <EuiFlexItem grow={false}>
-            <EuiFormControlLayout  className={styles.dropdown} prepend={<EuiFormLabel htmlFor={"ingest-picker"}>Ingest</EuiFormLabel>}>
-                <EuiSelect
-                    value={ingestId}
-                    onChange={(e) => setIngestId(e.target.value)} options={ingestOptions}>
-                    id={"ingest-picker"}
+                            </EuiSelect>
+                        </EuiFormControlLayout>
+                        </EuiFlexItem>
+                    }
 
-                </EuiSelect>
-            </EuiFormControlLayout>
-            </EuiFlexItem>
-            }
-            </EuiFlexGroup>
+                    <EuiButtonGroup 
+                        css={css`border: none;`}
+                        legend="selection group to show all events or just the errors"
+                        options={toggleFilterButtons} 
+                        idSelected={toggleIdSelected}
+                        onChange={(id) => {
+                            console.log(`status changed to ${id}`);
+                            setToggleIdSelected(id);
+                        }}
+                    /> 
+                </EuiFlexGroup>
 
-        {selectedCollectionId && <IngestionEvents collectionId={selectedCollectionId} ingestId={ingestId} workspaces={workspacesMetadata} breakdownByWorkspace={false}></IngestionEvents>}
-    </EuiProvider>
-    </div>
+                {selectedCollectionId && 
+                    <IngestionEvents 
+                        collectionId={selectedCollectionId} 
+                        ingestId={ingestId} 
+                        workspaces={workspacesMetadata} 
+                        breakdownByWorkspace={false}
+                        showErrorsOnly={toggleIdSelected === 'errors__1'}
+                    />
+                }
+            </EuiProvider>
+        </div>
+    );  
 }
 
 

--- a/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
@@ -15,6 +15,7 @@ import {EuiSelect} from "@elastic/eui";
 import {EuiSelectOption} from "@elastic/eui";
 import styles from "./IngestionEvents.module.css";
 import { css } from "@emotion/react";
+import { FilterState } from "./types";
 
 function getCollection(collectionId: string, collections: Collection[]) {
     return collections.find((collection: Collection) => collection.uri === collectionId)
@@ -27,12 +28,10 @@ export function AllIngestionEvents(
         workspacesMetadata: WorkspaceMetadata[],
     }) {
 
-    const ALL_FILTER_ID = 'all__0';
-    const ERRORS_FILTER_ID = 'errors__1';
     const [selectedCollectionId, setSelectedCollectionId] = useState<string>("")
     const [ingestOptions, setIngestOptions] = useState<EuiSelectOption[]>([])
     const [ingestId, setIngestId] = useState<string>("all")
-    const [toggleIdSelected, setToggleIdSelected] = useState(ALL_FILTER_ID);
+    const [toggleIdSelected, setToggleIdSelected] = useState<FilterState>(FilterState.All);
 
     useEffect(() => {
         getCollections({})
@@ -52,8 +51,8 @@ export function AllIngestionEvents(
     }, [selectedCollectionId, collections])
 
     const toggleFilterButtons = [
-        { id: ALL_FILTER_ID, label: 'all' },
-        { id: ERRORS_FILTER_ID, label: 'errors only' },
+        { id: FilterState.All, label: 'all' },
+        { id: FilterState.ErrorsOnly, label: 'errors only' },
       ];
 
     return (
@@ -92,7 +91,7 @@ export function AllIngestionEvents(
                         legend="selection group to show all events or just the errors"
                         options={toggleFilterButtons} 
                         idSelected={toggleIdSelected}
-                        onChange={(id) => setToggleIdSelected(id)}
+                        onChange={(id) => setToggleIdSelected(id as FilterState)}
                     /> 
                 </EuiFlexGroup>
 
@@ -102,7 +101,7 @@ export function AllIngestionEvents(
                         ingestId={ingestId} 
                         workspaces={workspacesMetadata} 
                         breakdownByWorkspace={false}
-                        showErrorsOnly={toggleIdSelected === ERRORS_FILTER_ID}
+                        showErrorsOnly={toggleIdSelected === FilterState.ErrorsOnly}
                     />
                 }
             </EuiProvider>

--- a/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/AllIngestionEvents.tsx
@@ -27,10 +27,12 @@ export function AllIngestionEvents(
         workspacesMetadata: WorkspaceMetadata[],
     }) {
 
+    const ALL_FILTER_ID = 'all__0';
+    const ERRORS_FILTER_ID = 'errors__1';
     const [selectedCollectionId, setSelectedCollectionId] = useState<string>("")
     const [ingestOptions, setIngestOptions] = useState<EuiSelectOption[]>([])
     const [ingestId, setIngestId] = useState<string>("all")
-    const [toggleIdSelected, setToggleIdSelected] = useState(`all__0`);
+    const [toggleIdSelected, setToggleIdSelected] = useState(ALL_FILTER_ID);
 
     useEffect(() => {
         getCollections({})
@@ -50,8 +52,8 @@ export function AllIngestionEvents(
     }, [selectedCollectionId, collections])
 
     const toggleFilterButtons = [
-        { id: `all__0`, label: 'all' },
-        { id: `errors__1`, label: 'errors only' },
+        { id: ALL_FILTER_ID, label: 'all' },
+        { id: ERRORS_FILTER_ID, label: 'errors only' },
       ];
 
     return (
@@ -90,10 +92,7 @@ export function AllIngestionEvents(
                         legend="selection group to show all events or just the errors"
                         options={toggleFilterButtons} 
                         idSelected={toggleIdSelected}
-                        onChange={(id) => {
-                            console.log(`status changed to ${id}`);
-                            setToggleIdSelected(id);
-                        }}
+                        onChange={(id) => setToggleIdSelected(id)}
                     /> 
                 </EuiFlexGroup>
 
@@ -103,7 +102,7 @@ export function AllIngestionEvents(
                         ingestId={ingestId} 
                         workspaces={workspacesMetadata} 
                         breakdownByWorkspace={false}
-                        showErrorsOnly={toggleIdSelected === 'errors__1'}
+                        showErrorsOnly={toggleIdSelected === ERRORS_FILTER_ID}
                     />
                 }
             </EuiProvider>

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -8,46 +8,7 @@ import hdate from 'human-date';
 import {WorkspaceMetadata} from "../../types/Workspaces";
 import moment from "moment";
 import _ from "lodash";
-
-type Metadata = {
-    blobId: string;
-    ingestId: string;
-}
-
-type BlobStatus =  {
-    metadata: Metadata;
-    paths: string[];
-    fileSize?: number;
-    ingestStart: Date;
-    mostRecentEvent: Date;
-    extractorStatuses: ExtractorStatus[];
-    errors: string[];
-    workspaceName: string;
-}
-
-type IngestionTable = {
-    title: string;
-    blobs: BlobStatus[]
-}
-
-type Status = "Unknown" | "Started" | "Success" | "Failure"
-
-type ExtractorStatusUpdate = {
-    eventTime?: Date;
-    status?: Status
-}
-
-type ExtractorStatus = {
-    extractorType: string;
-    statusUpdates: ExtractorStatusUpdate[];
-}
-
-const extractorStatusColors = {
-    "Success": "success",
-    "Started": "primary",
-    "Failure": "danger",
-    "Unknown": "default"
-}
+import { BlobStatus, ExtractorStatus, IngestionTable, Status, extractorStatusColors } from "./types";
 
 const blobStatusIcons = {
     complete: <EuiIconTip type="checkInCircleFilled" />,

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -133,7 +133,7 @@ export function IngestionEvents(
         ingestId?: string,
         workspaces: WorkspaceMetadata[],
         breakdownByWorkspace: boolean,
-        showErrorsOnly?: boolean,
+        showErrorsOnly: boolean,
     }) {
     const [blobs, updateBlobs] = useState<BlobStatus[] | undefined>(undefined)
     const [tableData, setTableData] = useState<IngestionTable[]>([])

--- a/frontend/src/js/components/IngestionEvents/MyUploads.tsx
+++ b/frontend/src/js/components/IngestionEvents/MyUploads.tsx
@@ -29,11 +29,14 @@ function MyUploads(
         currentUser?: PartialUser,
         workspacesMetadata: WorkspaceMetadata[],
           }) {
+
+    const ALL_FILTER_ID = 'all__0';
+    const ERRORS_FILTER_ID = 'errors__1';
     const [defaultCollection, setDefaultCollection] = useState<Collection>()
 
     const [selectedWorkspace, setSelectedWorkspace] = useState<string>("all");
 
-    const [toggleIdSelected, setToggleIdSelected] = useState(`all__0`);      
+    const [toggleIdSelected, setToggleIdSelected] = useState(ALL_FILTER_ID);      
 
     useEffect(() => {
         getCollections({})
@@ -47,8 +50,8 @@ function MyUploads(
     }, [collections, currentUser])
 
     const toggleFilterButtons = [
-        { id: `all__0`, label: 'all' },
-        { id: `errors__1`, label: 'errors only' },
+        { id: ALL_FILTER_ID, label: 'all' },
+        { id: ERRORS_FILTER_ID, label: 'errors only' },
       ];
 
     return (
@@ -86,13 +89,12 @@ function MyUploads(
                      collectionId={defaultCollection.uri}
                      workspaces={workspacesMetadata.filter((w) => selectedWorkspace === "all" || w.name === selectedWorkspace)}
                      breakdownByWorkspace={true}
-                     showErrorsOnly={toggleIdSelected === 'errors__1'}
+                     showErrorsOnly={toggleIdSelected === ERRORS_FILTER_ID}
                  ></IngestionEvents>
                 </>
             }
         </EuiProvider>
-                </div>
-
+        </div>
     )
 }
 

--- a/frontend/src/js/components/IngestionEvents/MyUploads.tsx
+++ b/frontend/src/js/components/IngestionEvents/MyUploads.tsx
@@ -1,6 +1,6 @@
 
 
-import React, {useEffect, useState} from "react";
+import {useEffect, useState} from "react";
 import {GiantState} from "../../types/redux/GiantState";
 import {GiantDispatch} from "../../types/redux/GiantDispatch";
 import {connect} from "react-redux";
@@ -12,10 +12,13 @@ import {Collection} from "../../types/Collection";
 import {getDefaultCollection} from "../Uploads/UploadTarget";
 import {IngestionEvents} from "./IngestionEvents";
 import {PartialUser} from "../../types/User";
-import {EuiProvider, EuiSelect} from "@elastic/eui";
+import {EuiButtonGroup, EuiFlexGroup, EuiProvider, EuiSelect} from "@elastic/eui";
 import {getWorkspacesMetadata} from "../../actions/workspaces/getWorkspacesMetadata";
 import {EuiFormControlLayout} from "@elastic/eui";
 import {EuiFormLabel} from "@elastic/eui";
+import { css } from "@emotion/react";
+
+
 
 
 function MyUploads(
@@ -28,7 +31,9 @@ function MyUploads(
           }) {
     const [defaultCollection, setDefaultCollection] = useState<Collection>()
 
-    const [selectedWorkspace, setSelectedWorkspace] = useState<string>("all")
+    const [selectedWorkspace, setSelectedWorkspace] = useState<string>("all");
+
+    const [toggleIdSelected, setToggleIdSelected] = useState(`all__0`);      
 
     useEffect(() => {
         getCollections({})
@@ -41,6 +46,10 @@ function MyUploads(
         }
     }, [collections, currentUser])
 
+    const toggleFilterButtons = [
+        { id: `all__0`, label: 'all' },
+        { id: `errors__1`, label: 'errors only' },
+      ];
 
     return (
         <div className='app__main-content'>
@@ -49,24 +58,35 @@ function MyUploads(
             {defaultCollection &&
                 <>
                 {workspacesMetadata.length > 0 &&
+                <EuiFlexGroup>
                     <EuiFormControlLayout prepend={<EuiFormLabel htmlFor={"workspace-picker"}>Workspace</EuiFormLabel>}>
-                    <EuiSelect
-                        value={selectedWorkspace}
-                        onChange={(e) => setSelectedWorkspace(e.target.value)}
-                        id={"workspace-picker"}
-                        options={
-                        [{value: "all", text: "All workspaces"}].concat(
-                            workspacesMetadata.map((w: WorkspaceMetadata) =>
-                                ({value: w.name, text: w.name}))
-                        )
-                    }>
-                    </EuiSelect>
+                        <EuiSelect
+                            value={selectedWorkspace}
+                            onChange={(e) => setSelectedWorkspace(e.target.value)}
+                            id={"workspace-picker"}
+                            options={
+                                [{value: "all", text: "All workspaces"}].concat(
+                                    workspacesMetadata.map((w: WorkspaceMetadata) =>
+                                        ({value: w.name, text: w.name}))
+                                )
+                            }>
+                        </EuiSelect>                     
                     </EuiFormControlLayout>
+                    <EuiButtonGroup 
+                        css={css`border: none;`}
+                        legend="selection group to show all events or just the errors"
+                        options={toggleFilterButtons} 
+                        idSelected={toggleIdSelected}
+                        onChange={(id) => setToggleIdSelected(id)}
+                    >                                
+                    </EuiButtonGroup> 
+                </EuiFlexGroup>
                 }
                  <IngestionEvents
                      collectionId={defaultCollection.uri}
                      workspaces={workspacesMetadata.filter((w) => selectedWorkspace === "all" || w.name === selectedWorkspace)}
                      breakdownByWorkspace={true}
+                     showErrorsOnly={toggleIdSelected === 'errors__1'}
                  ></IngestionEvents>
                 </>
             }

--- a/frontend/src/js/components/IngestionEvents/MyUploads.tsx
+++ b/frontend/src/js/components/IngestionEvents/MyUploads.tsx
@@ -17,9 +17,7 @@ import {getWorkspacesMetadata} from "../../actions/workspaces/getWorkspacesMetad
 import {EuiFormControlLayout} from "@elastic/eui";
 import {EuiFormLabel} from "@elastic/eui";
 import { css } from "@emotion/react";
-
-
-
+import { FilterState } from "./types";
 
 function MyUploads(
     {getCollections, getWorkspacesMetadata, collections, currentUser, workspacesMetadata}: {
@@ -30,13 +28,11 @@ function MyUploads(
         workspacesMetadata: WorkspaceMetadata[],
           }) {
 
-    const ALL_FILTER_ID = 'all__0';
-    const ERRORS_FILTER_ID = 'errors__1';
     const [defaultCollection, setDefaultCollection] = useState<Collection>()
 
     const [selectedWorkspace, setSelectedWorkspace] = useState<string>("all");
 
-    const [toggleIdSelected, setToggleIdSelected] = useState(ALL_FILTER_ID);      
+    const [toggleIdSelected, setToggleIdSelected] = useState<FilterState>("all");      
 
     useEffect(() => {
         getCollections({})
@@ -49,9 +45,9 @@ function MyUploads(
         }
     }, [collections, currentUser])
 
-    const toggleFilterButtons = [
-        { id: ALL_FILTER_ID, label: 'all' },
-        { id: ERRORS_FILTER_ID, label: 'errors only' },
+    const toggleFilterButtons: {id: FilterState, label: string}[] = [
+        { id: "all", label: 'all' },
+        { id: "errorsOnly", label: 'errors only' },
       ];
 
     return (
@@ -80,7 +76,7 @@ function MyUploads(
                         legend="selection group to show all events or just the errors"
                         options={toggleFilterButtons} 
                         idSelected={toggleIdSelected}
-                        onChange={(id) => setToggleIdSelected(id)}
+                        onChange={(id) => setToggleIdSelected(id as FilterState)}
                     >                                
                     </EuiButtonGroup> 
                 </EuiFlexGroup>
@@ -89,7 +85,7 @@ function MyUploads(
                      collectionId={defaultCollection.uri}
                      workspaces={workspacesMetadata.filter((w) => selectedWorkspace === "all" || w.name === selectedWorkspace)}
                      breakdownByWorkspace={true}
-                     showErrorsOnly={toggleIdSelected === ERRORS_FILTER_ID}
+                     showErrorsOnly={toggleIdSelected === "errorsOnly"}
                  ></IngestionEvents>
                 </>
             }

--- a/frontend/src/js/components/IngestionEvents/MyUploads.tsx
+++ b/frontend/src/js/components/IngestionEvents/MyUploads.tsx
@@ -32,7 +32,7 @@ function MyUploads(
 
     const [selectedWorkspace, setSelectedWorkspace] = useState<string>("all");
 
-    const [toggleIdSelected, setToggleIdSelected] = useState<FilterState>("all");      
+    const [toggleIdSelected, setToggleIdSelected] = useState<FilterState>(FilterState.All);      
 
     useEffect(() => {
         getCollections({})
@@ -46,8 +46,8 @@ function MyUploads(
     }, [collections, currentUser])
 
     const toggleFilterButtons: {id: FilterState, label: string}[] = [
-        { id: "all", label: 'all' },
-        { id: "errorsOnly", label: 'errors only' },
+        { id: FilterState.All, label: 'all' },
+        { id: FilterState.ErrorsOnly, label: 'errors only' },
       ];
 
     return (
@@ -85,7 +85,7 @@ function MyUploads(
                      collectionId={defaultCollection.uri}
                      workspaces={workspacesMetadata.filter((w) => selectedWorkspace === "all" || w.name === selectedWorkspace)}
                      breakdownByWorkspace={true}
-                     showErrorsOnly={toggleIdSelected === "errorsOnly"}
+                     showErrorsOnly={toggleIdSelected === FilterState.ErrorsOnly}
                  ></IngestionEvents>
                 </>
             }

--- a/frontend/src/js/components/IngestionEvents/types.ts
+++ b/frontend/src/js/components/IngestionEvents/types.ts
@@ -38,4 +38,7 @@ export const extractorStatusColors = {
     "Unknown": "default"
 }
 
-export type FilterState = "all" | "errorsOnly"
+export enum FilterState {
+    All = "all",
+    ErrorsOnly = "errorsOnly"
+}

--- a/frontend/src/js/components/IngestionEvents/types.ts
+++ b/frontend/src/js/components/IngestionEvents/types.ts
@@ -1,0 +1,41 @@
+export type Metadata = {
+    blobId: string;
+    ingestId: string;
+}
+
+export type BlobStatus =  {
+    metadata: Metadata;
+    paths: string[];
+    fileSize?: number;
+    ingestStart: Date;
+    mostRecentEvent: Date;
+    extractorStatuses: ExtractorStatus[];
+    errors: string[];
+    workspaceName: string;
+}
+
+export type IngestionTable = {
+    title: string;
+    blobs: BlobStatus[]
+}
+
+export type Status = "Unknown" | "Started" | "Success" | "Failure"
+
+export type ExtractorStatusUpdate = {
+    eventTime?: Date;
+    status?: Status
+}
+
+export type ExtractorStatus = {
+    extractorType: string;
+    statusUpdates: ExtractorStatusUpdate[];
+}
+
+export const extractorStatusColors = {
+    "Success": "success",
+    "Started": "primary",
+    "Failure": "danger",
+    "Unknown": "default"
+}
+
+export type FilterState = "all" | "errorsOnly"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a filter button group with 2 option of `all` & `errors only` in order to provide ability for filtering the ingestion events. 

This change is applied for both `My uploads` & `All ingestion events` views. 


![ezgif-2-b45aea962b](https://github.com/guardian/giant/assets/15894063/a03e0795-90fc-479c-a6e4-6f6afdd5521d)
