### PR TITLE
remove alpha channel from tiff file

### DIFF
--- a/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
@@ -28,6 +28,8 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
     "image/tiff"
   )
 
+  val imageTypesWithAlpha = Set("image/png", "image/tiff")
+
   override def canProcessMimeType = mimeTypes.contains
 
   override def indexing = true
@@ -58,9 +60,10 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
 
   override def extractOcr(blob: Blob, file: File, params: ExtractionParams, stdErrLogger: OcrStderrLogger): Unit = {
     val tmpDir = scratch.createWorkingDir(s"ocrmypdf-tmp-${blob.uri.value}")
+    val shouldRemoveAlpha = blob.mimeType.forall(m => imageTypesWithAlpha.contains(m.mimeType))
 
     try {
-      val fileToOCR = if (blob.mimeType.contains(MimeType("image/png"))) removeAlphaChannel(file, tmpDir, stdErrLogger).getOrElse(file) else file
+      val fileToOCR = if (shouldRemoveAlpha) removeAlphaChannel(file, tmpDir, stdErrLogger).getOrElse(file) else file
       params.languages.foreach { lang =>
         val text = invokeOcrMyPdf(blob.uri, lang, fileToOCR, config, stdErrLogger, tmpDir)
         val optionalText = if (text.trim().isEmpty) None else Some(text)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR removes alpha channel from tiff files since ocrMyPdf can not process image files with alpha channel enabled. 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
tested locally 