### PR TITLE
Create API token page for whistleflow

### DIFF
--- a/frontend/src/js/App.js
+++ b/frontend/src/js/App.js
@@ -32,6 +32,7 @@ import SettingsSidebar from './components/Settings/SettingsSidebar';
 import ExtractionFailures from './components/Settings/ExtractionFailuresComponent';
 import Users from './components/Settings/Users';
 import About from './components/Settings/About';
+import Token from './components/UtilComponents/Token';
 import FeatureSwitches from './components/Settings/FeatureSwitches';
 import { WeeklyUploadsFeed } from './components/Uploads/Uploads';
 
@@ -93,6 +94,10 @@ class App extends React.Component {
 
                     <Route path = '/settings/my-uploads' component={MyUploads} />
                     <Route path = '/settings/all-ingestion-events' component={AllIngestionEvents} />
+
+                    {/* This page is used by securedrop workstation / whistleflow to retrieve a jwt token
+                        that will be used to export SDW submissions to giant */}
+                    <Route path='/token' component={Token} />
                 </div>
             </div>
             <Route exact path='/' render={() => <Redirect to='/search' />} />
@@ -113,7 +118,7 @@ class App extends React.Component {
         </div>;
     }
 
-    renderAnonymouse() {
+    renderAnonymous() {
         return <Switch>
             <Route path='/login' component={Login} />
             <Route path='/register' component={Register} />
@@ -139,7 +144,7 @@ class App extends React.Component {
             <ConnectedRouter history={this.props.history}>
                 <div className='app'>
                     <Header user={maybeUser} config={this.props.config} preferences={this.props.preferences}/>
-                    {loggedIn ? this.renderLoggedIn() : this.renderAnonymouse()}
+                    {loggedIn ? this.renderLoggedIn() : this.renderAnonymous()}
                 </div>
             </ConnectedRouter>
         );

--- a/frontend/src/js/App.js
+++ b/frontend/src/js/App.js
@@ -118,7 +118,7 @@ class App extends React.Component {
         </div>;
     }
 
-    renderAnonymous() {
+    renderAnonymouse() {
         return <Switch>
             <Route path='/login' component={Login} />
             <Route path='/register' component={Register} />
@@ -144,7 +144,7 @@ class App extends React.Component {
             <ConnectedRouter history={this.props.history}>
                 <div className='app'>
                     <Header user={maybeUser} config={this.props.config} preferences={this.props.preferences}/>
-                    {loggedIn ? this.renderLoggedIn() : this.renderAnonymous()}
+                    {loggedIn ? this.renderLoggedIn() : this.renderAnonymouse()}
                 </div>
             </ConnectedRouter>
         );

--- a/frontend/src/js/components/UtilComponents/Token.tsx
+++ b/frontend/src/js/components/UtilComponents/Token.tsx
@@ -9,6 +9,14 @@ class Token extends React.Component<Props> {
     render() {
         return (
             <div className="app__main-content">
+                <h1>
+                    Securedrop Workstation / Whistleflow authentication page
+                </h1>
+                <p>
+                    If you see this page for more than a few seconds, something
+                    has gone wrong with SecureDrop login. Please close this
+                    window and try again.
+                </p>
                 {/* Whistleflow relies on this id */}
                 <div id="giant-api-token">{this.props.auth.jwtToken}</div>
             </div>

--- a/frontend/src/js/components/UtilComponents/Token.tsx
+++ b/frontend/src/js/components/UtilComponents/Token.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { GiantState } from "../../types/redux/GiantState"
+
+import { connect } from "react-redux"
+
+type Props = ReturnType<typeof mapStateToProps>
+
+class Token extends React.Component<Props> {
+    render() {
+        return (
+            <div className="app__main-content">
+                {/* Whistleflow relies on this id */}
+                <div id="giant-api-token">{this.props.auth.jwtToken}</div>
+            </div>
+        )
+    }
+}
+
+function mapStateToProps(state: GiantState) {
+    return {
+        config: state.app.config,
+        auth: state.auth,
+    }
+}
+
+function mapDispatchToProps() {
+    return {}
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Token)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Creates a page with a logged-in user's jwt token on it so that it can be scraped by [whistleflow-giant-login](https://github.com/guardian/whistleflow/pull/43).

## Why
To enable export from SecureDrop Workstation to Giant, we need SDW users to be able to log in to Giant in a dedicated whistleflow-giant-login VM, and scrape their jwt token so that it can be used to authenticate against the Giant API to retrieve a list of their workspaces and to upload files.

This token is currently available on the [settings/about](https://giant.pfi.gutools.co.uk/settings/about) page but creating a dedicated page will reduce the risk that future changes to the about page break whistleflow.



