### PR TITLE
Fix `NullPointerException` in `EmlEmailExtractor`

### DIFF
--- a/backend/app/extraction/email/eml/EmlParser.scala
+++ b/backend/app/extraction/email/eml/EmlParser.scala
@@ -46,7 +46,7 @@ class EmlParser(val scratch: ScratchSpace, val ingestionServices: IngestionServi
           .collect { case p: MimeBodyPart => p }
           .flatMap(flattenMultipart)
 
-        val attachments = parts.filter(p => p.getEncoding.toLowerCase() == "base64" && getFilename(p).nonEmpty)
+        val attachments = parts.filter(p => Option(p.getEncoding).filter(_ == "base64").nonEmpty && getFilename(p).nonEmpty)
         val nonAttachments = parts.filter(p => getFilename(p).isEmpty)
 
         val bodyPart = nonAttachments.find(_.getContentType.toLowerCase().startsWith("text/plain"))

--- a/backend/app/extraction/email/eml/EmlParser.scala
+++ b/backend/app/extraction/email/eml/EmlParser.scala
@@ -46,7 +46,7 @@ class EmlParser(val scratch: ScratchSpace, val ingestionServices: IngestionServi
           .collect { case p: MimeBodyPart => p }
           .flatMap(flattenMultipart)
 
-        val attachments = parts.filter(p => Option(p.getEncoding).filter(_ == "base64").nonEmpty && getFilename(p).nonEmpty)
+        val attachments = parts.filter(p => Option(p.getEncoding).filter(_.toLowerCase() == "base64").nonEmpty && getFilename(p).nonEmpty)
         val nonAttachments = parts.filter(p => getFilename(p).isEmpty)
 
         val bodyPart = nonAttachments.find(_.getContentType.toLowerCase().startsWith("text/plain"))


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
`MimeBodyPart.getEncoding` can return null if the header is unavailable, leading to a null pointer exception when we call toLowerCase on the return value. Wrap the return value in an Option to handle this case.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
