### PR TITLE
When a file fails to ingest, move to a 'dead letter' bucket

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -92,7 +92,7 @@ class AppComponents(context: Context, config: Config)
     scratchSpace.setup().await()
 
     // data storage services
-    val ingestStorage = S3IngestStorage(s3Client, config.s3.buckets.ingestion).valueOr(failure => throw new Exception(failure.msg))
+    val ingestStorage = S3IngestStorage(s3Client, config.s3.buckets.ingestion, config.s3.buckets.deadLetter).valueOr(failure => throw new Exception(failure.msg))
     val blobStorage = S3ObjectStorage(s3Client, config.s3.buckets.collections).valueOr(failure => throw new Exception(failure.msg))
 
     val postgresClient = config.postgres match {
@@ -195,6 +195,7 @@ class AppComponents(context: Context, config: Config)
     val commentsController = new Comments(authControllerComponents, manifest, esResources, annotations)
     val usersController = new Users(authControllerComponents, userProvider)
     val pagesController = new PagesController(authControllerComponents, manifest, esResources, pages2, annotations, previewStorage)
+    val ingestionController = new Ingestion(authControllerComponents, ingestStorage)
     val ingestionEventsController = new IngestionEvents(authControllerComponents, postgresClient, users )
 
     val workerControl = config.aws match {
@@ -234,6 +235,7 @@ class AppComponents(context: Context, config: Config)
       httpErrorHandler,
       eventsController,
       collectionsController,
+      ingestionController,
       ingestionEventsController,
       blobsController,
       filtersController,

--- a/backend/app/controllers/api/Ingestion.scala
+++ b/backend/app/controllers/api/Ingestion.scala
@@ -1,0 +1,21 @@
+package controllers.api
+
+import model.user.UserPermission.CanPerformAdminOperations
+import play.api.mvc._
+import services.S3IngestStorage
+import utils.attempt._
+import utils.controller.{AuthApiController, AuthControllerComponents}
+
+class Ingestion(override val controllerComponents: AuthControllerComponents, storage: S3IngestStorage)
+  extends AuthApiController {
+
+  def retryDeadLetterFiles(): Action[AnyContent] = ApiAction.attempt { req =>
+    checkPermission(CanPerformAdminOperations, req) {
+      Attempt.fromEither(storage.retryDeadLetters() match {
+        case Right(_) => Right(Ok("Sent all dead letter files for reingest"))
+        case Left(failure) => Left(failure)
+      })
+    }
+  }
+
+}

--- a/backend/app/ingestion/phase2/IngestStorePolling.scala
+++ b/backend/app/ingestion/phase2/IngestStorePolling.scala
@@ -78,7 +78,7 @@ class IngestStorePolling(
                 case Left(failure) =>
                   metricsService.updateMetric(Metrics.itemsFailed)
                   logger.warn(s"Failed to process $key: $failure. File will be moved to dead letter bucket. To re-ingest the file, " +
-                    s"either re-upload it or copy the contents of the dead letter bucket back into the ingest bucket")
+                    s"either re-upload it or use the /api/ingestion/retry-dead-letter-files endpoint to re-ingest all dead letter files.")
                   ingestStorage.sendToDeadLetterBucket(key)
                 case _ => ingestStorage.delete(key)
               }

--- a/backend/app/ingestion/phase2/IngestStorePolling.scala
+++ b/backend/app/ingestion/phase2/IngestStorePolling.scala
@@ -77,7 +77,9 @@ class IngestStorePolling(
               result match {
                 case Left(failure) =>
                   metricsService.updateMetric(Metrics.itemsFailed)
-                  logger.warn(s"Failed to process $key: $failure")
+                  logger.warn(s"Failed to process $key: $failure. File will be moved to dead letter bucket. To re-ingest the file, " +
+                    s"either re-upload it or copy the contents of the dead letter bucket back into the ingest bucket")
+                  ingestStorage.sendToDeadLetterBucket(key)
                 case _ => ingestStorage.delete(key)
               }
               result

--- a/backend/app/services/Config.scala
+++ b/backend/app/services/Config.scala
@@ -152,10 +152,11 @@ case class S3Config(
 
 case class BucketConfig(
   ingestion: String,
+  deadLetter: String,
   collections: String,
   preview: String
 ) {
-  val all: List[String] = List(ingestion, collections, preview)
+  val all: List[String] = List(ingestion, deadLetter, collections, preview)
 }
 
 case class AWSDiscoveryConfig(

--- a/backend/app/utils/AwsDiscovery.scala
+++ b/backend/app/utils/AwsDiscovery.scala
@@ -158,6 +158,7 @@ object AwsDiscovery extends Logging {
 
     val after = BucketConfig(
       ingestion = s"$stack-${before.ingestion}-$lowerCaseStage",
+      deadLetter = s"$stack-${before.deadLetter}-$lowerCaseStage",
       collections = s"$stack-${before.collections}-$lowerCaseStage",
       preview = s"$stack-${before.preview}-$lowerCaseStage"
     )

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -156,6 +156,7 @@ postgres {
 s3 {
   buckets {
     ingestion = "ingest-data"
+    deadLetter = "ingest-data-dead-letter"
     collections = "data"
     preview = "preview"
   }

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -11,6 +11,8 @@ POST          /api/collections/:collection/:ingestion                       cont
 DELETE        /api/collections/:collection/:ingestion                       controllers.api.Collections.deleteIngestion(collection, ingestion)
 POST          /api/collections/:collection/:ingestion/verifyFiles           controllers.api.Collections.verifyFiles(collection, ingestion)
 
+POST          /api/ingestion/retry-dead-letter-items                        controllers.api.Ingestion.retryDeadLetterFiles()
+
 GET           /api/ingestion-events/:collection                             controllers.api.IngestionEvents.getCollectionEvents(collection)
 GET           /api/ingestion-events/:collection/:ingestion                controllers.api.IngestionEvents.getIngestionEvents(collection, ingestion)
 

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -11,7 +11,7 @@ POST          /api/collections/:collection/:ingestion                       cont
 DELETE        /api/collections/:collection/:ingestion                       controllers.api.Collections.deleteIngestion(collection, ingestion)
 POST          /api/collections/:collection/:ingestion/verifyFiles           controllers.api.Collections.verifyFiles(collection, ingestion)
 
-POST          /api/ingestion/retry-dead-letter-items                        controllers.api.Ingestion.retryDeadLetterFiles()
+POST          /api/ingestion/retry-dead-letter-files                        controllers.api.Ingestion.retryDeadLetterFiles()
 
 GET           /api/ingestion-events/:collection                             controllers.api.IngestionEvents.getCollectionEvents(collection)
 GET           /api/ingestion-events/:collection/:ingestion                controllers.api.IngestionEvents.getIngestionEvents(collection, ingestion)

--- a/backend/test/test/integration/Helpers.scala
+++ b/backend/test/test/integration/Helpers.scala
@@ -242,7 +242,7 @@ object Helpers extends Matchers with Logging with OptionValues with Inside {
 
     elasticsearch.resetIndices()
 
-    val s3Config = S3Config("fake", BucketConfig("fake", "fake", "fake"), None, None, None, None)
+    val s3Config = S3Config("fake", BucketConfig("fake", "fake", "fake", "fake"), None, None, None, None)
     val downloadExpiryPeriod = 1.minute
 
     val userManagement = Neo4jUserManagement(neo4jDriver, ec, queryLoggingConfig, manifest, elasticsearch.elasticResources, elasticsearch.elasticPages, annotations)


### PR DESCRIPTION
## What does this change?
We have seen an issue in giant where if a file fails the initial ('phase 1') ingestion step - i.e. any of the below processes fail:
 - hashing
 - copying to data bucket with hash as the key
 - mimetype detection with tikka
 - determining what extractors need running based off the mimetype
 - writing manifest to neo4j
 - writing to elasticsearch

....then the file will remain in the ingest bucket and be retried over and over again. This adds a lot of noise to the logs and observability dashboard and may result in increased AWS spend as workers try over and over again to ingest the same files.

This PR prevents this behaviour by removing ingest files from the ingest bucket and copying them to a 'dead letter' bucket. In order to get giant to have another go at ingesting those files, they will have to be uploaded again via the CLI or an API endpoint has been provided to copy the files back to the ingest bucket (this endpoint isn't very discoverable at the moment - arguably it should have an associated CLI option or a button somewhere, but it's reference in the logs and I think is better than nothing).

Note that this functionality only affects uploads via the CLI. User uploads will continue to fail immediately with an error message to the user if the initial ingest fails.

Depends on https://github.com/guardian/investigations-platform/pull/453 (already deployed)

## How to test
I tested this functionality on playground by stopping elasticsearch and then attempting a CLI ingest. At the same time I tested the 'retry dead letter' endpoint. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
At the moment, if an ingest fails because e.g. elasticsearch is down then it will be retried over and over again so that if elasticsearch recovers it will go through. In this new world this requires a manual step. Given that CLI uploads are already pretty manual this seems a worthwhile trade off

## Wikipedia on Dead Letter Mail
_Dead letter mail or undeliverable mail is [mail](https://en.wikipedia.org/wiki/Mail) that cannot be delivered to the addressee or returned to the sender. This is usually due to lack of compliance with postal regulations, an incomplete address and [return address](https://en.wikipedia.org/wiki/Return_address), or the inability to [forward the mail](https://en.wikipedia.org/wiki/Mail_forwarding) when both correspondents move before the letter can be delivered._
https://en.wikipedia.org/wiki/Dead_letter_mail

![no post on sundays gif](https://media4.giphy.com/media/h7nrxCMMNEkg0/giphy.gif)