### PR TITLE
Show infinitely looping files in observability dashboard

### DIFF
--- a/backend/app/services/observability/Models.scala
+++ b/backend/app/services/observability/Models.scala
@@ -197,7 +197,8 @@ case class BlobStatus(
                        eventStatuses: List[IngestionEventStatus],
                        extractorStatuses: List[ExtractorStatus],
                        errors: List[IngestionErrorsWithEventType],
-                       mimeTypes: Option[String])
+                       mimeTypes: Option[String],
+                       infiniteLoop: Boolean)
 object BlobStatus {
   implicit val dateWrites = JodaReadWrites.dateWrites
   implicit val dateReads = JodaReadWrites.dateReads

--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -157,6 +157,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
             ie.errors,
             ie.workspace_name AS "workspaceName",
             ie.mime_types AS "mimeTypes",
+            infinite_loop,
             ARRAY_AGG(DISTINCT blob_metadata.path ) AS paths,
             (ARRAY_AGG(blob_metadata.file_size))[1] as "fileSize",
             ARRAY_REMOVE(ARRAY_AGG(extractor_statuses.extractor), NULL) AS extractors,
@@ -167,22 +168,41 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
             SELECT
               blob_id,
               ingest_id,
-              MIN(EXTRACT(EPOCH from event_time)) AS ingest_start,
-              MAX(EXTRACT(EPOCH from event_time)) AS most_recent_event,
+              MIN(EXTRACT(EPOCH FROM event_time)) AS ingest_start,
+              MAX(EXTRACT(EPOCH FROM event_time)) AS most_recent_event,
               ARRAY_AGG(type) as event_types,
               ARRAY_AGG(EXTRACT(EPOCH from event_time)) as event_times,
               ARRAY_AGG(status) as event_statuses,
               ARRAY_AGG(details -> 'errors') as errors,
               (ARRAY_AGG(details ->> 'workspaceName')  FILTER (WHERE details ->> 'workspaceName' IS NOT NULL))[1] as workspace_name,
-              (ARRAY_AGG(details ->> 'mimeTypes')  FILTER (WHERE details ->> 'mimeTypes' IS NOT NULL))[1] as mime_types
+              (ARRAY_AGG(details ->> 'mimeTypes')  FILTER (WHERE details ->> 'mimeTypes' IS NOT NULL))[1] as mime_types,
+              FALSE AS infinite_loop
             FROM ingestion_events
             WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId}
             AND blob_id NOT IN (SELECT blob_id FROM problem_blobs)
             GROUP BY 1,2
+            UNION
+            -- blobs in the ingestion that are failing in an infinite loop
+            SELECT DISTINCT
+              blob_id,
+              ingest_id,
+              MIN(EXTRACT(EPOCH FROM event_time)) AS ingest_start,
+              MAX(EXTRACT(EPOCH FROM event_time)) AS most_recent_event,
+              array[]::text[] AS event_types,
+              array[]::numeric[] AS event_times,
+              array[]::text[] AS event_statuses,
+              array['[]'::jsonb] AS errors,
+              NULL AS workspace_name,
+              NULL AS mime_types,
+              TRUE AS infinite_loop
+            FROM ingestion_events
+            WHERE ingest_id LIKE ${if(ingestIdIsPrefix) LikeConditionEscapeUtil.beginsWith(ingestId) else ingestId}
+            AND blob_id IN (SELECT blob_id FROM problem_blobs)
+            GROUP BY 1,2
           ) AS ie
           LEFT JOIN blob_metadata USING(ingest_id, blob_id)
           LEFT JOIN extractor_statuses on extractor_statuses.blob_id = ie.blob_id and extractor_statuses.ingest_id = ie.ingest_id
-          GROUP BY 1,2,3,4,5,6,7,8,9,10
+          GROUP BY 1,2,3,4,5,6,7,8,9,10,11
           ORDER by ingest_start desc
      """.map(rs => {
             val eventTypes = rs.array("event_types").getArray.asInstanceOf[Array[String]]

--- a/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
+++ b/frontend/src/js/components/IngestionEvents/IngestionEvents.tsx
@@ -1,27 +1,54 @@
-import React, {ReactNode, useEffect, useState} from "react";
-import authFetch from "../../util/auth/authFetch";
-import {EuiFlexItem, EuiBasicTable, EuiToolTip, EuiText, EuiButtonIcon, EuiScreenReaderOnly, EuiSpacer, EuiIconTip, EuiBadge, EuiFlexGroup, EuiInMemoryTable, EuiBasicTableColumn, EuiLoadingSpinner, EuiCodeBlock, Criteria} from "@elastic/eui";
-import '@elastic/eui/dist/eui_theme_light.css';
-import hdate from 'human-date';
-import {WorkspaceMetadata} from "../../types/Workspaces";
-import moment from "moment";
-import _ from "lodash";
+import React, { ReactNode, useEffect, useState } from "react"
+import authFetch from "../../util/auth/authFetch"
+import {
+    EuiFlexItem,
+    EuiBasicTable,
+    EuiToolTip,
+    EuiText,
+    EuiButtonIcon,
+    EuiScreenReaderOnly,
+    EuiSpacer,
+    EuiIconTip,
+    EuiBadge,
+    EuiFlexGroup,
+    EuiInMemoryTable,
+    EuiBasicTableColumn,
+    EuiLoadingSpinner,
+    EuiCodeBlock,
+    Criteria,
+} from "@elastic/eui"
+import "@elastic/eui/dist/eui_theme_light.css"
+import hdate from "human-date"
+import { WorkspaceMetadata } from "../../types/Workspaces"
+import moment from "moment"
+import _ from "lodash"
 import {
     BlobStatus,
     ExtractorStatus,
     IngestionTable,
     Status,
     extractorStatusColors,
-    IngestionEventStatus
-} from "./types";
-import styles from "./IngestionEvents.module.css";
+    IngestionEventStatus,
+} from "./types"
+import styles from "./IngestionEvents.module.css"
 
 type BlobProgress = "complete" | "completeWithErrors" | "inProgress"
 
 const blobStatusIcons = {
-    complete: <EuiIconTip type="checkInCircleFilled" content={"Ingestion complete"} />,
-    completeWithErrors: <EuiIconTip type="alert" content={"Ingestion complete with some errors"} />,
-    inProgress: <EuiToolTip content={"Ingestion in progress"}><EuiLoadingSpinner /></EuiToolTip>
+    complete: (
+        <EuiIconTip type="checkInCircleFilled" content={"Ingestion complete"} />
+    ),
+    completeWithErrors: (
+        <EuiIconTip
+            type="alert"
+            content={"Ingestion complete with some errors"}
+        />
+    ),
+    inProgress: (
+        <EuiToolTip content={"Ingestion in progress"}>
+            <EuiLoadingSpinner />
+        </EuiToolTip>
+    ),
 }
 
 const SHORT_READABLE_DATE = "DD MMM HH:mm:ss"
@@ -29,200 +56,323 @@ const SHORT_READABLE_DATE = "DD MMM HH:mm:ss"
 const statusToColor = (status: Status) => extractorStatusColors[status]
 
 const getFailedStatuses = (statuses: ExtractorStatus[]) =>
-    statuses.filter(status => status.statusUpdates.find(u => u.status === "Failure") !== undefined);
+    statuses.filter(
+        (status) =>
+            status.statusUpdates.find((u) => u.status === "Failure") !==
+            undefined
+    )
 
 const getFailedBlobs = (blobs: BlobStatus[]) => {
-    return  blobs.filter(wb => {
-        return getFailedStatuses(wb.extractorStatuses).length > 0;
-    });
+    return blobs.filter((wb) => {
+        return getFailedStatuses(wb.extractorStatuses).length > 0
+    })
 }
 
 const getBlobStatus = (statuses: ExtractorStatus[]): BlobProgress => {
-    const failures = getFailedStatuses(statuses);
-    const inProgress = statuses.filter(status => status.statusUpdates.find(u => !u.status || ["Failure", "Success"].includes(u.status)) === undefined)
-    return failures.length > 0 ? "completeWithErrors" : inProgress.length > 0 ? "inProgress" : "complete"
+    const failures = getFailedStatuses(statuses)
+    const inProgress = statuses.filter(
+        (status) =>
+            status.statusUpdates.find(
+                (u) => !u.status || ["Failure", "Success"].includes(u.status)
+            ) === undefined
+    )
+    return failures.length > 0
+        ? "completeWithErrors"
+        : inProgress.length > 0
+        ? "inProgress"
+        : "complete"
 }
 
-const blobIngestedMultipleTimes = (status:BlobStatus) => status.extractorStatuses.find(s => s.statusUpdates.filter(u => u.status === "Started").length > 1) !== undefined
+const blobIngestedMultipleTimes = (status: BlobStatus) =>
+    status.extractorStatuses.find(
+        (s) => s.statusUpdates.filter((u) => u.status === "Started").length > 1
+    ) !== undefined
 
 const extractorStatusList = (status: ExtractorStatus, title?: string) => {
-    const statusUpdateStrings = status.statusUpdates.map(u => `${moment(u.eventTime).format(SHORT_READABLE_DATE)} ${u.status}`)
-    return status.statusUpdates.length > 0 ? <p>
-        {title && <><b>{title}</b> <br /></>}
-        <ul>
-            {statusUpdateStrings.map(s => <li key={s}>{s}</li>)}
-        </ul>
-    </p> : "No events so far"
+    const statusUpdateStrings = status.statusUpdates.map(
+        (u) => `${moment(u.eventTime).format(SHORT_READABLE_DATE)} ${u.status}`
+    )
+    return status.statusUpdates.length > 0 ? (
+        <p>
+            {title && (
+                <>
+                    <b>{title}</b> <br />
+                </>
+            )}
+            <ul>
+                {statusUpdateStrings.map((s) => (
+                    <li key={s}>{s}</li>
+                ))}
+            </ul>
+        </p>
+    ) : (
+        "No events so far"
+    )
 }
 
 // throw away everything after last / to get the filename from a path
-const pathsToFileNames = (paths: string[]) => paths.map(p => p.split("/").slice(-1)).join("\n")
-
+const pathsToFileNames = (paths: string[]) =>
+    paths.map((p) => p.split("/").slice(-1)).join("\n")
 
 const blobStatusText = {
     complete: "Complete",
     completeWithErrors: "Complete with errors",
-    inProgress: "In progress"
+    inProgress: "In progress",
 }
 
 const statusIconColumn = {
-        field: 'extractorStatuses',
-        name: '',
-        width: '40',
-        render: (statuses: ExtractorStatus[], row: BlobStatus) => {
-            const totalErrors = row.errors.length
-            const extractorStatus = getBlobStatus(statuses)
-            // if extractors have finished but there are other non-extractor related errors, show an error icon
-            const combinedStatus = extractorStatus === "complete" && totalErrors > 0 ? "completeWithErrors" : extractorStatus
-            return blobStatusIcons[combinedStatus]
-        }
-    }
+    field: "extractorStatuses",
+    name: "",
+    width: "40",
+    render: (statuses: ExtractorStatus[], row: BlobStatus) => {
+        const totalErrors = row.errors.length
+        const extractorStatus = getBlobStatus(statuses)
+        // if extractors have finished but there are other non-extractor related errors, show an error icon
+        const combinedStatus =
+            extractorStatus === "complete" && totalErrors > 0
+                ? "completeWithErrors"
+                : extractorStatus
+        return blobStatusIcons[combinedStatus]
+    },
+}
 
 const columns: Array<EuiBasicTableColumn<BlobStatus>> = [
     {
-        field: 'paths',
-        name: 'Filename(s)',
+        field: "paths",
+        name: "Filename(s)",
         sortable: true,
         truncateText: true,
-        render: pathsToFileNames
+        render: pathsToFileNames,
     },
     {
-        field: 'ingestStart',
-        name: 'First event time',
+        field: "ingestStart",
+        name: "First event time",
         sortable: true,
-        render: (ingestStart: Date) => moment(ingestStart).format(SHORT_READABLE_DATE)
+        render: (ingestStart: Date) =>
+            moment(ingestStart).format(SHORT_READABLE_DATE),
     },
     {
-        name: 'Ingestion run time',
-        render: (row: BlobStatus) =>
-            <>{moment.duration(moment(row.mostRecentEvent).diff(moment(row.ingestStart))).humanize()} {
-                blobIngestedMultipleTimes(row) && <EuiIconTip
-                aria-label="Info"
-                size="m"
-                type="iInCircle"
-                color="primary"
-                content={"This file has been ingested more than once so ingestion run time may not be accurate."}
-            />}</>
+        name: "Ingestion run time",
+        render: (row: BlobStatus) => (
+            <>
+                {moment
+                    .duration(
+                        moment(row.mostRecentEvent).diff(
+                            moment(row.ingestStart)
+                        )
+                    )
+                    .humanize()}{" "}
+                {blobIngestedMultipleTimes(row) && (
+                    <EuiIconTip
+                        aria-label="Info"
+                        size="m"
+                        type="iInCircle"
+                        color="primary"
+                        content={
+                            "This file has been ingested more than once so ingestion run time may not be accurate."
+                        }
+                    />
+                )}
+            </>
+        ),
     },
     {
-        field: 'extractorStatuses',
-        name: 'Status',
+        field: "extractorStatuses",
+        name: "Status",
         render: (statuses: ExtractorStatus[]) => {
             return blobStatusText[getBlobStatus(statuses)]
-        }
+        },
     },
     {
-        field: 'extractorStatuses',
-        name: 'Extractors',
+        field: "extractorStatuses",
+        name: "Extractors",
         render: (statuses: ExtractorStatus[]) => {
-            return statuses.length > 0 ? (<ul>
-                {statuses.map(status => {
-                    const mostRecent = status.statusUpdates.length > 0 ? status.statusUpdates[status.statusUpdates.length - 1] : undefined
-                    return <li key={status.extractorType}><EuiFlexGroup>
-                        <EuiFlexItem>{status.extractorType.replace("Extractor", "")}</EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                            {mostRecent?.status ?
-                                (<EuiToolTip content = {extractorStatusList(status, `All ${status.extractorType} events`)}>
-                                    <EuiBadge color={statusToColor(mostRecent.status)}>
-                                        {mostRecent.status} ({moment(mostRecent.eventTime).format("HH:mm:ss")  })
-                                    </EuiBadge>
-                            </EuiToolTip>) : <>No updates</>
-                            }
-                        </EuiFlexItem>
-                    </EuiFlexGroup></li>
-            })}
-            </ul>) : <></>
-
+            return statuses.length > 0 ? (
+                <ul>
+                    {statuses.map((status) => {
+                        const mostRecent =
+                            status.statusUpdates.length > 0
+                                ? status.statusUpdates[
+                                      status.statusUpdates.length - 1
+                                  ]
+                                : undefined
+                        return (
+                            <li key={status.extractorType}>
+                                <EuiFlexGroup>
+                                    <EuiFlexItem>
+                                        {status.extractorType.replace(
+                                            "Extractor",
+                                            ""
+                                        )}
+                                    </EuiFlexItem>
+                                    <EuiFlexItem grow={false}>
+                                        {mostRecent?.status ? (
+                                            <EuiToolTip
+                                                content={extractorStatusList(
+                                                    status,
+                                                    `All ${status.extractorType} events`
+                                                )}
+                                            >
+                                                <EuiBadge
+                                                    color={statusToColor(
+                                                        mostRecent.status
+                                                    )}
+                                                >
+                                                    {mostRecent.status} (
+                                                    {moment(
+                                                        mostRecent.eventTime
+                                                    ).format("HH:mm:ss")}
+                                                    )
+                                                </EuiBadge>
+                                            </EuiToolTip>
+                                        ) : (
+                                            <>No updates</>
+                                        )}
+                                    </EuiFlexItem>
+                                </EuiFlexGroup>
+                            </li>
+                        )
+                    })}
+                </ul>
+            ) : (
+                <></>
+            )
         },
-        width: "300"
+        width: "300",
     },
-
-];
+]
 
 const parseBlobStatus = (status: any): BlobStatus => {
     return {
         ...status,
-        paths: status.paths.map((p: any) => p ? p : "unknown-filename"),
+        paths: status.paths.map((p: any) => (p ? p : "unknown-filename")),
         ingestStart: new Date(status.ingestStart),
         mostRecentEvent: new Date(status.mostRecentEvent),
         mimeTypes: status.mimeTypes?.split(","),
-        eventStatuses: status.eventStatuses.map((es: any) => ({...es, eventTime: new Date(es.eventTime)})),
+        eventStatuses: status.eventStatuses.map((es: any) => ({
+            ...es,
+            eventTime: new Date(es.eventTime),
+        })),
         extractorStatuses: status.extractorStatuses.map((s: any) => ({
             extractorType: s.extractorType.replace("Extractor", ""),
-            statusUpdates: _.sortBy(s.statusUpdates
-                // discard empty status updates (does this make sense? Maybe we should tag them as 'unknown status' instead
-                .filter((u: any) => u.eventTime !== undefined && u.status !== undefined)
-                .map((u: any) => ({
-                    ...u,
-                    eventTime: new Date(u.eventTime)
-            })), update => update.eventTime)
-        }))
+            statusUpdates: _.sortBy(
+                s.statusUpdates
+                    // discard empty status updates (does this make sense? Maybe we should tag them as 'unknown status' instead
+                    .filter(
+                        (u: any) =>
+                            u.eventTime !== undefined && u.status !== undefined
+                    )
+                    .map((u: any) => ({
+                        ...u,
+                        eventTime: new Date(u.eventTime),
+                    })),
+                (update) => update.eventTime
+            ),
+        })),
     }
 }
 
-const blobStatusId = (blobStatus: BlobStatus) => `${blobStatus.metadata.ingestId}-${blobStatus.metadata.blobId}`
+const blobStatusId = (blobStatus: BlobStatus) =>
+    `${blobStatus.metadata.ingestId}-${blobStatus.metadata.blobId}`
 
 const renderExpandedRow = (blobStatus: BlobStatus) => {
     const columns: Array<EuiBasicTableColumn<IngestionEventStatus>> = [
         {
-            field: 'eventTime',
-            name: 'Event time',
-            render: (time: Date) => moment(time).format(SHORT_READABLE_DATE)
+            field: "eventTime",
+            name: "Event time",
+            render: (time: Date) => moment(time).format(SHORT_READABLE_DATE),
         },
         {
-            field: 'eventType',
-            name: 'Event',
+            field: "eventType",
+            name: "Event",
         },
         {
-            field: 'eventStatus',
-            name: 'Status',
+            field: "eventStatus",
+            name: "Status",
             render: (status: Status) => {
-                return <EuiBadge color={statusToColor(status)}>{status}</EuiBadge>
+                return (
+                    <EuiBadge color={statusToColor(status)}>{status}</EuiBadge>
+                )
             },
         },
-    ];
+    ]
 
-    return <EuiText>
-        <h3>{pathsToFileNames(blobStatus.paths)}</h3>
-        <p>Full file path(s) : {blobStatus.paths.join(", ")}. Ingestion started on {hdate.prettyPrint(blobStatus.ingestStart)}</p>
-        <h4>All ingestion events prior to extraction</h4>
-        <EuiBasicTable
-            tableCaption="Demo of EuiBasicTable"
-            items={_.sortBy(blobStatus.eventStatuses, s => s.eventTime.toISOString() )}
-            columns={columns}
-        />
-        <h4>Extraction events</h4>
-        {blobStatus.mimeTypes && `This file is of type ${blobStatus.mimeTypes.join(",")}.`} Giant has run the following extractors on the file:
-        <div className={styles.expandedRowExtractorStatus}>
-            {blobStatus.extractorStatuses.map(extractorStatus => {
-                const numErrors = extractorStatus.statusUpdates.filter(su => su.status === "Failure").length
-                const numStarted = extractorStatus.statusUpdates.filter(su => su.status === "Started").length
-                const mostRecent = extractorStatus.statusUpdates.length > 0 ? extractorStatus.statusUpdates[extractorStatus.statusUpdates.length - 1] : undefined
-                return <><h4>{extractorStatus.extractorType}</h4>
-                    <p>The extractor {extractorStatus.extractorType} has been started {numStarted} times. There have been {numErrors} errors.<br />
-                        {mostRecent ? <>The most recent status event is '{mostRecent.status}' which happened on {hdate.prettyPrint(mostRecent.eventTime, {showTime: true})}</> : ""} <br /> <br />
-
-                        All {extractorStatus.extractorType} events:
-
-                        {extractorStatusList(extractorStatus)}
-
-
-                    </p></>
-            })}
-        </div>
-        {blobStatus.errors.length > 0 &&
-            <>
-                <h4>Errors encountered processing this file</h4>
-                {blobStatus.errors.map(error =>
-                    <div>
-                        <h5>{error.eventType}</h5>
-                        {error.errors.map(e => <EuiCodeBlock>{e.message}</EuiCodeBlock>)}
-                    </div>
-                )
-                }
-            </>
-        }
-    </EuiText>
+    return (
+        <EuiText>
+            <h3>{pathsToFileNames(blobStatus.paths)}</h3>
+            <p>
+                Full file path(s) : {blobStatus.paths.join(", ")}. Ingestion
+                started on {hdate.prettyPrint(blobStatus.ingestStart)}
+            </p>
+            <h4>All ingestion events prior to extraction</h4>
+            <EuiBasicTable
+                tableCaption="Demo of EuiBasicTable"
+                items={_.sortBy(blobStatus.eventStatuses, (s) =>
+                    s.eventTime.toISOString()
+                )}
+                columns={columns}
+            />
+            <h4>Extraction events</h4>
+            {blobStatus.mimeTypes &&
+                `This file is of type ${blobStatus.mimeTypes.join(",")}.`}{" "}
+            Giant has run the following extractors on the file:
+            <div className={styles.expandedRowExtractorStatus}>
+                {blobStatus.extractorStatuses.map((extractorStatus) => {
+                    const numErrors = extractorStatus.statusUpdates.filter(
+                        (su) => su.status === "Failure"
+                    ).length
+                    const numStarted = extractorStatus.statusUpdates.filter(
+                        (su) => su.status === "Started"
+                    ).length
+                    const mostRecent =
+                        extractorStatus.statusUpdates.length > 0
+                            ? extractorStatus.statusUpdates[
+                                  extractorStatus.statusUpdates.length - 1
+                              ]
+                            : undefined
+                    return (
+                        <>
+                            <h4>{extractorStatus.extractorType}</h4>
+                            <p>
+                                The extractor {extractorStatus.extractorType}{" "}
+                                has been started {numStarted} times. There have
+                                been {numErrors} errors.
+                                <br />
+                                {mostRecent ? (
+                                    <>
+                                        The most recent status event is '
+                                        {mostRecent.status}' which happened on{" "}
+                                        {hdate.prettyPrint(
+                                            mostRecent.eventTime,
+                                            { showTime: true }
+                                        )}
+                                    </>
+                                ) : (
+                                    ""
+                                )}{" "}
+                                <br /> <br />
+                                All {extractorStatus.extractorType} events:
+                                {extractorStatusList(extractorStatus)}
+                            </p>
+                        </>
+                    )
+                })}
+            </div>
+            {blobStatus.errors.length > 0 && (
+                <>
+                    <h4>Errors encountered processing this file</h4>
+                    {blobStatus.errors.map((error) => (
+                        <div>
+                            <h5>{error.eventType}</h5>
+                            {error.errors.map((e) => (
+                                <EuiCodeBlock>{e.message}</EuiCodeBlock>
+                            ))}
+                        </div>
+                    ))}
+                </>
+            )}
+        </EuiText>
+    )
 }
 
 function IngestionEventsTable({
@@ -271,101 +421,135 @@ function IngestionEventsTable({
     )
 }
 
-export function IngestionEvents(
-    {collectionId, ingestId, workspaces, breakdownByWorkspace, showErrorsOnly}: {
-        collectionId: string,
-        ingestId?: string,
-        workspaces: WorkspaceMetadata[],
-        breakdownByWorkspace: boolean,
-        showErrorsOnly: boolean,
-    }) {
+export function IngestionEvents({
+    collectionId,
+    ingestId,
+    workspaces,
+    breakdownByWorkspace,
+    showErrorsOnly,
+}: {
+    collectionId: string
+    ingestId?: string
+    workspaces: WorkspaceMetadata[]
+    breakdownByWorkspace: boolean
+    showErrorsOnly: boolean
+}) {
     const [blobs, updateBlobs] = useState<BlobStatus[] | undefined>(undefined)
     const [tableData, setTableData] = useState<IngestionTable[]>([])
 
     const ingestIdSuffix = ingestId && ingestId !== "all" ? `/${ingestId}` : ""
 
     // Expanding rows logic - we use itemIdToExpandedRowMap to keep track of which rows have been expanded
-    const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap ] = useState<
+    const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<
         Record<string, ReactNode>
-    >({});
+    >({})
     const openRow = (blobStatus: BlobStatus) => {
-        const map = {...itemIdToExpandedRowMap}
+        const map = { ...itemIdToExpandedRowMap }
         const id = blobStatusId(blobStatus)
         map[id] = renderExpandedRow(blobStatus)
         setItemIdToExpandedRowMap(map)
     }
 
     const closeRow = (blobStatus: BlobStatus) => {
-        const map = {...itemIdToExpandedRowMap}
+        const map = { ...itemIdToExpandedRowMap }
         delete map[blobStatusId(blobStatus)]
         setItemIdToExpandedRowMap(map)
     }
 
-    const columnsWithWorkspace = breakdownByWorkspace ?
-        columns : columns.concat(    {
-            field: 'workspaceName',
-            sortable: true,
-            name: 'Workspace name'
-        })
+    const columnsWithWorkspace = breakdownByWorkspace
+        ? columns
+        : columns.concat({
+              field: "workspaceName",
+              sortable: true,
+              name: "Workspace name",
+          })
 
     const columnsWithExpandingRow: Array<EuiBasicTableColumn<BlobStatus>> = [
         ...columnsWithWorkspace,
         statusIconColumn,
         {
-            align: 'right',
-            width: '40px',
+            align: "right",
+            width: "40px",
             isExpander: true,
-            name: (<EuiScreenReaderOnly><span>Expand rows</span></EuiScreenReaderOnly>),
+            name: (
+                <EuiScreenReaderOnly>
+                    <span>Expand rows</span>
+                </EuiScreenReaderOnly>
+            ),
             render: (row: BlobStatus) => (
                 <EuiButtonIcon
-                    onClick={() => itemIdToExpandedRowMap[blobStatusId(row)] ? closeRow(row) : openRow(row)}
+                    onClick={() =>
+                        itemIdToExpandedRowMap[blobStatusId(row)]
+                            ? closeRow(row)
+                            : openRow(row)
+                    }
                     aria-label={
-                        itemIdToExpandedRowMap[blobStatusId(row)] ? 'Collapse' : 'Expand'
+                        itemIdToExpandedRowMap[blobStatusId(row)]
+                            ? "Collapse"
+                            : "Expand"
                     }
                     iconType={
-                        itemIdToExpandedRowMap[blobStatusId(row)] ? 'arrowDown' : 'arrowRight'
+                        itemIdToExpandedRowMap[blobStatusId(row)]
+                            ? "arrowDown"
+                            : "arrowRight"
                     }
                 />
-            )
-        }
+            ),
+        },
     ]
 
     useEffect(() => {
         authFetch(`/api/ingestion-events/${collectionId}${ingestIdSuffix}`)
-            .then(resp => resp.json())
-            .then(json => {
+            .then((resp) => resp.json())
+            .then((json) => {
                 const blobStatuses: BlobStatus[] = json.map(parseBlobStatus)
                 updateBlobs(blobStatuses)
-        })
+            })
     }, [collectionId, ingestId, updateBlobs, ingestIdSuffix])
 
-    const getWorkspaceBlobs = (allBlobs: BlobStatus[], workspaceName: string, errorsOnly: boolean | undefined) => {
-        const workspaceBlobs = allBlobs.filter(b => b.workspaceName === workspaceName);
+    const getWorkspaceBlobs = (
+        allBlobs: BlobStatus[],
+        workspaceName: string,
+        errorsOnly: boolean | undefined
+    ) => {
+        const workspaceBlobs = allBlobs.filter(
+            (b) => b.workspaceName === workspaceName
+        )
 
-        if (errorsOnly) return getFailedBlobs(workspaceBlobs);
+        if (errorsOnly) return getFailedBlobs(workspaceBlobs)
 
-        return workspaceBlobs;
+        return workspaceBlobs
     }
 
     useEffect(() => {
         if (blobs) {
             if (breakdownByWorkspace) {
-                setTableData(workspaces
-                    .map((w: WorkspaceMetadata) => ({
+                setTableData(
+                    workspaces.map((w: WorkspaceMetadata) => ({
                         title: `Workspace: ${w.name}`,
-                        blobs: getWorkspaceBlobs(blobs, w.name, showErrorsOnly)
-                    })))
+                        blobs: getWorkspaceBlobs(blobs, w.name, showErrorsOnly),
+                    }))
+                )
             } else {
                 setTableData([
                     {
                         title: `${collectionId}${ingestIdSuffix}`,
-                        blobs: showErrorsOnly ? getFailedBlobs(blobs) : blobs
-                    }])
+                        blobs: showErrorsOnly ? getFailedBlobs(blobs) : blobs,
+                    },
+                ])
             }
         } else {
             setTableData([])
         }
-    }, [breakdownByWorkspace, blobs, workspaces, ingestIdSuffix, collectionId, showErrorsOnly, setItemIdToExpandedRowMap])
+    }, [
+        breakdownByWorkspace,
+        blobs,
+        workspaces,
+        ingestIdSuffix,
+        collectionId,
+        showErrorsOnly,
+        setItemIdToExpandedRowMap,
+    ])
 
     return (
         <>
@@ -384,4 +568,3 @@ export function IngestionEvents(
         </>
     )
 }
-

--- a/frontend/src/js/components/IngestionEvents/types.ts
+++ b/frontend/src/js/components/IngestionEvents/types.ts
@@ -32,6 +32,7 @@ export type BlobStatus =  {
     errors: IngestionErrorWithEventType[];
     workspaceName: string;
     mimeTypes: string[];
+    infiniteLoop: boolean;
 }
 
 export type IngestionTable = {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

Some file types fail to be ingested and ingestion is retried over and over in an infinite loop, inserting new rows into the observability database every few minutes. in #149 we stopped this from happening by moving failed files to a dead-letter bucket. 
Any files that have previously been in an infinite loop, and any files that cause this failure mode for other reasons that we haven't thought of in the future should be shown in the observability dashboard.

## Before
- files with more than 100 ingestion events are assumed to be stuck in an infinitely loop and, in order to improve performance, are excluded from the query that selects the data for the dashboard.

## After
- These problematic files are added back into the observability dashboard. In order to avoid slowing down the query, we don't array aggregate the ingestion events' errors (of which there could be thousands).
- Most of the dropdown in the dashboard for these files is replaced with a message explaining that there's an infinite loop and providing the blob id so that the problem can be investigated

<img width="1055" alt="Screenshot 2023-10-04 at 17 49 45" src="https://github.com/guardian/giant/assets/17057932/56489fc3-efa7-4c14-8e41-8ffd2da4b911">


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
