### PR TITLE
Add transcript.<language> query param on transcribed resource url

### DIFF
--- a/frontend/src/js/components/viewer/PreviewSwitcher.js
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.js
@@ -101,7 +101,7 @@ class PreviewSwitcher extends React.Component {
         return <nav className='preview__links'>
             <KeyboardShortcut shortcut={keyboardShortcuts.showText} func={this.showText} />
             <KeyboardShortcut shortcut={keyboardShortcuts.showPreview} func={this.showPreview} />
-            {this.props.resource.text  ? <PreviewLink current={current} text='Text' to='text' navigate={this.props.setResourceView} />    : false}
+            {this.props.resource.text && !this.props.resource.transcript ? <PreviewLink current={current} text='Text' to='text' navigate={this.props.setResourceView} />    : false}
             {this.props.resource.transcript  ? this.renderMultiLangLinks(current, 'transcript')    : false}
             {!this.props.resource.transcript && this.renderMultiLangLinks(current, 'ocr')}
             {this.canPreview(this.props.resource.previewStatus) ? <PreviewLink current={current} text='Preview' to='preview' navigate={this.props.setResourceView} /> : false}

--- a/frontend/src/js/util/resourceUtils.ts
+++ b/frontend/src/js/util/resourceUtils.ts
@@ -72,6 +72,10 @@ export function getDefaultView(resource: Resource): string | undefined {
         return undefined;
     }
 
+    if (resource.transcript) {
+        return "transcript." + Object.keys(resource.transcript)[0];
+    }
+
     // We removed the isBasic check in Viewer during conversion to Typescript because it meant changing the definitions
     // of Resource and BasicResource in ways that would ripple across the codebase.
     // This is effectively the same thing, but without TypeScript really knowing what's going on.

--- a/frontend/src/js/util/resourceUtils.ts
+++ b/frontend/src/js/util/resourceUtils.ts
@@ -73,7 +73,7 @@ export function getDefaultView(resource: Resource): string | undefined {
     }
 
     if (resource.transcript) {
-        return "transcript." + Object.keys(resource.transcript)[0];
+        return `transcript.${Object.keys(resource.transcript)[0]}`;
     }
 
     // We removed the isBasic check in Viewer during conversion to Typescript because it meant changing the definitions


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a check if resource has transcript, and returns the transcript.<language> for view query parameter. 

It also removes the `Text` tab on the viewer if resource has transcript. 