### PR TITLE
Show correct title on viewer languange tab

### DIFF
--- a/frontend/src/js/components/viewer/PreviewSwitcher.js
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.js
@@ -83,11 +83,11 @@ class PreviewSwitcher extends React.Component {
         this.props.setResourceView('table');
     }
 
-    renderMultiLangLinks(current, view) {
+    renderMultiLangLinks(current, view, textPrefix) {
         if (_.get(this.props.resource, view)) {
             const languages = Object.keys(_.get(this.props.resource, view));
             if (languages.length > 0) {
-                return languages.map( l => <PreviewLink key={l} current={current} to={`${view}.${l}`} text={`Transcript (${_.startCase(l)})`} navigate={this.props.setResourceView} />);
+                return languages.map( l => <PreviewLink key={l} current={current} to={`${view}.${l}`} text={`${textPrefix || ''} (${_.startCase(l)})`} navigate={this.props.setResourceView} />);
             }
         }
         return false;
@@ -102,8 +102,8 @@ class PreviewSwitcher extends React.Component {
             <KeyboardShortcut shortcut={keyboardShortcuts.showText} func={this.showText} />
             <KeyboardShortcut shortcut={keyboardShortcuts.showPreview} func={this.showPreview} />
             {this.props.resource.text && !this.props.resource.transcript ? <PreviewLink current={current} text='Text' to='text' navigate={this.props.setResourceView} />    : false}
-            {this.props.resource.transcript  ? this.renderMultiLangLinks(current, 'transcript')    : false}
-            {!this.props.resource.transcript && this.renderMultiLangLinks(current, 'ocr')}
+            {this.props.resource.transcript  ? this.renderMultiLangLinks(current, 'transcript', 'Transcript')    : false}
+            {!this.props.resource.transcript && this.renderMultiLangLinks(current, 'ocr', 'OCR')}
             {this.canPreview(this.props.resource.previewStatus) ? <PreviewLink current={current} text='Preview' to='preview' navigate={this.props.setResourceView} /> : false}
             {parents && parents.some(m => m.uri.endsWith("csv") || m.uri.endsWith("tsv")) && <PreviewLink current={current} text="Table" to="table" navigate={this.props.setResourceView} /> }
         </nav>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR fixes the title of the language tab on viewer for the OCRed resources.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/giant/assets/15894063/a34eca6f-26df-4f36-b404-62052b178230) | ![image](https://github.com/guardian/giant/assets/15894063/7374ae2e-0bb9-4a78-b3a2-84f834ba3aa9) |

