### PR TITLE
Upgrade postgres and scalike libraries

### DIFF
--- a/backend/app/services/observability/PostgresClient.scala
+++ b/backend/app/services/observability/PostgresClient.scala
@@ -55,7 +55,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
         ${metaData.fileSize},
         ${metaData.path},
               now()
-            );""".execute().apply()
+            );""".execute()
         } match {
             case Success(_) => Right(())
             case Failure(exception) =>
@@ -85,7 +85,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
                 ${event.status.toString()},
                 $detailsJson::JSONB,
                 now()
-            );""".execute().apply()
+            );""".execute()
         } match {
             case Success(_) => Right(())
             case Failure(exception) =>
@@ -238,7 +238,7 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
                   rs.boolean("infiniteLoop")
                 )
             }
-            ).list().apply()
+            ).list()
             results
         }
         match {
@@ -250,8 +250,8 @@ class PostgresClientImpl(postgresConfig: PostgresConfig) extends PostgresClient 
   def deleteBlobIngestionEventsAndMetadata(blobId: String): Either[GiantFailure, Long] = {
     Try {
       DB.localTx { implicit session =>
-        val numIngestionDeleted = sql"DELETE FROM ingestion_events WHERE blob_id = ${blobId}".executeUpdate().apply()
-        val numBlobMetadataDeleted = sql"DELETE FROM blob_metadata WHERE blob_id = ${blobId}".executeUpdate().apply()
+        val numIngestionDeleted = sql"DELETE FROM ingestion_events WHERE blob_id = ${blobId}".executeUpdate()
+        val numBlobMetadataDeleted = sql"DELETE FROM blob_metadata WHERE blob_id = ${blobId}".executeUpdate()
         numIngestionDeleted + numBlobMetadataDeleted
       }
     } match {

--- a/build.sbt
+++ b/build.sbt
@@ -161,8 +161,8 @@ lazy val backend = (project in file("backend"))
       "com.github.junrar" % "junrar" % "7.4.1",
 
       // postgres
-      "org.scalikejdbc" %% "scalikejdbc"       % "3.5.0",
-      "org.postgresql"  %  "postgresql"        % "42.2.27",
+      "org.scalikejdbc" %% "scalikejdbc"       % "4.0.0",
+      "org.postgresql"  %  "postgresql"        % "42.5.4",
 
       // Test dependencies
 


### PR DESCRIPTION
## What does this change?
Resolves https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-2401816

The scalike upgrade wasn't really necessary as part of this but I went for it in the hope it would be painless as it is a requirement for Scala 3. In the end there was only a small code change required - doing '.apply()' doesn't appear necessary anymore.


## How to test
Tested on playground - giant still appears to be happily chatting with postgres.