### PR TITLE
Remove redundant package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "giant",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
All npm stuff lives in the frontend subdirectory, so we don't need a package-lock at the root. Also, having one here confuses the snyk GHA runner