### PR TITLE
Fix missing js asset bug

### DIFF
--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -23,7 +23,7 @@ play {
   }
 
   assets.urlPrefix = ""
-  assets.cache."public/index.html"="no-cache"
+  assets.cache."/public/index.html" = "no-cache"
 
   i18n.langs = [ "en", "fr" ]
   # TODO MRB: this is here because PDFjs uses inline styles, fonts and blobby images. Can we remove or harden?

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -23,7 +23,8 @@ play {
   }
 
   assets.urlPrefix = ""
-  
+  assets.cache."public/index.html"="no-cache"
+
   i18n.langs = [ "en", "fr" ]
   # TODO MRB: this is here because PDFjs uses inline styles, fonts and blobby images. Can we remove or harden?
   # TODO MRB: We can remove font-src when we get rid of Semantic UI (it @imports a Google font)


### PR DESCRIPTION
Co-Authored-By: Philip McMahon <philip.mcmahon@guardian.co.uk>

## The bug
- After a deployment of Giant, any browsers which had visited the site in the previous hour would see a "loading" page and would be unable to use the site.
- This was because the browser would load a cached version of `index.html` including a script tag with a url pointing to the old version of the javascript assets for the app, which no longer exists after the deployment.
- The browser requests this javascript file from the backend, it isn't found, and the [default response includes the contents of index.html](https://github.com/guardian/giant/blob/403ad2655c5721bf76c31858dc77231ca7cca71e/backend/app/controllers/frontend/App.scala#L24) which results in an error like `Refused to execute script because its MIME type ('text/html') is not executable`

## Fix
Setting Cache Control header `no-cache` on `index.html` makes it so that this file is always fetched from the backend. The url for js assets is always up-to-date.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested in CODE

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

