### PR TITLE
Bump postgresql library to 42.2.27 to fix vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -162,7 +162,7 @@ lazy val backend = (project in file("backend"))
 
       // postgres
       "org.scalikejdbc" %% "scalikejdbc"       % "3.5.0",
-      "org.postgresql"  %  "postgresql"        % "42.2.5",
+      "org.postgresql"  %  "postgresql"        % "42.2.27",
 
       // Test dependencies
 


### PR DESCRIPTION
See https://app.snyk.io/org/guardian-investigations/project/a40df7ee-382f-42d9-b182-53f7f515cca4#issue-SNYK-JAVA-ORGPOSTGRESQL-2970521 - this resolves https://cwe.mitre.org/data/definitions/89.html

This is a patch version bump so should be very safe
