### PR TITLE
Add pagination to ingestion events table

### DIFF
--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -180,6 +180,47 @@ const renderExpandedRow = (blobStatus: BlobStatus) => {
     </EuiText>
 }
 
+function IngestionEventsTable({
+    blobs,
+    columnsWithExpandingRow,
+    itemIdToExpandedRowMap,
+}: {
+    blobs: BlobStatus[]
+    columnsWithExpandingRow: Array<EuiBasicTableColumn<BlobStatus>>
+    itemIdToExpandedRowMap: Record<string, ReactNode>
+}) {
+    const [pageIndex, setPageIndex] = useState(0)
+    const [pageSize, setPageSize] = useState(10)
+
+    const pagination = {
+        pageIndex,
+        pageSize,
+        pageSizeOptions: [10, 100, 250],
+    }
+
+    const onTableChange = ({ page }: Criteria<BlobStatus>) => {
+        if (page) {
+            const { index: pageIndex, size: pageSize } = page
+            setPageIndex(pageIndex)
+            setPageSize(pageSize)
+        }
+    }
+
+    return (
+        <EuiInMemoryTable
+            tableCaption="ingestion events"
+            items={blobs}
+            itemId={blobStatusId}
+            loading={blobs === undefined}
+            columns={columnsWithExpandingRow}
+            sorting={true}
+            itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+            pagination={pagination}
+            onTableChange={onTableChange}
+        />
+    )
+}
+
 export function IngestionEvents(
     {collectionId, ingestId, workspaces, breakdownByWorkspace, showErrorsOnly}: {
         collectionId: string,
@@ -188,8 +229,6 @@ export function IngestionEvents(
         breakdownByWorkspace: boolean,
         showErrorsOnly: boolean,
     }) {
-    const [pageIndex, setPageIndex] = useState(0);
-    const [pageSize, setPageSize] = useState(10);
     const [blobs, updateBlobs] = useState<BlobStatus[] | undefined>(undefined)
     const [tableData, setTableData] = useState<IngestionTable[]>([])
 
@@ -278,39 +317,19 @@ export function IngestionEvents(
         }
     }, [breakdownByWorkspace, blobs, workspaces, ingestIdSuffix, collectionId, showErrorsOnly, setItemIdToExpandedRowMap])
 
-    const pagination = {
-        pageIndex,
-        pageSize,
-        pageSizeOptions: [10, 100, 250],
-    };
-
-    const onTableChange = ({ page }: Criteria<BlobStatus>) => {
-        if (page) {
-          const { index: pageIndex, size: pageSize } = page;
-          setPageIndex(pageIndex);
-          setPageSize(pageSize);
-        }
-    };
-
     return (
         <>
-        {tableData.map((t: IngestionTable) =>
-            <div key={t.title}>
-            <EuiSpacer size={"m"}/>
-            <h1>{t.title}</h1>
-            <EuiInMemoryTable
-                tableCaption="ingestion events"
-                items={t.blobs}
-                itemId={blobStatusId}
-                loading={t.blobs === undefined}
-                columns={columnsWithExpandingRow}
-                sorting={true}
-                itemIdToExpandedRowMap={itemIdToExpandedRowMap}
-                pagination={pagination}
-                onTableChange={onTableChange}
-            />
-            </div>
-        )}
+            {tableData.map((t: IngestionTable) => (
+                <div key={t.title}>
+                    <EuiSpacer size={"m"} />
+                    <h1>{t.title}</h1>
+                    <IngestionEventsTable
+                        blobs={t.blobs}
+                        columnsWithExpandingRow={columnsWithExpandingRow}
+                        itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+                    />
+                </div>
+            ))}
         </>
     )
 }

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -184,18 +184,23 @@ function IngestionEventsTable({
     blobs,
     columnsWithExpandingRow,
     itemIdToExpandedRowMap,
+    breakdownByWorkspace,
 }: {
     blobs: BlobStatus[]
     columnsWithExpandingRow: Array<EuiBasicTableColumn<BlobStatus>>
     itemIdToExpandedRowMap: Record<string, ReactNode>
+    breakdownByWorkspace: boolean
 }) {
+    const defaultPageSize = breakdownByWorkspace ? 10 : 100
     const [pageIndex, setPageIndex] = useState(0)
-    const [pageSize, setPageSize] = useState(10)
+    const [pageSize, setPageSize] = useState(defaultPageSize)
 
     const pagination = {
         pageIndex,
         pageSize,
-        pageSizeOptions: [10, 100, 250],
+        pageSizeOptions: breakdownByWorkspace
+            ? [defaultPageSize, 100, 250]
+            : [defaultPageSize, 250, 500],
     }
 
     const onTableChange = ({ page }: Criteria<BlobStatus>) => {
@@ -327,6 +332,7 @@ export function IngestionEvents(
                         blobs={t.blobs}
                         columnsWithExpandingRow={columnsWithExpandingRow}
                         itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+                        breakdownByWorkspace={breakdownByWorkspace}
                     />
                 </div>
             ))}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds pagination to ingestion events tables on "My uploads" and "All ingestion events" pages

![Screenshot 2023-09-19 at 17 24 10](https://github.com/guardian/giant/assets/17057932/5347620a-82a0-4dc9-bc5e-d8a1bb34d2dd)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
