### PR TITLE
Fix transcription languages

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -161,7 +161,7 @@ class AppComponents(context: Context, config: Config)
     val imageOcrExtractor = new ImageOcrExtractor(config.ocr, scratchSpace, esResources, ingestionServices)
     val ocrMyPdfImageExtractor = new OcrMyPdfImageExtractor(config.ocr, scratchSpace, esResources, previewStorage, ingestionServices)
 
-    val transcriptionExtractor = new TranscriptionExtractor(esResources, scratchSpace, ingestionServices)
+    val transcriptionExtractor = new TranscriptionExtractor(esResources, scratchSpace)
 
     val ocrExtractors = config.ocr.defaultEngine match {
       case OcrEngine.OcrMyPdf => List(ocrMyPdfExtractor, ocrMyPdfImageExtractor)

--- a/backend/app/extraction/TranscriptionExtractor.scala
+++ b/backend/app/extraction/TranscriptionExtractor.scala
@@ -14,7 +14,7 @@ import utils._
 import java.io.File
 import scala.io.Source
 
-class TranscriptionExtractor(index: Index, scratchSpace: ScratchSpace, ingestionServices: IngestionServices) extends FileExtractor(scratchSpace) with Logging {
+class TranscriptionExtractor(index: Index, scratchSpace: ScratchSpace) extends FileExtractor(scratchSpace) with Logging {
   val mimeTypes: Set[String] = Set(
     "audio/wav",
     "audio/vnd.wave",
@@ -49,28 +49,15 @@ class TranscriptionExtractor(index: Index, scratchSpace: ScratchSpace, ingestion
     val tmpDir = scratchSpace.createWorkingDir(s"whisper-tmp-${blob.uri.value}")
     val ffMpegTmpDir = scratchSpace.createWorkingDir(s"ffmpeg-tmp-${blob.uri.value}")
 
-    val stdErrLogger = new OcrStderrLogger(Some(ingestionServices.setProgressNote(blob.uri, this, _)))
-
-    val transcriptionLanguage = if (params.languages.length > 1) {
-      logger.warn("More than one language specified. Will tell whisper to autodetect and translate")
-      None
-    } else params.languages.headOption
-
-    println(params.languages)
+    val stdErrLogger = new BasicStdErrLogger()
 
     val result = Either.catchNonFatal{
       val convertedFile = FfMpeg.convertToWav(file.toPath, ffMpegTmpDir)
       val transcriptResult: TranscriptionResult = Whisper.invokeWhisper(convertedFile, tmpDir, translate =false)
       val translationResult = if (transcriptResult.language != "en") Some(Whisper.invokeWhisper(convertedFile, tmpDir, translate=true)) else None
-      val outputSource = Source.fromFile(transcriptResult.path.toFile)
-      val outputText = outputSource.getLines().toList.mkString("\n")
-      outputSource.close()
 
-      val translateText = translationResult.map(tr => Source.fromFile(tr.path.toFile).getLines().toList.mkString("\n"))
-
-      println(translateText)
-      logger.info(outputText)
-      index.addDocumentTranscription(blob.uri, Some(outputText), Languages.getByIso6391Code(transcriptResult.language).getOrElse(English))
+      index.addDocumentTranscription(blob.uri, Some(transcriptResult.text), Languages.getByIso6391Code(transcriptResult.language).getOrElse(English))
+      translationResult.map(tr => index.addDocumentTranscription(blob.uri, Some(tr.text), English))
       ()
     }.leftMap{
       case error: FfMpegSubprocessCrashedException =>
@@ -84,12 +71,5 @@ class TranscriptionExtractor(index: Index, scratchSpace: ScratchSpace, ingestion
     FileUtils.deleteDirectory(ffMpegTmpDir.toFile)
 
     result
-
-    // create temp dir
-    // sort out languages
-    // run whisper on blob
-    // pick most human readable version
-    // convert to PDF?
-    // make sure pdf gets pageviewerified
   }
 }

--- a/backend/app/extraction/TranscriptionExtractor.scala
+++ b/backend/app/extraction/TranscriptionExtractor.scala
@@ -53,8 +53,8 @@ class TranscriptionExtractor(index: Index, scratchSpace: ScratchSpace) extends F
 
     val result = Either.catchNonFatal{
       val convertedFile = FfMpeg.convertToWav(file.toPath, ffMpegTmpDir)
-      val transcriptResult: TranscriptionResult = Whisper.invokeWhisper(convertedFile, tmpDir, translate =false)
-      val translationResult = if (transcriptResult.language != "en") Some(Whisper.invokeWhisper(convertedFile, tmpDir, translate=true)) else None
+      val transcriptResult: TranscriptionResult = Whisper.invokeWhisper(convertedFile, tmpDir, stdErrLogger, translate =false)
+      val translationResult = if (transcriptResult.language != "en") Some(Whisper.invokeWhisper(convertedFile, tmpDir, stdErrLogger, translate=true)) else None
 
       index.addDocumentTranscription(blob.uri, Some(transcriptResult.text), Languages.getByIso6391Code(transcriptResult.language).getOrElse(English))
       translationResult.map(tr => index.addDocumentTranscription(blob.uri, Some(tr.text), English))

--- a/backend/app/utils/Whisper.scala
+++ b/backend/app/utils/Whisper.scala
@@ -20,8 +20,7 @@ object Whisper extends Logging {
   }
 
 
-  def invokeWhisper(audioFilePath: Path, tmpDir: Path, translate: Boolean): TranscriptionResult = {
-    val whisperLogger = new BasicStdErrLogger()
+  def invokeWhisper(audioFilePath: Path, tmpDir: Path, whisperLogger: BasicStdErrLogger, translate: Boolean): TranscriptionResult = {
     val tempFile = tmpDir.resolve(s"${audioFilePath.getFileName}")
 
     val translateParam = if(translate) "--translate" else ""

--- a/backend/app/utils/Whisper.scala
+++ b/backend/app/utils/Whisper.scala
@@ -1,12 +1,23 @@
 package utils
 
 import java.nio.file.Path
+import scala.io.Source
 import scala.sys.process._
 
-case class TranscriptionResult(path: Path, language: String)
+case class TranscriptionResult(text: String, language: String)
 
 object Whisper extends Logging {
   private class WhisperSubprocessCrashedException(exitCode: Int, stderr: String) extends Exception(s"Exit code: $exitCode: ${stderr}")
+
+
+  def getTranscriptOutputText(outputFile: Path) = {
+    //for some reason whisper adds an extra .txt extension
+    val outputLocation = outputFile.resolveSibling(outputFile.getFileName.toString + ".txt")
+    val outputSource = Source.fromFile(outputLocation.toFile)
+    val outputText = outputSource.getLines().toList.mkString("\n")
+    outputSource.close()
+    outputText
+  }
 
 
   def invokeWhisper(audioFilePath: Path, tmpDir: Path, translate: Boolean): TranscriptionResult = {
@@ -19,10 +30,15 @@ object Whisper extends Logging {
 
     exitCode match {
       case 0 =>
-        val detectedLanguage = whisperLogger.getOutput.split("auto-detected language: ")(1).slice(0,2).mkString("")
-        println(s"ah ${whisperLogger.getOutput}")
-        //for some reason whisper adds an extra .txt extension
-        TranscriptionResult(tempFile.resolveSibling(tempFile.getFileName.toString + ".txt"), detectedLanguage)
+        val transcriptText = getTranscriptOutputText(tempFile)
+        val languageSplit = whisperLogger.getOutput.split("auto-detected language: ")
+        if (languageSplit.length > 1) {
+          val detectedLanguage = if (translate) "en" else languageSplit(1).slice(0,2).mkString("")
+          TranscriptionResult(transcriptText, detectedLanguage)
+        } else {
+          logger.warn("Failed to detect language - transcription may have failed. Falling back to english.")
+          TranscriptionResult(transcriptText, "en")
+        }
       case _ =>
         logger.error("Whisper extraction failed")
         throw new WhisperSubprocessCrashedException(exitCode, whisperLogger.getOutput)

--- a/frontend/src/js/components/viewer/PreviewSwitcher.js
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.js
@@ -101,7 +101,7 @@ class PreviewSwitcher extends React.Component {
         return <nav className='preview__links'>
             <KeyboardShortcut shortcut={keyboardShortcuts.showText} func={this.showText} />
             <KeyboardShortcut shortcut={keyboardShortcuts.showPreview} func={this.showPreview} />
-            {this.props.resource.text  ? <PreviewLink current={current} text='Text' to='text' navigate={this.props.setResourceView} />    : false}
+            {this.props.resource.text && !this.props.resource.transcript ? <PreviewLink current={current} text='Text' to='text' navigate={this.props.setResourceView} />    : false}
             {this.props.resource.transcript  ? this.renderMultiLangLinks(current, 'transcript')    : false}
             {!this.props.resource.transcript && this.renderMultiLangLinks(current, 'ocr')}
             {this.canPreview(this.props.resource.previewStatus) ? <PreviewLink current={current} text='Preview' to='preview' navigate={this.props.setResourceView} /> : false}

--- a/frontend/src/js/components/viewer/PreviewSwitcher.js
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.js
@@ -83,11 +83,11 @@ class PreviewSwitcher extends React.Component {
         this.props.setResourceView('table');
     }
 
-    renderMultiLangLinks(current, view) {
+    renderMultiLangLinks(current, view, textPrefix) {
         if (_.get(this.props.resource, view)) {
             const languages = Object.keys(_.get(this.props.resource, view));
             if (languages.length > 0) {
-                return languages.map( l => <PreviewLink key={l} current={current} to={`${view}.${l}`} text={`Transcript (${_.startCase(l)})`} navigate={this.props.setResourceView} />);
+                return languages.map( l => <PreviewLink key={l} current={current} to={`${view}.${l}`} text={`${textPrefix || ''} (${_.startCase(l)})`} navigate={this.props.setResourceView} />);
             }
         }
         return false;
@@ -102,8 +102,8 @@ class PreviewSwitcher extends React.Component {
             <KeyboardShortcut shortcut={keyboardShortcuts.showText} func={this.showText} />
             <KeyboardShortcut shortcut={keyboardShortcuts.showPreview} func={this.showPreview} />
             {this.props.resource.text && !this.props.resource.transcript ? <PreviewLink current={current} text='Text' to='text' navigate={this.props.setResourceView} />    : false}
-            {this.props.resource.transcript  ? this.renderMultiLangLinks(current, 'transcript')    : false}
-            {!this.props.resource.transcript && this.renderMultiLangLinks(current, 'ocr')}
+            {this.props.resource.transcript  ? this.renderMultiLangLinks(current, 'transcript', 'Transcript')    : false}
+            {!this.props.resource.transcript && this.renderMultiLangLinks(current, 'ocr', 'OCR')}
             {this.canPreview(this.props.resource.previewStatus) ? <PreviewLink current={current} text='Preview' to='preview' navigate={this.props.setResourceView} /> : false}
             {parents && parents.some(m => m.uri.endsWith("csv") || m.uri.endsWith("tsv")) && <PreviewLink current={current} text="Table" to="table" navigate={this.props.setResourceView} /> }
         </nav>;

--- a/frontend/src/js/util/resourceUtils.ts
+++ b/frontend/src/js/util/resourceUtils.ts
@@ -72,6 +72,10 @@ export function getDefaultView(resource: Resource): string | undefined {
         return undefined;
     }
 
+    if (resource.transcript) {
+        return `transcript.${Object.keys(resource.transcript)[0]}`;
+    }
+
     // We removed the isBasic check in Viewer during conversion to Typescript because it meant changing the definitions
     // of Resource and BasicResource in ways that would ripple across the codebase.
     // This is effectively the same thing, but without TypeScript really knowing what's going on.


### PR DESCRIPTION
## What does this change?
The main complex thing this PR does is in HitReaders (backend/app/services/index/HitReaders.scala) - modifying the transcription hit reader so that it doesn't discard the transcript text for languages which don't have highlights in them. It also fixes a bug where we I wasn't actually saving the translated transcript to elasticsearch (https://github.com/guardian/giant/compare/pm-transcription...transcription-tidy?expand=1#diff-c1413c4436e0eaed3ad9d530cfc47fc20c0831a5fa7ac8523690ec0d208ab182R60)

Also - remove various unused variables/comments and pull out the code to read the output transcript file into a separate function


## How to test
Tested locally, everything was very broken before so I think this is a big improvement!