### PR TITLE
Fix transcription bug where a translation overwrites a transcription

### DIFF
--- a/backend/app/services/index/Index.scala
+++ b/backend/app/services/index/Index.scala
@@ -15,7 +15,7 @@ trait Index {
 
   def addDocumentDetails(uri: Uri, text: Option[String], metadata: Map[String, Seq[String]], enrichedMetadata: EnrichedMetadata, languages: List[Language]): Attempt[Unit]
   def addDocumentOcr(uri: Uri, ocr: Option[String], language: Language): Attempt[Unit]
-  def addDocumentTranscription(uri: Uri, transcription: Option[String], language: Language): Attempt[Unit]
+  def addDocumentTranscription(uri: Uri, transcription: String, translation: Option[String], language: Language): Attempt[Unit]
 
   def ingestEmail(email: Email, ingestion: String, sourceMimeType: String, parentBlobs: List[Uri], workspace: Option[WorkspaceItemContext], languages: List[Language]): Attempt[Unit]
 

--- a/backend/app/utils/Whisper.scala
+++ b/backend/app/utils/Whisper.scala
@@ -10,7 +10,7 @@ object Whisper extends Logging {
   private class WhisperSubprocessCrashedException(exitCode: Int, stderr: String) extends Exception(s"Exit code: $exitCode: ${stderr}")
 
 
-  def getTranscriptOutputText(outputFile: Path) = {
+  private def getTranscriptOutputText(outputFile: Path) = {
     //for some reason whisper adds an extra .txt extension
     val outputLocation = outputFile.resolveSibling(outputFile.getFileName.toString + ".txt")
     val outputSource = Source.fromFile(outputLocation.toFile)


### PR DESCRIPTION
## What does this change?
We had a bug in the transcript code - addDocumentTranscript is an async function but we were calling it once for the transcription then again for the translation without waiting for the first call to finish, resulting in unpredictable behaviour (often the transcription would overwrite the translation or vice versa).

This fixes that by writing both transcript and translated transcript in a single elasticsearch query

## How to test
I've tested this locally with a file in german. Will test on playground just as soon as github actions finishes...