### PR TITLE
Add delete functionality in document viewer for non-admin users

### DIFF
--- a/backend/app/controllers/api/Blobs.scala
+++ b/backend/app/controllers/api/Blobs.scala
@@ -107,7 +107,7 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
     manifest.getCollectionsForBlob(blobUri).flatMap { collections =>
       // Here we check either of 2 followings:
       // if there's only 1 collection holding the blob and if the requesting user has view access to the collection
-      // OR if the requesting user is the only creator of the blob
+      // OR if the requesting user is the only creator of the blob e.g. if a user has uploaded the same file to multiple workspaces
       if ((collections.size == 1 && collections.head._2.contains(user.username)) || collections.forall(c => c._1.createdBy == Some(user.username))) {
         logAction(user, s"Deleting resource from Giant if no children. Resource uri: $blobUri")
         val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage, postgresClient)

--- a/backend/app/controllers/api/Blobs.scala
+++ b/backend/app/controllers/api/Blobs.scala
@@ -99,11 +99,11 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
         result.map(_ => NoContent)
       }
     } else {
-      deleteForNoneAdmin(req.user, id).map(_ => NoContent)
+      deleteForNonAdmin(req.user, id).map(_ => NoContent)
     }
   }
 
-  private def deleteForNoneAdmin(user: User, blobUri: String): Attempt[Unit] = {
+  private def deleteForNonAdmin(user: User, blobUri: String): Attempt[Unit] = {
     manifest.getCollectionsForBlob(blobUri).flatMap { collections =>
       // Here we check either of 2 followings:
       // if there's only 1 collection holding the blob and if the requesting user has view access to the collection

--- a/backend/app/controllers/api/Blobs.scala
+++ b/backend/app/controllers/api/Blobs.scala
@@ -5,14 +5,13 @@ import model.Uri
 import model.user.UserPermission.CanPerformAdminOperations
 import net.logstash.logback.marker.LogstashMarker
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, Request, Result}
+import play.api.mvc.{Action, AnyContent, Request}
 import services.ObjectStorage
 import services.index.Index
 import services.manifest.Manifest
 import services.observability.PostgresClient
-import services.previewing.PreviewService
 import utils.Logging
-import utils.attempt.{Attempt, DeleteFailure}
+import utils.attempt.{Attempt, DeleteNotAllowed}
 import utils.auth.User
 import utils.controller.{AuthApiController, AuthControllerComponents, FailureToResultMapper}
 
@@ -115,7 +114,7 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
         deleteResource.deleteBlobCheckChildren(blobUri)
       } else {
         logAction(user, s"Can't delete resource due to file ownership conflict. Resource uri: $blobUri")
-        Attempt.Left[Unit](DeleteFailure("Failed to delete resource"))
+        Attempt.Left[Unit](DeleteNotAllowed("Failed to delete resource"))
       }
     }
   }

--- a/backend/app/controllers/api/Blobs.scala
+++ b/backend/app/controllers/api/Blobs.scala
@@ -3,6 +3,7 @@ package controllers.api
 import commands.DeleteResource
 import model.Uri
 import model.user.UserPermission.CanPerformAdminOperations
+import net.logstash.logback.marker.LogstashMarker
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, Request, Result}
 import services.ObjectStorage
@@ -12,6 +13,7 @@ import services.observability.PostgresClient
 import services.previewing.PreviewService
 import utils.Logging
 import utils.attempt.{Attempt, DeleteFailure}
+import utils.auth.User
 import utils.controller.{AuthApiController, AuthControllerComponents, FailureToResultMapper}
 
 
@@ -88,13 +90,39 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
   }
 
 
-  def delete(id: String, checkChildren: Boolean): Action[AnyContent] = ApiAction.attempt { req =>
+  def delete(id: String, checkChildren: Boolean, isAdminDelete: Boolean): Action[AnyContent] = ApiAction.attempt { req =>
     import scala.language.existentials
-    val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage, postgresClient)
-    checkPermission(CanPerformAdminOperations, req) {
-      val result = if (checkChildren) deleteResource.deleteBlobCheckChildren(id)
-      else deleteResource.deleteBlob(id)
-      result.map(_ => NoContent)
+    val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage)
+    if (isAdminDelete) {
+      checkPermission(CanPerformAdminOperations, req) {
+        val result = if (checkChildren) deleteResource.deleteBlobCheckChildren(id)
+        else deleteResource.deleteBlob(id)
+        result.map(_ => NoContent)
+      }
+    } else {
+      deleteForNoneAdmin(req.user, id).map(_ => NoContent)
     }
   }
+
+  private def deleteForNoneAdmin(user: User, blobUri: String): Attempt[Unit] = {
+    manifest.getCollectionsForBlob(blobUri).flatMap { collections =>
+      // Here we check either of 2 followings:
+      // if there's only 1 collection holding the blob and if the requesting user has view access to the collection
+      // OR if the requesting user is the only creator of the blob
+      if ((collections.size == 1 && collections.head._2.contains(user.username)) || collections.forall(c => c._1.createdBy == Some(user.username))) {
+        logAction(user, s"Deleting resource from Giant if no children. Resource uri: $blobUri")
+        val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage)
+        deleteResource.deleteBlobCheckChildren(blobUri)
+      } else {
+        logAction(user, s"Can't delete resource due to file ownership conflict. Resource uri: $blobUri")
+        Attempt.Left[Unit](DeleteFailure("Failed to delete resource"))
+      }
+    }
+  }
+
+  private def logAction(user: User, message: String) = {
+    val markers: LogstashMarker = user.asLogMarker
+    logger.info(markers, message)
+  }
+
 }

--- a/backend/app/controllers/api/Blobs.scala
+++ b/backend/app/controllers/api/Blobs.scala
@@ -92,7 +92,7 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
 
   def delete(id: String, checkChildren: Boolean, isAdminDelete: Boolean): Action[AnyContent] = ApiAction.attempt { req =>
     import scala.language.existentials
-    val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage)
+    val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage, postgresClient)
     if (isAdminDelete) {
       checkPermission(CanPerformAdminOperations, req) {
         val result = if (checkChildren) deleteResource.deleteBlobCheckChildren(id)
@@ -111,7 +111,7 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
       // OR if the requesting user is the only creator of the blob
       if ((collections.size == 1 && collections.head._2.contains(user.username)) || collections.forall(c => c._1.createdBy == Some(user.username))) {
         logAction(user, s"Deleting resource from Giant if no children. Resource uri: $blobUri")
-        val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage)
+        val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage, postgresClient)
         deleteResource.deleteBlobCheckChildren(blobUri)
       } else {
         logAction(user, s"Can't delete resource due to file ownership conflict. Resource uri: $blobUri")

--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -275,7 +275,7 @@ class Workspaces(override val controllerComponents: AuthControllerComponents, an
         deleteResource.deleteBlobCheckChildren(blobUri)
       } else {
         logAction(req.user, workspaceId, s"Can't delete resource due to file ownership conflict. Resource uri: $blobUri")
-        Attempt.Left[Unit](DeleteFailure("Failed to delete resource"))
+        Attempt.Left[Unit](DeleteNotAllowed("Failed to delete resource"))
       }
     } map (_ => NoContent)
   }

--- a/backend/app/services/manifest/Manifest.scala
+++ b/backend/app/services/manifest/Manifest.scala
@@ -48,6 +48,8 @@ trait Manifest extends WorkerManifest {
 
   def getCollections: Attempt[List[Collection]]
 
+  def getCollectionsForBlob(blobUri: String): Attempt[Map[Collection, Seq[String]]]
+
   def getResource(resourceUri: Uri): Either[Failure, BasicResource]
 
   def getIngestions(collection: Uri): Attempt[Seq[Ingestion]]

--- a/backend/app/utils/controller/FailureToResultMapper.scala
+++ b/backend/app/utils/controller/FailureToResultMapper.scala
@@ -111,6 +111,9 @@ object FailureToResultMapper extends Logging {
       case DeleteFailure(msg) =>
         logUserAndMessage(user, s"Delete failed: ${msg}")
         Results.InternalServerError(msg)
+      case DeleteNotAllowed(msg) =>
+        logUserAndMessage(user, s"Deletion is refused: ${msg}")
+        Results.Forbidden(msg)
       case f: PostgresWriteFailure =>
         logger.error(f.msg, f.throwable)
         Results.InternalServerError(f.msg)

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -18,7 +18,7 @@ GET           /api/ingestion-events/:collection/:ingestion                contro
 GET           /api/blobs                                                    controllers.api.Blobs.getBlobs(collection: Option[String], ingestion: Option[String], inMultiple: Option[Boolean], size: Option[Int])
 GET           /api/blobs/count                                              controllers.api.Blobs.countBlobs(collection: Option[String], ingestion: Option[String], inMultiple: Option[Boolean])
 POST          /api/blobs/:id/reprocess                                      controllers.api.Blobs.reprocess(id, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])
-DELETE        /api/blobs/:id                                                controllers.api.Blobs.delete(id, checkChildren: Boolean)
+DELETE        /api/blobs/:id                                                controllers.api.Blobs.delete(id, checkChildren: Boolean, isAdminDelete: Boolean)
 
 GET           /api/filters                                                  controllers.api.Filters.getFilters()
 

--- a/backend/test/controllers/api/WorkspaceSharingITest.scala
+++ b/backend/test/controllers/api/WorkspaceSharingITest.scala
@@ -195,7 +195,7 @@ class WorkspaceSharingITest extends AnyFunSuite with Neo4jTestService with Elast
       status(deleteFileFromWorkspace(
         workspaceId = paulWorkspace.id,
         blobUri = paulBlobAndNodeId.blobId
-      )) should be(500)
+      )) should be(403)
     }
   }
 

--- a/common/src/main/scala/utils/attempt/Failure.scala
+++ b/common/src/main/scala/utils/attempt/Failure.scala
@@ -123,3 +123,5 @@ case object SubprocessInterruptedFailure extends Failure {
 case class ContentTooLongFailure(msg: String) extends Failure
 
 case class DeleteFailure(msg: String) extends Failure
+
+case class DeleteNotAllowed(msg: String) extends Failure

--- a/frontend/src/js/components/viewer/ViewerActions.js
+++ b/frontend/src/js/components/viewer/ViewerActions.js
@@ -4,6 +4,7 @@ import DeleteButton from './DeleteButtonModal';
 import AddToWorkspaceModal from './AddToWorkspaceModal';
 import { resourcePropType } from '../../types/Resource';
 import PropTypes from 'prop-types';
+import { deleteBlob, deleteBlobForAdmin } from '../../services/BlobApi';
 
 export default class ViewerActions extends React.Component {
     static propTypes = {
@@ -27,7 +28,9 @@ export default class ViewerActions extends React.Component {
                     </button>
                     <DownloadButton />
 
-                    {!this.props.disableDelete && this.props.isAdmin && this.props.resource && <DeleteButton />  }
+                    <DeleteButton deleteBlob={deleteBlob} />
+
+                    {!this.props.disableDelete && this.props.isAdmin && this.props.resource && <DeleteButton deleteBlob={deleteBlobForAdmin} buttonTitle='Admin delete' />  }
 
                 </div>
 

--- a/frontend/src/js/services/BlobApi.ts
+++ b/frontend/src/js/services/BlobApi.ts
@@ -1,6 +1,10 @@
 import authFetch from '../util/auth/authFetch';
 
-export function deleteBlob(uri: string): Promise<Response> {
+export function deleteBlobForAdmin(uri: string): Promise<Response> {
     // Do not delete blob if it has children
-    return authFetch(`/api/blobs/${uri}?checkChildren=true`, {method: "DELETE"})
+    return authFetch(`/api/blobs/${uri}?checkChildren=true&isAdminDelete=true`, {method: "DELETE"})
+}
+
+export function deleteBlob(blobUri: string) {
+    return authFetch(`/api/blobs/${blobUri}?checkChildren=true&isAdminDelete=false`, {method: "DELETE"});
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds delete functionality for all users within document viewer. However, the delete may only pass if 
- the file doesn't have children and
  - the file is within only 1 collection and the user has view access on the file
  - Or the file is within several collections that have been created by the requesting user

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
![ezgif-5-abab464ff6](https://github.com/guardian/giant/assets/15894063/a078b83b-931e-450b-abbb-6e44e3c8f782)

## How to test
This was tested both locally and in playground

