### PR TITLE
Show error icon in events dashboard for non-extractor errors

### DIFF
--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -62,8 +62,12 @@ const statusIconColumn = {
         field: 'extractorStatuses',
         name: '',
         width: '40',
-        render: (statuses: ExtractorStatus[]) => {
-            return blobStatusIcons[getBlobStatus(statuses)]
+        render: (statuses: ExtractorStatus[], row: BlobStatus) => {
+            const totalErrors = row.errors.length
+            const extractorStatus = getBlobStatus(statuses)
+            // if extractors have finished but there are other non-extractor related errors, show an error icon
+            const combinedStatus = extractorStatus === "complete" && totalErrors > 0 ? "completeWithErrors" : extractorStatus
+            return blobStatusIcons[combinedStatus]
         }
     }
 


### PR DESCRIPTION
## What does this change?
At the moment we only show the 'error' icon in the dashboard if an extractor has failed. There are other error conditions, such as if a file fails to be added to neo4j/elasticsearch. In the latter case (fail to add to elasticsearch, e.g. if elastic is down) then the file _may_ still have succesful extractor runs, but have problems associated with it.

We are already exposing all errors that are written to postgres on the client side UI at the bottom of the 'expanded row' view. This PR makes them a bit more discoverable by changing the status icon for the row to 'complete with errors' (warning icon)

## How to test
I've tested this locally, I think it's a small enough change not to test on playground (as this would be a bit challenging to reproduce such an error condition). Happy to try test it if others disagree though!

## How can we measure success?
More visibility on errors occuring as part of an ingestion