### PR TITLE
allow admin user to delete a public workspace

### DIFF
--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -244,7 +244,9 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
   override def deleteWorkspace(currentUser: String, workspace: String): Attempt[Unit] = attemptTransaction { tx =>
     tx.run(
       """
-        |MATCH (workspace: Workspace {id: {workspaceId}})<-[:CREATED]-(u: User {username: {username}})
+        |MATCH (user: User { username: {username} })
+        |MATCH (workspace: Workspace {id: {workspaceId}})<-[:CREATED]-(u:User)
+        |WHERE u.username = {username} OR (workspace.isPublic and (:Permission {name: "CanPerformAdminOperations"})<-[:HAS_PERMISSION]-(user))
         |MATCH (workspace)<-[:PART_OF]-(node: WorkspaceNode)
         |
         |DETACH DELETE node

--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -25,7 +25,8 @@ type Props = {
     getWorkspaceContents: typeof getWorkspace,
     focusedEntry: TreeEntry<WorkspaceEntry> | null,
     workspaces: WorkspaceMetadata[],
-    expandedNodes: TreeNode<WorkspaceEntry>[]
+    expandedNodes: TreeNode<WorkspaceEntry>[],
+    isAdmin: boolean,
 }
 
 export default function WorkspaceSummary({
@@ -40,7 +41,8 @@ export default function WorkspaceSummary({
     getWorkspaceContents,
     focusedEntry,
     workspaces,
-    expandedNodes
+    expandedNodes,
+    isAdmin
 }: Props) {
 
     const workspaceUsers = workspace.followers.filter(follower =>
@@ -97,7 +99,7 @@ export default function WorkspaceSummary({
                 actionDescription='Delete'
                 title={`Delete workspace '${workspace.name}'?`}
                 onConfirm={() => deleteWorkspace(workspace.id)}
-                disabled={currentUser.username !== workspace.owner.username}
+                disabled={currentUser.username !== workspace.owner.username && !(isAdmin && workspace.isPublic)}
             >
                 Delete Workspace
             </ModalAction>

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -47,6 +47,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { reprocessBlob } from '../../actions/workspaces/reprocessBlob';
 import { DeleteModal, DeleteStatus } from './DeleteModal';
 import { PartialUser } from '../../types/User';
+import { getMyPermissions } from '../../actions/users/getMyPermissions';
 
 
 type Props = ReturnType<typeof mapStateToProps>
@@ -331,6 +332,10 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             document.title = "Workspaces - Giant";
         }
     };
+
+    UNSAFE_componentWillMount() {
+        this.props.getMyPermissions();
+    }
 
     UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const workspaceId = this.props.match.params.id;
@@ -625,6 +630,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                     focusedEntry={this.props.focusedEntry}
                     workspaces={this.props.workspacesMetadata}
                     expandedNodes={this.props.expandedNodes}
+                    isAdmin={this.props.myPermissions.includes('CanPerformAdminOperations')}
                 />
                 <div className='workspace'>
                     {this.renderFolderTree(this.props.currentWorkspace)}
@@ -660,6 +666,7 @@ function mapStateToProps(state: GiantState) {
         users: state.users.userList,
         expandedNodes: state.workspaces.expandedNodes,
         collections: state.collections,
+        myPermissions: state.users.myPermissions,
     };
 }
 
@@ -691,7 +698,8 @@ function mapDispatchToProps(dispatch: GiantDispatch) {
         listUsers: bindActionCreators(listUsers, dispatch),
         getCollections: bindActionCreators(getCollections, dispatch),
         getWorkspacesMetadata: bindActionCreators(getWorkspacesMetadata, dispatch),
-        getWorkspace: bindActionCreators(getWorkspace, dispatch)
+        getWorkspace: bindActionCreators(getWorkspace, dispatch),
+        getMyPermissions: bindActionCreators(getMyPermissions, dispatch),
     };
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR updates the query for deleting workspace in order to allow the admins to delete a public workspace. 
Also on the UI, the delete button is only enabled if the user is admin and the workspace is public, or if the user is the owner of the workspace. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
This was tested locally and in playground. In playground, I asked my colleague to create a workspace and make it public. I then deleted that workspace as I am an admin user. 