### PR TITLE
add timeout to ocrMyPdf process

### DIFF
--- a/backend/app/extraction/ocr/BaseOcrExtractor.scala
+++ b/backend/app/extraction/ocr/BaseOcrExtractor.scala
@@ -29,7 +29,6 @@ abstract class BaseOcrExtractor(scratchSpace: ScratchSpace) extends FileExtracto
         Left(SubprocessInterruptedFailure)
 
       case e: OcrMyPdfTimeout =>
-        println(s"${this.name} error - ${e.getMessage}")
         Left(OcrTimeout(s"${this.name} error - ${e.getMessage}"))
 
       case NonFatal(e) =>

--- a/backend/app/extraction/ocr/BaseOcrExtractor.scala
+++ b/backend/app/extraction/ocr/BaseOcrExtractor.scala
@@ -3,9 +3,9 @@ package extraction.ocr
 import extraction.{ExtractionParams, FileExtractor}
 import model.manifest.Blob
 import services.ScratchSpace
-import utils.Ocr.OcrSubprocessInterruptedException
+import utils.Ocr.{OcrMyPdfTimeout, OcrSubprocessInterruptedException}
 import utils.OcrStderrLogger
-import utils.attempt.{Failure, SubprocessInterruptedFailure}
+import utils.attempt.{Failure, OcrTimeout, SubprocessInterruptedFailure}
 
 import java.io.File
 import scala.util.control.NonFatal
@@ -27,6 +27,10 @@ abstract class BaseOcrExtractor(scratchSpace: ScratchSpace) extends FileExtracto
     } catch {
       case OcrSubprocessInterruptedException =>
         Left(SubprocessInterruptedFailure)
+
+      case e: OcrMyPdfTimeout =>
+        println(s"${this.name} error - ${e.getMessage}")
+        Left(OcrTimeout(s"${this.name} error - ${e.getMessage}"))
 
       case NonFatal(e) =>
         // Throw exception here instead of returning Left to include stderr and preserve the original stack trace

--- a/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
@@ -19,6 +19,7 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.sys.process.{Process, ProcessLogger}
+import scala.util.Try
 
 class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, previewStorage: ObjectStorage,
   ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
@@ -75,7 +76,8 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
   }
 
   private def invokeOcrMyPdf(blobUri: Uri, lang: Language, file: File, config: OcrConfig, stderr: OcrStderrLogger, tmpDir: Path): String = {
-    val pdfFile = Ocr.invokeOcrMyPdf(lang.ocr, file.toPath, Some(config.dpi), stderr, tmpDir)
+    val unprocessedFilePages = Try(PDDocument.load(file).getNumberOfPages).toOption
+    val pdfFile = Ocr.invokeOcrMyPdf(lang.ocr, file.toPath, Some(config.dpi), stderr, tmpDir, unprocessedFilePages)
     var document: PDDocument = null
 
     try {

--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -6,8 +6,11 @@ import java.nio.file.{Files, Path}
 import services.TesseractOcrConfig
 import utils.attempt.Failure
 
+import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.concurrent.{Await, Future, TimeoutException, blocking, duration}
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.sys.process._
 
 
@@ -53,6 +56,7 @@ object Ocr extends Logging {
   object OcrMyPdfPdfaConversionFailed extends Exception("A valid PDF was created, PDF/A conversion failed. The file will be available.")
   object OcrMyPdfOtherError extends Exception("Some other error occurred.")
   object OcrMyPdfCtrlC extends Exception("The program was interrupted by pressing Ctrl+C.")
+  case class OcrMyPdfTimeout(msg: String) extends Exception(msg)
 
   def invokeTesseractDirectly(lang: String, imageFileName: String, config: TesseractOcrConfig, stderr: OcrStderrLogger): String = {
     val cmd = s"tesseract $imageFileName stdout -l $lang --oem ${config.engineMode} --psm ${config.pageSegmentationMode}"
@@ -102,15 +106,36 @@ object Ocr extends Logging {
 
   // TODO MRB: allow OcrMyPdf to read DPI if set in metadata
   // OCRmyPDF is a wrapper for Tesseract that we use to overlay the OCR as a text layer in the resulting PDF
-  def invokeOcrMyPdf(lang: String, inputFilePath: Path, dpi: Option[Int], stderr: OcrStderrLogger, tmpDir: Path): Path = {
+  def invokeOcrMyPdf(lang: String, inputFilePath: Path, dpi: Option[Int], stderr: OcrStderrLogger, tmpDir: Path, numberOfPages: Option[Int]): Path = {
     val tempFile = tmpDir.resolve(s"${inputFilePath.getFileName}.ocr.pdf")
     val stdout = mutable.Buffer.empty[String]
+    val defaultTimeoutInMinutes = 300
+
+
+    // Timeout is added because ocrMyPdf may get stuck processing a file
+    // and we don't want to block the worker forever
+    def runProcessWithTimeout(processBuilder: ProcessBuilder): Int = {
+      val process = processBuilder.run(ProcessLogger(stdout.append(_), stderr.append))
+      val future = Future(blocking(process.exitValue()))
+      // timeout duration gives at most 1 minute to ocr every page
+      // default 300 minutes is used in case the number of pages failed to
+      // get retrieved from the file and the value was None at this stage
+      val timeoutDuration = numberOfPages.getOrElse(defaultTimeoutInMinutes)
+      try {
+        Await.result(future, duration.Duration(timeoutDuration, TimeUnit.MINUTES))
+      } catch {
+        case _: TimeoutException =>
+          process.destroy()
+          process.exitValue()
+          throw OcrMyPdfTimeout(s"Timing out after ${timeoutDuration} minutes")
+      }
+    }
 
     def ocrWithOcrMyPdf(flag: OcrMyPdfFlag, overrideFile: Option[Path] = None): Int = {
       val sourceFilePath = overrideFile.getOrElse(inputFilePath)
       val cmd = s"ocrmypdf ${flag.flag} -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${sourceFilePath.toAbsolutePath} ${tempFile.toAbsolutePath}"
       val process = Process(cmd, cwd = None, extraEnv = "TMPDIR" -> tmpDir.toAbsolutePath.toString)
-      process.!(ProcessLogger(stdout.append(_), stderr.append))
+      runProcessWithTimeout(process)
     }
 
     def decryptWithQpdf(decryptTempFile: Path): Boolean = {

--- a/backend/app/utils/controller/FailureToResultMapper.scala
+++ b/backend/app/utils/controller/FailureToResultMapper.scala
@@ -114,6 +114,9 @@ object FailureToResultMapper extends Logging {
       case DeleteNotAllowed(msg) =>
         logUserAndMessage(user, s"Deletion is refused: ${msg}")
         Results.Forbidden(msg)
+      case OcrTimeout(msg) =>
+        logger.error(msg)
+        Results.InternalServerError(msg)
       case f: PostgresWriteFailure =>
         logger.error(f.msg, f.throwable)
         Results.InternalServerError(f.msg)

--- a/common/src/main/scala/utils/attempt/Failure.scala
+++ b/common/src/main/scala/utils/attempt/Failure.scala
@@ -112,6 +112,8 @@ case class PanDomainCookieInvalid(override val msg: String, reportAsFailure: Boo
 
 case class MisconfiguredAccount(msg: String) extends Failure
 
+case class OcrTimeout(msg: String) extends Failure
+
 case object PreviewNotSupportedFailure extends Failure {
   final override def msg = "Preview not supported for this file type"
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR is adding a timeout to `ocrMyPdf` process. This is because there's been occurrences where ocrMyPdf gets stuck in processing a file and doesn't return any exit code. As a result, the worker waits forever until the file processing is completed or errored. 

The timeout duration is chosen based on the number of pages within a file and is giving at most 1 minute for every page plus an overall 5 minutes to mitigate the risk of un-necessary timeout for files with low number of pages, e.g. for a pdf page with 10 pages, 15 (10 + 5) minutes is allocated for timeout. 

Thanks to @zekehuntergreen who helped with looking through the ingestion_events table to confirm that (1 minute * numberOfPages) + 5 minutes should be more than enough time to allocate for the timeout duration of ocrMyPdf.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested locally and in playground once by manually setting a shorter timeout and handling the error. And also, by setting the timeout based on page numbers and upload a few files. 