### PR TITLE
Temprarily increase the max number of children

### DIFF
--- a/frontend/src/js/util/resourceUtils.ts
+++ b/frontend/src/js/util/resourceUtils.ts
@@ -2,7 +2,7 @@ import { BasicResource, BasicResourceWithSingleBlobChild, HighlightableText, Res
 import { HighlightsState } from '../types/redux/GiantState';
 
 // safety-valve against a large flat structure slowing down the browser
-export const MAX_NUMBER_OF_CHILDREN = 1000;
+export const MAX_NUMBER_OF_CHILDREN = 1100;
 
 export function hasSingleBlobChild(resource: BasicResource): resource is BasicResourceWithSingleBlobChild {
     return !!(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR temporarily increases the `MAX_NUMBER_OF_CHILDREN` from 1000 to 1100. This is because there seems to be a bug in UI to display the children of a folder when it's over 1000 files. A ticket was created to fix this bug but we are temporarily increasing the limit as a quick fix.

![image](https://github.com/guardian/giant/assets/15894063/23c78645-65fd-48e8-9468-129e7230bec7)

![image](https://github.com/guardian/giant/assets/15894063/71d41b68-a8be-4533-bbe0-19ec23bdc8de)
