### PR TITLE
Enable caching for github actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
       # TODO: configure caching
       # See https://github.com/actions/setup-java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: .nvmrc
+          cache: npm
 
       # TODO: configure caching
       # See https://github.com/actions/setup-java
@@ -40,6 +41,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+          cache: sbt
 
       - name: Run script/teamcity
         run: |


### PR DESCRIPTION
## What does this change?
Following advice from @adamnfish and in an attempt to speed up giant builds (and generally be less wasteful), let's enable caching for the relevant [setup npm](https://github.com/actions/setup-node/tree/main) and [setup java](https://github.com/actions/setup-java#caching-sbt-dependencies) steps. 

We can also look at caching the docker containers we use to run the tests but I'm guessing that might be slightly more complex, so possibly for a future PR.

## How to test
If this build completes https://github.com/guardian/giant/actions/runs/6614917759/job/17965921924 that will be encouraging. We'd then need to run a few more builds to get some updated build time data. 

## How can we measure success?
Faster builds, less energy wastage, happy days