### PR TITLE
Migrate giant to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,5 +50,5 @@ jobs:
       - name: Run script/teamcity
         run: |
           LAST_TEAMCITY_BUILD=5000
-          export BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-           ./scripts/teamcity.sh
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          ./scripts/teamcity.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches:
-      - "main"
+
 jobs:
   CI:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+# Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+name: CI
+
+on:
+  pull_request:
+
+  # Manual invocation.
+  workflow_dispatch:
+
+  push:
+    branches:
+      - "main"
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      # required by aws-actions/configure-aws-credentials
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
+      # See https://github.com/aws-actions/configure-aws-credentials
+      - uses: aws-actions/configure-aws-credentials@v4
+        name: setup-riffraff-credentials
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+          unset-current-credentials: true
+
+      # Setup Node, checking common Node config files to determine the version of Node to use.
+      # Configuring caching is also recommended.
+      # See https://github.com/guardian/actions-setup-node
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: frontend/.nvmrc
+
+      # Configuring caching is also recommended.
+      # See https://github.com/actions/setup-java
+      - name: Setup Java 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      # 1. Seed the build number with last number from TeamCity.
+      #    Update `LAST_TEAMCITY_BUILD` as needed or remove entirely if changing Riff-Raff project name.
+      # See https://github.com/github/scripts-to-rule-them-all
+      - name: Run script/teamcity
+        run: |
+          LAST_TEAMCITY_BUILD=5000
+          export BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          ./scripts/teamcity.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,7 @@ on:
   # Manual invocation.
   workflow_dispatch:
 
-  # None of the projects in this build are in use so all auto-building is disabled
-#  push:
-#  pull_request:
+  push:
 
 jobs:
   CI:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: frontend/.nvmrc
+          node-version-file: .nvmrc
 
       # Configuring caching is also recommended.
       # See https://github.com/actions/setup-java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,12 @@
 name: CI
 
 on:
-  pull_request:
-
   # Manual invocation.
   workflow_dispatch:
 
-  push:
+  # None of the projects in this build are in use so all auto-building is disabled
+#  push:
+#  pull_request:
 
 jobs:
   CI:
@@ -53,4 +53,4 @@ jobs:
         run: |
           LAST_TEAMCITY_BUILD=5000
           export BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          ./scripts/teamcity.sh
+           ./scripts/teamcity.sh

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -21,7 +21,7 @@ popd
 cp -r frontend/build/* backend/public
 # Replace the symbolic link we use in dev with the actual file.
 # On Teamcity the JDeb build doesn't seem to follow the symbolic link while packaging, weirdly
-cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/pdf.worker.min.js
+#cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/pdf.worker.min.js
 
 #Use java 11
 export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/scripts/teamcity.sh
+++ b/scripts/teamcity.sh
@@ -21,6 +21,9 @@ popd
 cp -r frontend/build/* backend/public
 # Replace the symbolic link we use in dev with the actual file.
 # On Teamcity the JDeb build doesn't seem to follow the symbolic link while packaging, weirdly
+# NOTE: On Github actions this seems to work, and in fact it will complain if you try and run the below line
+# because it thinks that the two files are the same. So  could be removed at some point but let's leave it for
+# a bit in case e.g. github actions custom runners have similar issues
 #cp frontend/node_modules/pdfjs-dist/build/pdf.worker.min.js backend/public/third-party/pdf.worker.min.js
 
 #Use java 11


### PR DESCRIPTION
## What does this change?
Adds a github actions workflow to build giant. 

The only change I had to make was to comment out this bit where we manually copy the compiled pdf.worker.min.js file as github actions appears to not have the same issue that teamcity did where it didn't follow the symbolic link associated with the file. 

Otherwise this is a fairly standard node/scala gha build

## How to test
I've tested this on playground by deploying a version generated by github actions, it seems to work (including the pdf worker!)

## How can we measure success?
