### PR TITLE
fix bug where todo attempt was not updated after fetchWork

### DIFF
--- a/backend/app/extraction/Worker.scala
+++ b/backend/app/extraction/Worker.scala
@@ -56,8 +56,10 @@ class Worker(
               Attempt.Right((extractor, blob, ExtractionParams(ingestion, languages, parentBlobs, workspace)))
 
             case _ =>
-              logger.error(s"Unknown extractor $extractorName")
-              Attempt.Left(UnsupportedOperationFailure(s"Unknown extractor $extractorName"))
+              val failureMsg = s"Unknown extractor $extractorName"
+              logger.error(failureMsg)
+              manifest.logExtractionFailure(blob.uri, extractorName, failureMsg)
+              Attempt.Left(UnsupportedOperationFailure(failureMsg))
           }
       }
     }

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -453,7 +453,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
         |  ORDER BY coalesce(todo.priority, e.priority) DESC
         |  LIMIT {maxBatchSize}
         |
-        |MERGE (blob)-[:LOCKED_BY]->(worker)
+        |MERGE (b)-[:LOCKED_BY]->(worker)
         |
         |WITH collect({todo: todo, extractor: e, blob: b, worker: worker}) as allTasks
         |WITH tail(reduce(acc = [0, []], task in allTasks |


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
When worker calls fetchWork, the resources that have `TODO` relationships will be returned so the worker can execute the relevant extractors. As part of the fetchWork, the `attempts` property of the TODO relationship is supposed to get updated. For a strange reason that I didn't fully understand, the query was not updating the TODO attempts. Therefore, everytime the worker is triggered, the task that has already been attempted is returned by the query meaning it's stuck in an infinite loop. 

The fix in this PR does the 2 followings:
- Fix the query so that the todo attempts is updated 
- Add a `Extraction_Failure` relationship between the relevant resource and the extractor, so that it is known to us that this extractor is not supported. This way the UI also shows that the extractor for the file failed. 

 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested locally