### PR TITLE
reduce pdf image ppi before running ocrMyPdf

### DIFF
--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -45,7 +45,8 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
 
     try {
       pdDocuments = params.languages.map { lang =>
-        val pdfPath = Ocr.invokeOcrMyPdf(lang.ocr, file.toPath, None, stdErrLogger, tmpDir)
+        val preProcessPdf = Ocr.preProcessPdf(file.toPath, tmpDir, stdErrLogger)
+        val pdfPath = Ocr.invokeOcrMyPdf(lang.ocr, preProcessPdf.getOrElse(file.toPath), None, stdErrLogger, tmpDir)
         val pdfDoc = PDDocument.load(pdfPath.toFile)
 
         lang -> (pdfPath, pdfDoc)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
ocrMyPdf fails to process files that contain images with over 500000000 pixels. Although this default max limit can be increased in ocrMyPdf using `max-image-mpixels` param, the tesseract would still fail complaining about the image pixle with this error `Error in pixCreateHeader: requested bytes >= 2^31`

This PR is adding a pre-process call which reduces the pdf image ppi to 300 using ghostscript. If the images are originally below 300, they would stay with their original ppi. 

This not only fixes the ocrMyPdf failure, but also improves the performance of ocrMyPdf greatly for any file with an image ppi over 300. 

**Note:** If the pre-process call fails for any reason, it would not break the rest of the process. `Option` is used as the return type so that it would return the down sampled file path only if gs down sampling succeeds.  

**Note2:** This implementation is only added to `OcrMyPdfExtractor` and not in `OcrMyPdfImageExtractor`. It seems that the `image-dpi` parameter used for ocr-ing the images is limiting the image pixels.  But this parameter can only be used  when the input file is an image.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
This was tested locally