### PR TITLE
Rename 'uploads' settings option to 'uploads calendar'

### DIFF
--- a/frontend/src/js/components/Settings/SettingsSidebar.js
+++ b/frontend/src/js/components/Settings/SettingsSidebar.js
@@ -26,7 +26,7 @@ class SettingsSidebar extends React.Component {
     renderAdminLinks = () => {
         return <React.Fragment>
             <SidebarSearchLink className='sidebar__item' to='/settings/uploads'>
-                <div className='sidebar__item__text'>Uploads</div>
+                <div className='sidebar__item__text'>Upload calendar</div>
             </SidebarSearchLink>
             <SidebarSearchLink className='sidebar__item' to='/settings/users'>
                 <div className='sidebar__item__text'>Users</div>


### PR DESCRIPTION
As we now have 2 new upload related dashboards called 'my uploads' and 'all ingestion events' this one needs a more accurate name