### PR TITLE
Fix excel extractor failure on invalid dates

### DIFF
--- a/backend/app/extraction/tables/ExcelTableExtractor.scala
+++ b/backend/app/extraction/tables/ExcelTableExtractor.scala
@@ -118,8 +118,12 @@ class ExcelTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: 
               val formatIndex = style.getDataFormat
               val formatString = style.getDataFormatString
 
-              if(DateUtil.isADateFormat(formatIndex, formatString)) value = DateUtil.getJavaDate(Some(xmlReader.getElementText.toDouble).getOrElse(0)).toString
-              else value = xmlReader.getElementText
+              if(DateUtil.isADateFormat(formatIndex, formatString)) {
+                val date = DateUtil.getJavaDate(xmlReader.getElementText.toDouble)
+                if (date != null) {
+                  value = date.toString
+                }
+              } else value = xmlReader.getElementText
             }
           }
         }

--- a/backend/app/extraction/tables/ExcelTableExtractor.scala
+++ b/backend/app/extraction/tables/ExcelTableExtractor.scala
@@ -119,10 +119,8 @@ class ExcelTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: 
               val formatString = style.getDataFormatString
 
               if(DateUtil.isADateFormat(formatIndex, formatString)) {
-                val date = DateUtil.getJavaDate(xmlReader.getElementText.toDouble)
-                if (date != null) {
-                  value = date.toString
-                }
+                val date = Option(DateUtil.getJavaDate(xmlReader.getElementText.toDouble))
+                value = date.getOrElse(DateUtil.getJavaDate(0)).toString
               } else value = xmlReader.getElementText
             }
           }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR fixes a bug where an excel date field has an invalid date value,, and therefore can not be converted to a Java date. `DateUtil.getJavaDate(dateAsDouble)` returns null if the provided argument is not a valid date. So the ingestion of the file was failing due to calling `toString` on a null and was getting a `NullPointerException` exception. 


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested locally and in playground