### PR TITLE
Set whisper model via configuration parameter

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -161,7 +161,7 @@ class AppComponents(context: Context, config: Config)
     val imageOcrExtractor = new ImageOcrExtractor(config.ocr, scratchSpace, esResources, ingestionServices)
     val ocrMyPdfImageExtractor = new OcrMyPdfImageExtractor(config.ocr, scratchSpace, esResources, previewStorage, ingestionServices)
 
-    val transcriptionExtractor = new TranscriptionExtractor(esResources, scratchSpace)
+    val transcriptionExtractor = new TranscriptionExtractor(esResources, scratchSpace, config.transcribe)
 
     val ocrExtractors = config.ocr.defaultEngine match {
       case OcrEngine.OcrMyPdf => List(ocrMyPdfExtractor, ocrMyPdfImageExtractor)

--- a/backend/app/services/Config.scala
+++ b/backend/app/services/Config.scala
@@ -80,6 +80,10 @@ case class OcrConfig(
   tesseract: TesseractOcrConfig
 )
 
+case class TranscribeConfig(
+  whisperModelFilename: String,
+)
+
 case class WorkerConfig(
   name: Option[String],
   interval: FiniteDuration,
@@ -180,7 +184,8 @@ case class Config(
   preview: PreviewConfig,
   s3: S3Config,
   aws: Option[AWSDiscoveryConfig],
-  ocr: OcrConfig
+  ocr: OcrConfig,
+  transcribe: TranscribeConfig
 )
 
 object Config {
@@ -196,7 +201,8 @@ object Config {
     raw.as[PreviewConfig]("preview"),
     raw.as[S3Config]("s3"),
     raw.as[Option[AWSDiscoveryConfig]]("aws"),
-    raw.as[OcrConfig]("ocr")
+    raw.as[OcrConfig]("ocr"),
+    raw.as[TranscribeConfig]("transcribe")
   )
 
   private def parseAuth(rawAuthConfig: com.typesafe.config.Config): AuthConfig = {

--- a/backend/app/utils/AwsDiscovery.scala
+++ b/backend/app/utils/AwsDiscovery.scala
@@ -74,6 +74,9 @@ object AwsDiscovery extends Logging {
           name = Some(instanceId)
         )
       }.getOrElse(config.worker),
+      transcribe = config.transcribe.copy(
+        whisperModelFilename = readSSMParameter("transcribe/modelFilename", stack, stage, ssmClient)
+      ),
       underlying = config.underlying
         .withValue("play.http.secret.key", fromAnyRef(readSSMParameter("pfi/playSecret", stack, stage, ssmClient)))
         .withValue("pekko.actor.provider", fromAnyRef("local")) // disable Akka clustering, we query EC2 directly

--- a/backend/app/utils/Whisper.scala
+++ b/backend/app/utils/Whisper.scala
@@ -1,5 +1,7 @@
 package utils
 
+import services.TranscribeConfig
+
 import java.nio.file.Path
 import scala.io.Source
 import scala.sys.process._
@@ -19,12 +21,11 @@ object Whisper extends Logging {
     outputText
   }
 
-
-  def invokeWhisper(audioFilePath: Path, tmpDir: Path, whisperLogger: BasicStdErrLogger, translate: Boolean): TranscriptionResult = {
+  def invokeWhisper(audioFilePath: Path, config: TranscribeConfig, tmpDir: Path, whisperLogger: BasicStdErrLogger, translate: Boolean): TranscriptionResult = {
     val tempFile = tmpDir.resolve(s"${audioFilePath.getFileName}")
 
     val translateParam = if(translate) "--translate" else ""
-    val cmd = s"/opt/whisper/whisper.cpp/main -m /opt/whisper/whisper.cpp/models/ggml-base.bin -f ${audioFilePath.toString} --output-txt --output-file ${tempFile.toString} -l auto ${translateParam}"
+    val cmd = s"/opt/whisper/whisper.cpp/main -m /opt/whisper/whisper.cpp/models/${config.whisperModelFilename} -f ${audioFilePath.toString} --output-txt --output-file ${tempFile.toString} -l auto ${translateParam}"
     val exitCode = Process(cmd, cwd = None).!(ProcessLogger(stdout.append(_), whisperLogger.append))
 
     exitCode match {

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -202,5 +202,9 @@ ocr {
   }
 }
 
+transcribe {
+    whisperModelFilename = "ggml-base.bin"
+}
+
 # This will overwrite some settings from above
 include "site.conf"


### PR DESCRIPTION
## What does this change?
This pulls out the model we are using for whisper into a configuration parameter, which will allow us to change the model we are using by updating a value in parameter store and then redeploying giant. It also allows us to use different models on playground/dev/prod - which may be useful given that playground runs on less performant hardware to PROD, and often when testing stuff we care less about the quality of the transcription.

In future, we might want to make this even more configurable by using a feature switch

## How to test
Tested on playground - I switched to using the `small` model and had a succesful trasnsription. 

To test in production edit the transcribe/modelFilename param in SSM

## How can we measure success?
Based on some recent experiments, we might be able to get away with bumping the model to `small` from `base` - this would make that an easier process. 