### PR TITLE
Fix incorrect status in observability dashboard for in-progress extractions 

### DIFF
--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -142,7 +142,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
               AND blob_extractors.ingest_id = ingestion_events.ingest_id
               -- there is no index on extractorName but we aren't expecting too many events for the same blob_id/ingest_id
               AND blob_extractors.extractor = ingestion_events.details ->> 'extractorName'
-            WHERE ingestion_events.type = 'RunExtractor'
+              AND ingestion_events.type = 'RunExtractor'
             -- A file may be uploaded multiple times within different ingests - use group by to merge them together
             GROUP BY 1,2,3
           )
@@ -201,7 +201,9 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
             GROUP BY 1,2
           ) AS ie
           LEFT JOIN blob_metadata USING(ingest_id, blob_id)
-          LEFT JOIN extractor_statuses on extractor_statuses.blob_id = ie.blob_id and extractor_statuses.ingest_id = ie.ingest_id
+          LEFT JOIN extractor_statuses
+            ON extractor_statuses.blob_id = ie.blob_id
+            AND extractor_statuses.ingest_id = ie.ingest_id
           GROUP BY 1,2,3,4,5,6,7,8,9,10,11
           ORDER by ingest_start desc
      """.map(rs => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## Before
At the point in the ingestion / extraction process where extractors have been detected but not yet run are mislabelled as 'Complete' in 'status' column. The cell in the 'extractors' column is empty.
<img width="2206" alt="Screenshot 2023-10-19 at 12 18 14" src="https://github.com/guardian/giant/assets/17057932/f8bf745a-b333-4b66-90ed-aa3fea9d7e3c">

## After
The tables accurately reflect the status of these extractors - the status is 'in progress', extractors that need to be run are listed.
<img width="2159" alt="Screenshot 2023-10-19 at 12 18 44" src="https://github.com/guardian/giant/assets/17057932/e05480f2-309c-4748-948e-86493a9b3176">
