### PR TITLE
Clean paths property of ingestion events in parser

### DIFF
--- a/backend/app/services/observability/Models.scala
+++ b/backend/app/services/observability/Models.scala
@@ -176,4 +176,11 @@ object BlobStatus {
   implicit val dateWrites = JodaReadWrites.dateWrites
   implicit val dateReads = JodaReadWrites.dateReads
   implicit val format = Json.format[BlobStatus]
+
+  def parsePathsArray(paths: Array[String]): List[String] = {
+    val nonNullPaths = paths.filter(p => p != null )
+    if (nonNullPaths.isEmpty) {
+      List("unknown filename")
+    } else nonNullPaths.toList
+  }
 }

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -168,7 +168,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
                         rs.string("blob_id"),
                         rs.string("ingest_id")
                     ),
-                    rs.array("paths").getArray().asInstanceOf[Array[String]].toList,
+                    BlobStatus.parsePathsArray(rs.array("paths").getArray().asInstanceOf[Array[String]]),
                     rs.longOpt("fileSize"),
                     rs.stringOpt("workspaceName"),
                   PostgresHelpers.postgresEpochToDateTime(rs.double("ingest_start")),

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -131,6 +131,7 @@ const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
 const parseBlobStatus = (status: any): BlobStatus => {
     return {
         ...status,
+        paths: status.paths.map((p: any) => p ? p : "unknown-filename"),
         ingestStart: new Date(status.ingestStart),
         mostRecentEvent: new Date(status.mostRecentEvent),
         mimeTypes: status.mimeTypes?.split(","),


### PR DESCRIPTION
## What does this change?
We have a bug at the moment where if there is no `path` available for a `BlobStatus` then the dashboard will crash. This PR fixes the problem at both ends - filtering out null paths both on the server and the client.

## How to test
Tested locally, think this is simple enough to go out as is!