### PR TITLE
fix: Exclude infinitely-ingesting blobs from observability query

### DIFF
--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -141,6 +141,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
               -- there is no index on extractorName but we aren't expecting too many events for the same blob_id/ingest_id
               AND blob_extractors.extractor = ingestion_events.details ->> 'extractorName'
               -- A file may be uploaded multiple times within different ingests - use group by to merge them together
+            WHERE ingestion_events.type = 'RunExtractor'
             GROUP BY 1,2,3
           )
           SELECT

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -142,8 +142,8 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
               AND blob_extractors.ingest_id = ingestion_events.ingest_id
               -- there is no index on extractorName but we aren't expecting too many events for the same blob_id/ingest_id
               AND blob_extractors.extractor = ingestion_events.details ->> 'extractorName'
-              -- A file may be uploaded multiple times within different ingests - use group by to merge them together
             WHERE ingestion_events.type = 'RunExtractor'
+            -- A file may be uploaded multiple times within different ingests - use group by to merge them together
             GROUP BY 1,2,3
           )
           SELECT

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -111,6 +111,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
             */
           val results = sql"""
           WITH problem_blobs AS (
+            -- assume that blobs with more than 100 ingestion_events are failing to be ingested in an infinite loop
             SELECT blob_id
             from ingestion_events
             WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId}

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -110,31 +110,31 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
             *
             */
           val results = sql"""
-      WITH blob_extractors AS (
-      -- get all the extractors expected for a given blob
-       SELECT ingest_id, blob_id, jsonb_array_elements_text(details -> 'extractors') as extractor from ingestion_events
-       WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId} AND
-       type = ${IngestionEventType.MimeTypeDetected.toString}
+          WITH blob_extractors AS (
+            -- get all the extractors expected for a given blob
+            SELECT ingest_id, blob_id, jsonb_array_elements_text(details -> 'extractors') as extractor from ingestion_events
+            WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId} AND
+            type = ${IngestionEventType.MimeTypeDetected.toString}
           ),
           extractor_statuses as (
-          -- Aggregate all the status updates for the relevant extractors for a given blob
-          SELECT
-            blob_extractors.blob_id,
-            blob_extractors.ingest_id,
-            blob_extractors.extractor,
-            -- As the same status update may happen multiple times if a blob is reingested, it's useful to have the time
-            -- this field is destined to be converted to a string so use epoch time (seconds) to make getting it back into
-            -- a date a bit less of a faff
-            ARRAY_AGG(EXTRACT(EPOCH from ingestion_events.event_time)) AS extractor_event_times,
-            ARRAY_AGG(ingestion_events.status) AS extractor_event_statuses
-            FROM blob_extractors
-            LEFT JOIN ingestion_events
-            ON blob_extractors.blob_id = ingestion_events.blob_id
-            AND blob_extractors.ingest_id = ingestion_events.ingest_id
-            -- there is no index on extractorName but we aren't expecting too many events for the same blob_id/ingest_id
-            AND blob_extractors.extractor = ingestion_events.details ->> 'extractorName'
-            -- A file may be uploaded multiple times within different ingests - use group by to merge them together
-            GROUP BY 1,2,3
+            -- Aggregate all the status updates for the relevant extractors for a given blob
+            SELECT
+              blob_extractors.blob_id,
+              blob_extractors.ingest_id,
+              blob_extractors.extractor,
+              -- As the same status update may happen multiple times if a blob is reingested, it's useful to have the time
+              -- this field is destined to be converted to a string so use epoch time (seconds) to make getting it back into
+              -- a date a bit less of a faff
+              ARRAY_AGG(EXTRACT(EPOCH from ingestion_events.event_time)) AS extractor_event_times,
+              ARRAY_AGG(ingestion_events.status) AS extractor_event_statuses
+              FROM blob_extractors
+              LEFT JOIN ingestion_events
+              ON blob_extractors.blob_id = ingestion_events.blob_id
+              AND blob_extractors.ingest_id = ingestion_events.ingest_id
+              -- there is no index on extractorName but we aren't expecting too many events for the same blob_id/ingest_id
+              AND blob_extractors.extractor = ingestion_events.details ->> 'extractorName'
+              -- A file may be uploaded multiple times within different ingests - use group by to merge them together
+              GROUP BY 1,2,3
           )
           SELECT
             ie.blob_id,
@@ -150,23 +150,23 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
             -- You can't array_agg arrays of varying cardinality so here we convert to string
             ARRAY_REMOVE(ARRAY_AGG(ARRAY_TO_STRING(extractor_statuses.extractor_event_times, ',','null')), NULL) AS "extractorEventTimes",
             ARRAY_REMOVE(ARRAY_AGG(ARRAY_TO_STRING(extractor_statuses.extractor_event_statuses, ',','null')), NULL) AS "extractorStatuses"
-            FROM (
-              SELECT
-                blob_id,
-                ingest_id,
-                MIN(EXTRACT(EPOCH from event_time)) AS ingest_start,
-                MAX(EXTRACT(EPOCH from event_time)) AS most_recent_event,
-                ARRAY_AGG(details -> 'errors') as errors,
-                (ARRAY_AGG(details ->> 'workspaceName')  FILTER (WHERE details ->> 'workspaceName' IS NOT NULL))[1] as workspace_name,
-                (ARRAY_AGG(details ->> 'mimeTypes')  FILTER (WHERE details ->> 'mimeTypes' IS NOT NULL))[1] as mime_types
-              FROM ingestion_events
-              WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId}
-              GROUP BY 1,2
-            ) AS ie
-            LEFT JOIN blob_metadata USING(ingest_id, blob_id)
-            LEFT JOIN extractor_statuses on extractor_statuses.blob_id = ie.blob_id and extractor_statuses.ingest_id = ie.ingest_id
-            GROUP BY 1,2,3,4,5,6,7
-            ORDER by ingest_start desc
+          FROM (
+            SELECT
+              blob_id,
+              ingest_id,
+              MIN(EXTRACT(EPOCH from event_time)) AS ingest_start,
+              MAX(EXTRACT(EPOCH from event_time)) AS most_recent_event,
+              ARRAY_AGG(details -> 'errors') as errors,
+              (ARRAY_AGG(details ->> 'workspaceName')  FILTER (WHERE details ->> 'workspaceName' IS NOT NULL))[1] as workspace_name,
+              (ARRAY_AGG(details ->> 'mimeTypes')  FILTER (WHERE details ->> 'mimeTypes' IS NOT NULL))[1] as mime_types
+            FROM ingestion_events
+            WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId}
+            GROUP BY 1,2
+          ) AS ie
+          LEFT JOIN blob_metadata USING(ingest_id, blob_id)
+          LEFT JOIN extractor_statuses on extractor_statuses.blob_id = ie.blob_id and extractor_statuses.ingest_id = ie.ingest_id
+          GROUP BY 1,2,3,4,5,6,7
+          ORDER by ingest_start desc
      """.map(rs => {
                 BlobStatus(
                     EventMetadata(

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -120,8 +120,9 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
           blob_extractors AS (
             -- get all the extractors expected for a given blob
             SELECT ingest_id, blob_id, jsonb_array_elements_text(details -> 'extractors') as extractor from ingestion_events
-            WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId} AND
-            type = ${IngestionEventType.MimeTypeDetected.toString}
+            WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId}
+            AND type = ${IngestionEventType.MimeTypeDetected.toString}
+            AND blob_id NOT IN (SELECT blob_id FROM problem_blobs)
           ),
           extractor_statuses as (
             -- Aggregate all the status updates for the relevant extractors for a given blob


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We've found a few cases of bugs where ingestion fails only to be retried minutes later, forever. These retries create thousands of rows in `ingestion_events` which makes the observability dashboard query timeout. This PR should fix the dashboard for ingests with problem files in an infinite retry cycle while we come up with a better retrying solution.

In a follow-up we plan to put blob ids which have more than 100 ingest events back into the dashboard table, with a helpful explanation as to what's going on.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
