### PR TITLE
Allow admins to view all observability data

### DIFF
--- a/backend/app/controllers/api/IngestionEvents.scala
+++ b/backend/app/controllers/api/IngestionEvents.scala
@@ -14,25 +14,29 @@ class IngestionEvents(override val controllerComponents: AuthControllerComponent
   extends AuthApiController {
 
   private def getEvents(collection: String, ingestion: Option[String] = None): Action[AnyContent] = ApiAction.attempt { req =>
-    for {
+    (for {
       canSeeCollection <- users.canSeeCollection(req.user.username, Uri(collection))
       isAdmin <- users.hasPermission(req.user.username, CanPerformAdminOperations)
     } yield {
-      if (isAdmin || canSeeCollection) {
+      (isAdmin, canSeeCollection)
+    }).flatMap {
+      case (isAdmin, canSeeCollection) if isAdmin || canSeeCollection =>
         val ingestIdSuffix = ingestion.map(i => s"/$i").getOrElse("")
         val ingestId = s"$collection$ingestIdSuffix"
         val maybeEvents = postgresClient.getEvents(ingestId, ingestion.isEmpty)
         val anonymisedEvents = if (canSeeCollection) {
+          // return original data
           maybeEvents
         } else {
+          // admins may need to see historical data for e.g. gaining an understanding of the most common types of error
+          // but they don't need to connect it to a particular user
           maybeEvents.map(e => BlobStatus.anonymiseEventsOlderThanTwoWeeks(e))
         }
         Attempt.fromEither(anonymisedEvents.map(e => Ok(Json.toJson(e))))
-      } else {
+      case _ =>
         // GitHub-style error - a thing exists but we can't see it so tell the user it doesn't exist
         Attempt.Left(NotFoundFailure(s"$collection/$ingestion does not exist"))
       }
-    }
   }
 
   def getCollectionEvents(collection: String) = getEvents(collection, None)

--- a/backend/app/controllers/api/IngestionEvents.scala
+++ b/backend/app/controllers/api/IngestionEvents.scala
@@ -35,7 +35,7 @@ class IngestionEvents(override val controllerComponents: AuthControllerComponent
         Attempt.fromEither(anonymisedEvents.map(e => Ok(Json.toJson(e))))
       case _ =>
         // GitHub-style error - a thing exists but we can't see it so tell the user it doesn't exist
-        Attempt.Left(NotFoundFailure(s"$collection/$ingestion does not exist"))
+        Attempt.Left(NotFoundFailure(s"$collection/${ingestion.getOrElse("")} does not exist"))
       }
   }
 

--- a/backend/app/services/observability/Models.scala
+++ b/backend/app/services/observability/Models.scala
@@ -193,7 +193,7 @@ object BlobStatus {
     */
   private def anonymise(status: BlobStatus): BlobStatus = {
     status.copy(
-      paths = List("redacted"),
+      paths = List("[REDACTED]"),
       workspaceName = status.workspaceName.map(DigestUtils.md5Hex)
     )
   }

--- a/backend/app/services/observability/Models.scala
+++ b/backend/app/services/observability/Models.scala
@@ -3,6 +3,7 @@ package services.observability
 import extraction.Extractor
 import play.api.libs.json.{Format, Json}
 import model.manifest.Blob
+import org.apache.commons.codec.digest.DigestUtils
 import org.joda.time.{DateTime, DateTimeZone}
 import services.index.IngestionData
 import services.observability.ExtractorType.ExtractorType
@@ -185,18 +186,15 @@ object BlobStatus {
     } else nonNullPaths.toList
   }
 
-  private def md5(string:String): String = MessageDigest.getInstance("MD5").digest(string.getBytes).map(_.toChar).mkString
-
   /**
     * Aims to remove all information from blob status that is likely to identify the user who uploaded it or the file itself
     * @param status
     * @return
     */
-  def anonymise(status: BlobStatus): BlobStatus = {
+  private def anonymise(status: BlobStatus): BlobStatus = {
     status.copy(
-      metadata = status.metadata.copy(ingestId = md5(status.metadata.ingestId)),
       paths = List("redacted"),
-      workspaceName = status.workspaceName.map(md5)
+      workspaceName = status.workspaceName.map(DigestUtils.md5Hex)
     )
   }
 


### PR DESCRIPTION
## What does this change?
In future we hope that if we see an alarm or user error report with giant, we will be able to use the observability dashboard to help diagnose the issue. With the current implementation, it is only possible to view the observability data associated with an upload if the 'viewing' user has the rights to see the relevant collection. This PR changes the behaviour so that admin giant users are able to 'spy' on the observability data associated with any users' collections. 

Security wise, this doesn't represent a significant change as Giant Admins are already able to add themselves to any collection. We'd prefer they didn't do this though as it allows them to access all the files a user has uploaded.

The new logic is:
 - If you have view access to a collection, you can see all observability data
 - If you don't have view access but are a giant admin, then you can see all observability data, but everything older than 2 weeks is anonymised in the UI
 - Otherwise, you get a 404.

The motivation for the 2 week anonymisation is that, after 2 weeks, there's a very slim chance an admin user is looking for a specific file - instead it is more likely they are looking for e.g. what is the most common error to have occurred - in which case they shouldn't need to know specific filenames, workspace names etc.

There is an argument that we should just anonymise all data where the admin user doesn't have view rights over a collection - happy to change this depending what people think

## How to test
I've tested this on playground and locally by taking away access to my own collections, it looks like this:

![Screenshot 2023-09-25 at 14 26 59](https://github.com/guardian/giant/assets/3606555/f345c294-40e6-47bb-abcb-9c22a146d57f)


## How can we measure success?
Admins are more quickly able to debug user upload errors