### PR TITLE
fix invalid number error in excel extration

### DIFF
--- a/backend/app/extraction/tables/ExcelTableExtractor.scala
+++ b/backend/app/extraction/tables/ExcelTableExtractor.scala
@@ -119,7 +119,8 @@ class ExcelTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: 
               val formatString = style.getDataFormatString
 
               if(DateUtil.isADateFormat(formatIndex, formatString)) {
-                val date = Option(DateUtil.getJavaDate(xmlReader.getElementText.toDouble))
+                val textElement = xmlReader.getElementText
+                val date = textElement.toDoubleOption.flatMap(double => Option(DateUtil.getJavaDate(double)))
                 value = date.getOrElse(DateUtil.getJavaDate(0)).toString
               } else value = xmlReader.getElementText
             }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
There was a file which had syntax error in one of the date fields that was using a formula. So the ElementText was returning a string that couldn't get converted to `Double`. I replaced the `toDouble` by `toDoubleOption` to avoid exception and extraction failure. 

 e.g. the formula in the field can’t evaluate the value of a date field

![image](https://github.com/guardian/giant/assets/15894063/f834ea45-8fc0-425f-bbdb-548231e87d85)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested locally & in playground