### PR TITLE
Upgrade to version 3 of the Play Framework. Remove akka completely

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -1,7 +1,5 @@
-import org.apache.pekko.actor.{ActorSystem => PekkoActorSystem, CoordinatedShutdown => PekkoCoordinatedShutdown}
-import akka.actor.{CoordinatedShutdown => AkkaCoordinatedShutdown}
-import org.apache.pekko.actor.CoordinatedShutdown.{Reason => PekkoReason}
-import akka.actor.CoordinatedShutdown.{Reason => AkkaReason}
+import org.apache.pekko.actor.{ActorSystem, CoordinatedShutdown}
+import org.apache.pekko.actor.CoordinatedShutdown.Reason
 import cats.syntax.either._
 import com.gu.pandomainauth
 import com.gu.pandomainauth.PublicSettings
@@ -62,7 +60,7 @@ class AppComponents(context: Context, config: Config)
 
   // Play includes an akka actorSystem but due to licensing constraints we can only use it for play specific tasks
   // so here we create a pekko actor system
-  private val pekkoActorSystem: PekkoActorSystem = PekkoActorSystem.create("pfi")
+  private val pekkoActorSystem: ActorSystem = ActorSystem.create("pfi")
   applicationLifecycle.addStopHook(() => {
     logger.info("Shutting down pekko")
     pekkoActorSystem.terminate()
@@ -264,8 +262,8 @@ class AppComponents(context: Context, config: Config)
       // If the exception comes initialising the actor system itself then running the CoordinatedShutdown will try and
       // initialise it again, so we also log the original error to make sure we see it
       logger.error("Error during initialisation, starting co-ordinated shutdown", e)
-      Await.ready(PekkoCoordinatedShutdown(pekkoActorSystem).run(new PekkoReason {}), 10 seconds)
-      Await.ready(AkkaCoordinatedShutdown(actorSystem).run(new AkkaReason {}), 10 seconds)
+      Await.ready(CoordinatedShutdown(pekkoActorSystem).run(new Reason {}), 10 seconds)
+      Await.ready(CoordinatedShutdown(actorSystem).run(new Reason {}), 10 seconds)
 
       throw e
   }

--- a/backend/app/commands/GetPagePreview.scala
+++ b/backend/app/commands/GetPagePreview.scala
@@ -1,6 +1,6 @@
 package commands
 
-import akka.stream.scaladsl.StreamConverters
+import org.apache.pekko.stream.scaladsl.StreamConverters
 import model.{Language, Uri}
 import play.api.http.HttpEntity
 import services.ObjectStorage

--- a/backend/app/controllers/api/Previews.scala
+++ b/backend/app/controllers/api/Previews.scala
@@ -1,6 +1,6 @@
 package controllers.api
 
-import akka.stream.scaladsl.StreamConverters
+import org.apache.pekko.stream.scaladsl.StreamConverters
 import model.{ObjectData, ObjectMetadata, Uri}
 import play.api.http.HttpEntity
 import play.api.mvc._

--- a/backend/app/model/frontend/Node.scala
+++ b/backend/app/model/frontend/Node.scala
@@ -1,6 +1,5 @@
 package model.frontend
 
-import org.apache.pekko.cluster.{Member, MemberStatus}
 import play.api.libs.json.Json
 
 case class Node(hostname: String, reachable: Boolean)

--- a/backend/app/utils/AllowFrameFilter.scala
+++ b/backend/app/utils/AllowFrameFilter.scala
@@ -1,6 +1,6 @@
 package utils
 
-import akka.stream.Materializer // use akka Materializer rather than pekko as this is what Filter expects
+import org.apache.pekko.stream.Materializer
 import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/backend/app/utils/RequestLoggingFilter.scala
+++ b/backend/app/utils/RequestLoggingFilter.scala
@@ -1,7 +1,7 @@
 package utils
 
 import java.net.URI
-import akka.stream.Materializer // use akka Materializer rather than pekko as this is what Filter expects
+import org.apache.pekko.stream.Materializer // use akka Materializer rather than pekko as this is what Filter expects
 import org.slf4j.LoggerFactory
 import play.api.mvc.{Filter, RequestHeader, Result}
 

--- a/backend/test/commands/CollectionSharingITest.scala
+++ b/backend/test/commands/CollectionSharingITest.scala
@@ -2,7 +2,7 @@ package commands
 
 import java.util.concurrent.TimeUnit
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import model.Uri
 import model.manifest.{Blob, Collection}
 import org.scalatest.funsuite.AnyFunSuite

--- a/backend/test/controllers/api/EventsTest.scala
+++ b/backend/test/controllers/api/EventsTest.scala
@@ -3,7 +3,7 @@ package controllers.api
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import model.Uri
 import model.manifest.Collection
 import model.user.UserPermission.CanPerformAdminOperations

--- a/backend/test/controllers/api/ExtractorITest.scala
+++ b/backend/test/controllers/api/ExtractorITest.scala
@@ -3,7 +3,7 @@ package controllers.api
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import extraction.ExtractionParams
 import extraction.archives.ZipExtractor
 import model.ingestion.WorkspaceItemContext

--- a/backend/test/controllers/api/WorkspaceSearchITest.scala
+++ b/backend/test/controllers/api/WorkspaceSearchITest.scala
@@ -2,7 +2,7 @@ package controllers.api
 
 import java.util.concurrent.TimeUnit
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import model.frontend.SearchResults
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.BeforeAndAfterEach

--- a/backend/test/controllers/api/WorkspaceSharingITest.scala
+++ b/backend/test/controllers/api/WorkspaceSharingITest.scala
@@ -2,7 +2,7 @@ package controllers.api
 
 import java.util.concurrent.TimeUnit
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.BeforeAndAfterEach
 import model.frontend.user.PartialUser

--- a/backend/test/controllers/api/WorkspacesITest.scala
+++ b/backend/test/controllers/api/WorkspacesITest.scala
@@ -2,7 +2,7 @@ package controllers.api
 
 import java.util.concurrent.TimeUnit
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import model.Uri
 import model.annotations.{Workspace, WorkspaceEntry}
 import model.frontend.{SearchResults, TreeEntry, TreeLeaf, TreeNode}

--- a/backend/test/test/integration/Helpers.scala
+++ b/backend/test/test/integration/Helpers.scala
@@ -1,6 +1,6 @@
 package test.integration
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import commands.IngestFileResult
 import controllers.api._
 import extraction.MimeTypeMapper

--- a/backend/test/utils/IndexTestHelpers.scala
+++ b/backend/test/utils/IndexTestHelpers.scala
@@ -1,6 +1,6 @@
 package utils
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import controllers.api.Search
 import extraction.MetadataEnrichment
 import model.frontend.{Highlight, SearchResults}

--- a/backend/test/utils/auth/AuthActionBuilderTest.scala
+++ b/backend/test/utils/auth/AuthActionBuilderTest.scala
@@ -30,7 +30,7 @@ class AuthActionBuilderTest extends AnyFreeSpec with Matchers with BaseOneAppPer
   override def fakeApplication(): Application = {
     val env = Environment.simple(new File("."))
     val initialSettings: Map[String, AnyRef] = Map(
-      "play.http.secret.key" -> "TestKey",
+      "play.http.secret.key" -> "MySecretKeyShhDontTellAnyoneOrIWillBeVerySad",
       "play.http.session.maxAge" -> Int.box(900000),
       "pekko.actor.provider" -> "local"
     )

--- a/backend/test/utils/auth/AuthActionBuilderTest.scala
+++ b/backend/test/utils/auth/AuthActionBuilderTest.scala
@@ -1,6 +1,6 @@
 package utils.auth
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val awsVersion = "1.12.428"
 val log4jVersion = "2.20.0"
 val slf4jVersion = "2.0.7"
 // To match what the main app gets from scalatestplus-play transitively
-val scalatestVersion = "3.1.1"
+val scalatestVersion = "3.2.17"
 
 val port = 9001
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ ThisBuild / scalaVersion := "2.13.9"
 
 import com.gu.riffraff.artifact.BuildInfo
 import play.sbt.PlayImport.PlayKeys._
-import com.typesafe.sbt.packager.MappingsHelper._
 
 val compilerFlags = Seq(
   "-unchecked",
@@ -81,10 +80,11 @@ lazy val common = (project in file("common"))
   .settings(
     name := "common",
     scalacOptions := compilerFlags,
+//    dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.2.0",
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.2.0",
-      "com.typesafe.play" %% "play-json" % "2.9.4",
-      "com.typesafe.play" %% "play-json-joda" % "2.9.4",
+      "org.playframework" %% "play-json" % "3.0.1",
+      "org.playframework" %% "play-json-joda" % "3.0.1",
       "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
       "org.scalatest" %% "scalatest" % scalatestVersion,
       // Play has a transitive dependency on Logback,
@@ -106,6 +106,7 @@ lazy val backend = (project in file("backend"))
   .settings(
     name := "pfi",
     scalacOptions := compilerFlags,
+    evictionErrorLevel := Level.Warn,
 
     libraryDependencies ++= Seq(
       ws,
@@ -130,13 +131,13 @@ lazy val backend = (project in file("backend"))
       "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
       "net.logstash.logback" % "logstash-logback-encoder" % "6.3",
-      "com.pauldijou" %% "jwt-play" % "5.0.0",
+      "com.github.jwt-scala" % "jwt-play_2.13" % "9.4.5",
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ssm" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatchmetrics" % awsVersion,
-      "com.beachape" %% "enumeratum-play" % "1.7.2",
+      "com.beachape" %% "enumeratum-play" % "1.8.0",
       "com.iheart" %% "ficus" % "1.5.2",
       "org.jsoup" % "jsoup" % "1.14.2",
       // angus mail is the implementation of jakarta mail. If updating this you may also need to update the mbox provider jar file
@@ -167,7 +168,7 @@ lazy val backend = (project in file("backend"))
       // Test dependencies
 
       "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
-      "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
+      "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test,
       "com.whisk" %% "docker-testkit-scalatest" % "0.9.9" % Test,
       "com.whisk" %% "docker-testkit-impl-spotify" % "0.9.9" % Test,
       "org.scalamock" %% "scalamock" % "4.4.0" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,6 @@ lazy val common = (project in file("common"))
   .settings(
     name := "common",
     scalacOptions := compilerFlags,
-//    dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.2.0",
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.2.0",
       "org.playframework" %% "play-json" % "3.0.1",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,7 @@
-// The Typesafe repository
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 


### PR DESCRIPTION
## What does this change?
Play 3.0 is the latest version of the play framework. There are two main benefits of upgrading:
 - Play 3 [uses pekko instead of akka](https://www.playframework.com/documentation/3.0.x/General#How-Play-Deals-with-Akkas-License-Change), so we can remove the last traces of akka from our codebase and not risk angering the license gods
 - Play 3 supports Scala 3

This was a pretty easy upgrade - just a few dependency bumps. The only 'code' change was I had to increase the length of the [play application secret ](https://www.playframework.com/documentation/3.0.x/ApplicationSecret)

We can't actually move to Scala 3 until we upgrade to elasticsearch 8 as elastic4s doesn't support elasticsearch 7 at the moment. 

## How to test
Tested on playground. 
