### PR TITLE
Increase max size limit to 250MB

### DIFF
--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -5,6 +5,7 @@ play {
     jwtResponseName = "X-Offer-Authorization"
   }
 
+  # When updating this value, also update MAX_FILE_UPLOAD_SIZE_MBYTES in UploadFiles.tsx
   http.parser.maxDiskBuffer = 250MB
 
   # Disable CSRF if there is an Authorization header

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -5,7 +5,7 @@ play {
     jwtResponseName = "X-Offer-Authorization"
   }
 
-  http.parser.maxDiskBuffer = 100MB
+  http.parser.maxDiskBuffer = 250MB
 
   # Disable CSRF if there is an Authorization header
   filters {

--- a/frontend/src/js/components/Uploads/FileList.tsx
+++ b/frontend/src/js/components/Uploads/FileList.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { MenuChevron } from '../UtilComponents/MenuChevron';
 import { Loader, Icon, Button, Message } from 'semantic-ui-react';
-import { UploadFile } from './UploadFiles';
+import {isFailedFileUploadState, UploadFile} from './UploadFiles';
 
 // Returns an array containing all the intermediate paths of the files,
 // e.g. ['/path/to/file.pdf'] => ['/path', /path/to', '/path/to/file.pdf']
@@ -85,7 +85,11 @@ export default function FileList({ files, disabled, removeByPath }: { files: Map
 
     const filesAndFolders = buildTree(filePaths, Array.from(collapsed));
 
-    const anyFailed = [...files.values()].some(({ state }) => state.description === 'failed');
+    const failedFiles = [...files.values()].filter(f => isFailedFileUploadState(f.state));
+    const anyFailed = failedFiles.length > 0
+    const failureReasons = failedFiles
+        .map(s => ({file: s.file.name, failureReason: isFailedFileUploadState(s.state) ? s.state.failureReason : undefined }))
+        .filter(fr => fr.failureReason !== undefined)
 
     return (
         <React.Fragment>
@@ -123,6 +127,14 @@ export default function FileList({ files, disabled, removeByPath }: { files: Map
             {anyFailed ?
             <Message negative>
                 <Message.Header>Some uploads failed</Message.Header>
+                {failureReasons.length > 0 && (<p>Failure reasons:
+                    <ul>
+                    {failureReasons.map((fr) => (
+                        <li>{fr.file}: {fr.failureReason}</li>
+                    ))}
+                    </ul>
+                </p>)}
+
                 <p>Please contact your administrator</p>
             </Message> : false}
         </React.Fragment>

--- a/frontend/src/js/components/Uploads/UploadFiles.tsx
+++ b/frontend/src/js/components/Uploads/UploadFiles.tsx
@@ -20,6 +20,11 @@ import { isTreeLeaf, isTreeNode, TreeEntry, TreeNode } from '../../types/Tree';
 import { getWorkspace } from '../../actions/workspaces/getWorkspace';
 import { useDispatch } from 'react-redux';
 import { AppActionType } from '../../types/redux/GiantActions';
+import {BasicResource, BasicResourceWithSingleBlobChild} from "../../types/Resource";
+
+const MAX_FILE_UPLOAD_SIZE_MBYTES = 250 // should correspond to http.parser.maxDiskBuffer in application.conf
+const MAX_FILE_UPLOAD_SIZE_BYTES = MAX_FILE_UPLOAD_SIZE_MBYTES*1024*1024
+
 
 type InProgressFileUploadState = {
     description: 'uploading',
@@ -27,11 +32,20 @@ type InProgressFileUploadState = {
     totalBytes: number
 };
 
+type FailedFileUploadState = {
+    description: 'failed',
+    failureReason?: string
+}
+
 type FileUploadState =
     { description: 'pending' } |
     InProgressFileUploadState |
     { description: 'uploaded' } |
-    { description: 'failed' };
+    FailedFileUploadState;
+
+export function isFailedFileUploadState(uploadState: FileUploadState): uploadState is FailedFileUploadState {
+    return uploadState.description === "failed"
+}
 
 export type WorkspaceUploadMetadata = {
     workspaceId: string,
@@ -155,19 +169,24 @@ async function uploadFiles(target: WorkspaceTarget, files: Map<string, UploadFil
         const state: FileUploadState = { description: 'uploading', totalBytes: file.size };
         dispatch({ type: 'Set_Upload_State', file: path, state });
 
-        try {
-            function onProgress(loadedBytes: number, totalBytes: number) {
-                const state: FileUploadState = { description: 'uploading', loadedBytes, totalBytes };
-                dispatch({ type: 'Set_Upload_State', file: path, state });
+        if (file.size > MAX_FILE_UPLOAD_SIZE_BYTES) {
+            console.error(`Error uploading ${path}: file is too large (limit ${MAX_FILE_UPLOAD_SIZE_MBYTES}MB`)
+            dispatch({ type: "Set_Upload_State", file: path, state: { description: 'failed', failureReason: `File too large (limit ${MAX_FILE_UPLOAD_SIZE_MBYTES}MB)` }});
+        } else {
+            try {
+                function onProgress(loadedBytes: number, totalBytes: number) {
+                    const state: FileUploadState = { description: 'uploading', loadedBytes, totalBytes };
+                    dispatch({ type: 'Set_Upload_State', file: path, state });
+                }
+
+                const metadata = await buildWorkspaceUploadMetadata(path, target, workspaceFolderCache);
+                await uploadFileToIngestion(target.ingestion, uploadId, file, path, metadata, onProgress);
+
+                dispatch({ type: "Set_Upload_State", file: path, state: { description: 'uploaded' }});
+            } catch(e) {
+                console.error(`Error uploading ${path}: ${e}`);
+                dispatch({ type: "Set_Upload_State", file: path, state: { description: 'failed' }});
             }
-
-            const metadata = await buildWorkspaceUploadMetadata(path, target, workspaceFolderCache);
-            await uploadFileToIngestion(target.ingestion, uploadId, file, path, metadata, onProgress);
-
-            dispatch({ type: "Set_Upload_State", file: path, state: { description: 'uploaded' }});
-        } catch(e) {
-            console.error(`Error uploading ${path}: ${e}`);
-            dispatch({ type: "Set_Upload_State", file: path, state: { description: 'failed' }});
         }
 
         if(files.length > 1) {

--- a/frontend/src/js/components/Uploads/UploadFiles.tsx
+++ b/frontend/src/js/components/Uploads/UploadFiles.tsx
@@ -316,7 +316,7 @@ export default function UploadFiles(props: Props) {
             </button>
             <Modal isOpen={open} dismiss={onDismiss} isDismissable={!isUploading}>
                 <Form onSubmit={onSubmit}>
-                    <h2 className='form__title'>Upload Files</h2>
+                    <h2 className='form__title'>Upload Files (limit {MAX_FILE_UPLOAD_SIZE_MBYTES}MB per file)</h2>
                     { focusedWorkspaceRelativePath ? <div className='form__row'>Uploading to folder {focusedWorkspaceRelativePath}</div> : false}
                     <Form.Field>
                         <FilePicker

--- a/frontend/src/js/components/Uploads/UploadFiles.tsx
+++ b/frontend/src/js/components/Uploads/UploadFiles.tsx
@@ -20,7 +20,6 @@ import { isTreeLeaf, isTreeNode, TreeEntry, TreeNode } from '../../types/Tree';
 import { getWorkspace } from '../../actions/workspaces/getWorkspace';
 import { useDispatch } from 'react-redux';
 import { AppActionType } from '../../types/redux/GiantActions';
-import {BasicResource, BasicResourceWithSingleBlobChild} from "../../types/Resource";
 
 const MAX_FILE_UPLOAD_SIZE_MBYTES = 250 // should correspond to http.parser.maxDiskBuffer in application.conf
 const MAX_FILE_UPLOAD_SIZE_BYTES = MAX_FILE_UPLOAD_SIZE_MBYTES*1024*1024


### PR DESCRIPTION
## What does this change?
In https://github.com/guardian/pfi/pull/839 we set the file upload limit to 100MB. This PR bumps that further. As  far as I can tell, there was no particular reason to limit workspace uploads to 100MB. We have had at least one user need to upload a file larger than 100MB, this change would have helped them. 

As a follow up piece of work, we should expose the file size limit in the UI and warn users when they try to upload a file above the limit.

## How to test
Tested on playground with a 190MB file


## Have we considered potential risks?

There could be performance implications of allowing such a large file to be uploaded via the UI. Hopefully the new dashboards should allow us to pick those up as and when they occur
