### PR TITLE
Fix worker lock

### DIFF
--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -517,8 +517,8 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
 
         throw new IllegalStateException(message)
       } else {
-        val languages = rawLanguages.asList((v: Value) => v.asString).asScala.toList.flatMap(Languages.getByKey)
-        val parentBlobs: List[Uri] = rawParentBlobs.asList((v: Value) => v.asString).asScala.toList.map(Uri(_))
+        val languages = rawLanguages.asList(_.asString).asScala.toList.flatMap(Languages.getByKey)
+        val parentBlobs: List[Uri] = rawParentBlobs.asList(_.asString, new java.util.ArrayList[String]()).asScala.toList.map(Uri(_))
 
         WorkItem(blob, parentBlobs, extractorName, ingestion, languages, workspace)
       }

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -453,8 +453,6 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
         |  ORDER BY coalesce(todo.priority, e.priority) DESC
         |  LIMIT {maxBatchSize}
         |
-        |MERGE (b)-[:LOCKED_BY]->(worker)
-        |
         |WITH collect({todo: todo, extractor: e, blob: b, worker: worker}) as allTasks
         |WITH tail(reduce(acc = [0, []], task in allTasks |
         |    case
@@ -470,6 +468,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
         |  MATCH (worker :Worker { name: task.worker.name })
         |
         |  SET task.todo.attempts = task.todo.attempts + 1
+        |  MERGE (blob)-[:LOCKED_BY]->(worker)
         |
         |RETURN
         |    blob,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
Co-authored-by: Marjan Kalanaki <marjan.kalanaki@guardian.co.uk>

## What does this change?
- At the moment, workers can get into a state where all three have a lock on the same blob. 
- This PR reverts some of the changes in #157 which we think introduced the bug that allows this invalid state.
