### PR TITLE
Add a dropdown to ingestion events dashboard rows, showing errors and other data. 

### DIFF
--- a/backend/app/extraction/Worker.scala
+++ b/backend/app/extraction/Worker.scala
@@ -116,7 +116,7 @@ class Worker(
               IngestionEventType.RunExtractor,
               EventStatus.Failure,
               details = EventDetails.extractorErrorDetails(
-                extractor.name, failure.msg, failure.cause.map(throwable => throwable.getStackTrace.toString)
+                extractor.name, failure.msg, failure.toThrowable.getStackTrace.map(element => element.toString).mkString("\n")
               )
             )
           )

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.module.css
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.module.css
@@ -8,3 +8,7 @@
 .dropdown {
     min-width: 300px;
 }
+
+.expandedRowExtractorStatus {
+    margin-left: 20px;
+}

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -1,20 +1,23 @@
-
-
-import React, {useEffect, useState} from "react";
+import React, {ReactNode, useEffect, useState} from "react";
 import authFetch from "../../util/auth/authFetch";
-import {EuiFlexItem, EuiToolTip, EuiSpacer, EuiIconTip, EuiBadge, EuiFlexGroup, EuiInMemoryTable, EuiBasicTableColumn, EuiLoadingSpinner} from "@elastic/eui";
+import {EuiFlexItem, EuiToolTip, EuiText, EuiButtonIcon, EuiScreenReaderOnly, EuiSpacer, EuiIconTip, EuiBadge, EuiFlexGroup, EuiInMemoryTable, EuiBasicTableColumn, EuiLoadingSpinner, EuiCodeBlock} from "@elastic/eui";
 import '@elastic/eui/dist/eui_theme_light.css';
 import hdate from 'human-date';
 import {WorkspaceMetadata} from "../../types/Workspaces";
 import moment from "moment";
 import _ from "lodash";
 import { BlobStatus, ExtractorStatus, IngestionTable, Status, extractorStatusColors } from "./types";
+import styles from "./IngestionEvents.module.css";
+
+type BlobProgress = "complete" | "completeWithErrors" | "inProgress"
 
 const blobStatusIcons = {
-    complete: <EuiIconTip type="checkInCircleFilled" />,
-    completeWithErrors: <EuiIconTip type="alert" />,
-    inProgress: <EuiLoadingSpinner />
+    complete: <EuiIconTip type="checkInCircleFilled" content={"Ingestion complete"} />,
+    completeWithErrors: <EuiIconTip type="alert" content={"Ingestion complete with some errors"} />,
+    inProgress: <EuiToolTip content={"Ingestion in progress"}><EuiLoadingSpinner /></EuiToolTip>
 }
+
+const SHORT_READABLE_DATE = "DD MMM HH:mm:ss"
 
 const statusToColor = (status: Status) => extractorStatusColors[status]
 
@@ -27,60 +30,75 @@ const getFailedBlobs = (blobs: BlobStatus[]) => {
     });
 }
 
-const getBlobStatus = (statuses: ExtractorStatus[]) => {
+const getBlobStatus = (statuses: ExtractorStatus[]): BlobProgress => {
     const failures = getFailedStatuses(statuses);
     const inProgress = statuses.filter(status => status.statusUpdates.find(u => !u.status || ["Failure", "Success"].includes(u.status)) === undefined)
-    return failures.length > 0 ? blobStatusIcons.completeWithErrors : inProgress.length > 0 ? blobStatusIcons.inProgress : blobStatusIcons.complete
+    return failures.length > 0 ? "completeWithErrors" : inProgress.length > 0 ? "inProgress" : "complete"
 }
 
-const extractorStatusTooltip = (status: ExtractorStatus) => {
-    const statusUpdateStrings = status.statusUpdates.map(u => `${moment(u.eventTime).format("DD MMM HH:mm:ss")} ${u.status}`)
-    return status.statusUpdates.length > 0 ? <>
-        <b>All {status.extractorType} events</b> <br />
+const blobIngestedMultipleTimes = (status:BlobStatus) => status.extractorStatuses.find(s => s.statusUpdates.filter(u => u.status === "Started").length > 1) !== undefined
+
+const extractorStatusList = (status: ExtractorStatus, title?: string) => {
+    const statusUpdateStrings = status.statusUpdates.map(u => `${moment(u.eventTime).format(SHORT_READABLE_DATE)} ${u.status}`)
+    return status.statusUpdates.length > 0 ? <p>
+        {title && <><b>{title}</b> <br /></>}
         <ul>
             {statusUpdateStrings.map(s => <li key={s}>{s}</li>)}
         </ul>
-    </> : "No events so far"
+    </p> : "No events so far"
 }
 
-const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
-    {
+// throw away everything after last / to get the filename from a path
+const pathsToFileNames = (paths: string[]) => paths.map(p => p.split("/").slice(-1)).join("\n")
+
+
+const blobStatusText = {
+    complete: "Complete",
+    completeWithErrors: "Complete with errors",
+    inProgress: "In progress"
+}
+
+const statusIconColumn = {
         field: 'extractorStatuses',
         name: '',
+        width: '40',
         render: (statuses: ExtractorStatus[]) => {
-            return getBlobStatus(statuses)
+            return blobStatusIcons[getBlobStatus(statuses)]
         }
-    },
+    }
+
+const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
     {
         field: 'paths',
         name: 'Filename(s)',
         sortable: true,
         truncateText: true,
-        render: (paths: string[]) =>
-            // throw away everything after last / to get the filename from a path
-            paths.map(p => p.split("/").slice(-1)).join("\n")
-    },
-    {
-        field: 'paths',
-        name: 'Path(s)',
-        render: (paths: string[]) => paths.join("\n")
-    },
-    {
-        field: 'workspaceName',
-        sortable: true,
-        name: 'Workspace name'
+        render: pathsToFileNames
     },
     {
         field: 'ingestStart',
-        name: 'First event',
+        name: 'First event time',
         sortable: true,
-        render: (ingestStart: Date) => hdate.prettyPrint(ingestStart, {showTime: true})
+        render: (ingestStart: Date) => moment(ingestStart).format(SHORT_READABLE_DATE)
     },
     {
-        field: 'mostRecentEvent',
-        name: 'Most recent event',
-        sortable: true,
-        render: (mostRecentEvent: Date) => hdate.prettyPrint(mostRecentEvent, {showTime: true})
+        name: 'Ingestion run time',
+        render: (row: BlobStatus) =>
+            <>{moment.duration(moment(row.mostRecentEvent).diff(moment(row.ingestStart))).humanize()} {
+                blobIngestedMultipleTimes(row) && <EuiIconTip
+                aria-label="Info"
+                size="m"
+                type="iInCircle"
+                color="primary"
+                content={"This file has been ingested more than once so ingestion run time may not be accurate."}
+            />}</>
+    },
+    {
+        field: 'extractorStatuses',
+        name: 'Status',
+        render: (statuses: ExtractorStatus[]) => {
+            return blobStatusText[getBlobStatus(statuses)]
+        }
     },
     {
         field: 'extractorStatuses',
@@ -93,7 +111,7 @@ const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
                         <EuiFlexItem>{status.extractorType.replace("Extractor", "")}</EuiFlexItem>
                         <EuiFlexItem grow={false}>
                             {mostRecent?.status ?
-                                (<EuiToolTip content = {extractorStatusTooltip(status)}>
+                                (<EuiToolTip content = {extractorStatusList(status, `All ${status.extractorType} events`)}>
                                     <EuiBadge color={statusToColor(mostRecent.status)}>
                                         {mostRecent.status} ({moment(mostRecent.eventTime).format("HH:mm:ss")  })
                                     </EuiBadge>
@@ -107,6 +125,7 @@ const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
         },
         width: "300"
     },
+
 ];
 
 const parseBlobStatus = (status: any): BlobStatus => {
@@ -114,6 +133,7 @@ const parseBlobStatus = (status: any): BlobStatus => {
         ...status,
         ingestStart: new Date(status.ingestStart),
         mostRecentEvent: new Date(status.mostRecentEvent),
+        mimeTypes: status.mimeTypes?.split(","),
         extractorStatuses: status.extractorStatuses.map((s: any) => ({
             extractorType: s.extractorType.replace("Extractor", ""),
             statusUpdates: _.sortBy(s.statusUpdates
@@ -125,6 +145,39 @@ const parseBlobStatus = (status: any): BlobStatus => {
             })), update => update.eventTime)
         }))
     }
+}
+
+const blobStatusId = (blobStatus: BlobStatus) => `${blobStatus.metadata.ingestId}-${blobStatus.metadata.blobId}`
+
+const renderExpandedRow = (blobStatus: BlobStatus) => {
+    return <EuiText>
+        <h3>{pathsToFileNames(blobStatus.paths)}</h3>
+        <p>Full file path(s) : {blobStatus.paths.join(", ")}. Ingestion started on {hdate.prettyPrint(blobStatus.ingestStart)}</p>
+        {blobStatus.mimeTypes && `This file is of type ${blobStatus.mimeTypes.join(",")}.`} Giant has run the following extractors on the file:
+        <div className={styles.expandedRowExtractorStatus}>
+            {blobStatus.extractorStatuses.map(extractorStatus => {
+                const numErrors = extractorStatus.statusUpdates.filter(su => su.status === "Failure").length
+                const numStarted = extractorStatus.statusUpdates.filter(su => su.status === "Started").length
+                const mostRecent = extractorStatus.statusUpdates.length > 0 ? extractorStatus.statusUpdates[extractorStatus.statusUpdates.length - 1] : undefined
+                return <><h4>{extractorStatus.extractorType}</h4>
+                    <p>The extractor {extractorStatus.extractorType} has been started {numStarted} times. There have been {numErrors} errors.<br />
+                        {mostRecent ? <>The most recent status event is '{mostRecent.status}' which happened on {hdate.prettyPrint(mostRecent.eventTime, {showTime: true})}</> : ""} <br /> <br />
+
+                        All {extractorStatus.extractorType} events:
+
+                        {extractorStatusList(extractorStatus)}
+
+
+                </p></>
+            })}
+        </div>
+        {blobStatus.errors.length > 0 &&
+            <>
+                <h4>Errors encountered processing this file</h4>
+                {blobStatus.errors.map(error => <EuiCodeBlock>{error.message}</EuiCodeBlock>)}
+            </>
+        }
+    </EuiText>
 }
 
 export function IngestionEvents(
@@ -139,6 +192,52 @@ export function IngestionEvents(
     const [tableData, setTableData] = useState<IngestionTable[]>([])
 
     const ingestIdSuffix = ingestId && ingestId !== "all" ? `/${ingestId}` : ""
+
+    // Expanding rows logic - we use itemIdToExpandedRowMap to keep track of which rows have been expanded
+    const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap ] = useState<
+        Record<string, ReactNode>
+    >({});
+    const openRow = (blobStatus: BlobStatus) => {
+        const map = {...itemIdToExpandedRowMap}
+        const id = blobStatusId(blobStatus)
+        map[id] = renderExpandedRow(blobStatus)
+        setItemIdToExpandedRowMap(map)
+    }
+
+    const closeRow = (blobStatus: BlobStatus) => {
+        const map = {...itemIdToExpandedRowMap}
+        delete map[blobStatusId(blobStatus)]
+        setItemIdToExpandedRowMap(map)
+    }
+
+    const columnsWithWorkspace = breakdownByWorkspace ?
+        columns : columns.concat(    {
+            field: 'workspaceName',
+            sortable: true,
+            name: 'Workspace name'
+        })
+
+    const columnsWithExpandingRow: Array<EuiBasicTableColumn<BlobStatus>> = [
+        ...columnsWithWorkspace,
+        statusIconColumn,
+        {
+            align: 'right',
+            width: '40px',
+            isExpander: true,
+            name: (<EuiScreenReaderOnly><span>Expand rows</span></EuiScreenReaderOnly>),
+            render: (row: BlobStatus) => (
+                <EuiButtonIcon
+                    onClick={() => itemIdToExpandedRowMap[blobStatusId(row)] ? closeRow(row) : openRow(row)}
+                    aria-label={
+                        itemIdToExpandedRowMap[blobStatusId(row)] ? 'Collapse' : 'Expand'
+                    }
+                    iconType={
+                        itemIdToExpandedRowMap[blobStatusId(row)] ? 'arrowDown' : 'arrowRight'
+                    }
+                />
+            )
+        }
+    ]
 
     useEffect(() => {
         authFetch(`/api/ingestion-events/${collectionId}${ingestIdSuffix}`)
@@ -175,23 +274,23 @@ export function IngestionEvents(
         } else {
             setTableData([])
         }
-
-    }, [breakdownByWorkspace, blobs, workspaces, ingestIdSuffix, collectionId, showErrorsOnly])
+    }, [breakdownByWorkspace, blobs, workspaces, ingestIdSuffix, collectionId, showErrorsOnly, setItemIdToExpandedRowMap])
 
     return (
         <>
         {tableData.map((t: IngestionTable) =>
             <div key={t.title}>
-                <EuiSpacer size={"m"}/>
-                <h1>{t.title}</h1>
-                <EuiInMemoryTable
-                    tableCaption="ingestion events"
-                    items={t.blobs}
-                    itemId={(row: BlobStatus) => `${row.metadata.ingestId}-${row.metadata.blobId}`}
-                    loading={t.blobs === undefined}
-                    columns={columns}
-                    sorting={true}
-                />
+            <EuiSpacer size={"m"}/>
+            <h1>{t.title}</h1>
+            <EuiInMemoryTable
+                tableCaption="ingestion events"
+                items={t.blobs}
+                itemId={blobStatusId}
+                loading={t.blobs === undefined}
+                columns={columnsWithExpandingRow}
+                sorting={true}
+                itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+            />
             </div>
         )}
         </>

--- a/frontend/src/js/components/IngestionEvents/types.ts
+++ b/frontend/src/js/components/IngestionEvents/types.ts
@@ -3,6 +3,11 @@ export type Metadata = {
     ingestId: string;
 }
 
+type IngestionError = {
+    message: string;
+    stackTrace?: string;
+}
+
 export type BlobStatus =  {
     metadata: Metadata;
     paths: string[];
@@ -10,8 +15,9 @@ export type BlobStatus =  {
     ingestStart: Date;
     mostRecentEvent: Date;
     extractorStatuses: ExtractorStatus[];
-    errors: string[];
+    errors: IngestionError[];
     workspaceName: string;
+    mimeTypes: string[];
 }
 
 export type IngestionTable = {


### PR DESCRIPTION
## What does this change?
This PR adds a (hopefully) useful dropdown to rows on the ingestion events dashboard. The main aim is to show errors that have occurred during an ingestion together with the stack trace for debugging. I've also moved the 'path' field into this expanded row to save some space, and added some text (not so sure how useful this is) giving some info about the file.

This also adds a new 'ingest run time' column and 'status' column indicating whether the ingest has finished or not. 

It looks like this:
<img width="1068" alt="Screenshot 2023-09-07 at 16 06 56" src="https://github.com/guardian/giant/assets/3606555/469d2118-9143-4771-8205-c255084ec27f">

## How to test
You can just click on any row and see what it looks like! Tested on playground

## How can we measure success?
