### PR TITLE
Bump postgres to version 15

### DIFF
--- a/postgres/cdk/lib/giant.ts
+++ b/postgres/cdk/lib/giant.ts
@@ -1,9 +1,6 @@
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import {
-	AppIdentity,
-	GuParameter,
 	GuStack,
-	GuStringParameter,
 } from '@guardian/cdk/lib/constructs/core';
 import { GuVpc, SubnetType } from '@guardian/cdk/lib/constructs/ec2/vpc';
 import type { App } from 'aws-cdk-lib';
@@ -53,7 +50,7 @@ export class Giant extends GuStack {
 				}),
 			},
 			engine: DatabaseInstanceEngine.postgres({
-				version: PostgresEngineVersion.VER_13,
+				version: PostgresEngineVersion.VER_15
 			}),
 			allocatedStorage: dbStorage,
 			maxAllocatedStorage: dbStorage + 20,

--- a/postgres/cdk/lib/giant.ts
+++ b/postgres/cdk/lib/giant.ts
@@ -52,6 +52,7 @@ export class Giant extends GuStack {
 			engine: DatabaseInstanceEngine.postgres({
 				version: PostgresEngineVersion.VER_15
 			}),
+            allowMajorVersionUpgrade: true,
 			allocatedStorage: dbStorage,
 			maxAllocatedStorage: dbStorage + 20,
 			autoMinorVersionUpgrade: true,


### PR DESCRIPTION

## What does this change?
There is currently a mismatch between the version of postgres we are running locally via docker and the version we are running in RDS. Rather than downgrade our local version I decided to upgrade to 15.3 in RDS. As we're using 15.3 locally already, we have a good amount of confidence that we won't have any compatability issues.

## How to test
This has already been deployed on CODE and doesn't appear to cause any issues. 

Deploy steps for PROD:
 - merge this
 - deploy via riffraff 

## How can we measure success?
Queries that work locally should also work in AWS 🎉 