### PR TITLE
Make giant logging less noisy

### DIFF
--- a/backend/app/utils/RequestLoggingFilter.scala
+++ b/backend/app/utils/RequestLoggingFilter.scala
@@ -24,7 +24,9 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
       case Success(response) =>
         val duration = System.currentTimeMillis() - start
         val (structuredMessage, message) = RequestLoggingFilter.buildSuccessMessage(rh, response, duration)
-        logger.info(structuredMessage, message)
+        if (rh.path != "/healthcheck") {
+          logger.info(structuredMessage, message)
+        }
 
       case Failure(err) =>
         val duration = System.currentTimeMillis() - start

--- a/backend/app/utils/auth/AuthActionBuilder.scala
+++ b/backend/app/utils/auth/AuthActionBuilder.scala
@@ -69,7 +69,6 @@ class DefaultAuthActionBuilder(val controllerComponents: ControllerComponents, f
                 )
             }
           } else {
-            logger.info(token.user.asLogMarker, s"Authentication succeeded")
             Right(result
               .refreshJwtSession
               .addingToJwtSession(Token.REFRESHED_AT_KEY, now)


### PR DESCRIPTION
## What does this change?
This removes request logging for succesful requests to '/healthcheck' from giant logs, which makes up a lot of the noise. 

It also removes 'authentication succeeded' logging, I think it's ok to only log in the 'failure' path. 

## How to test
Tested locally.

##success?
More readable logs, less filtering required