### PR TITLE
Update http-proxy-middleware

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "d3": "^4.13.0",
         "date-fns": "^2.27.0",
         "history": "^4.10.1",
-        "http-proxy-middleware": "^0.19.1",
+        "http-proxy-middleware": "2.0.6",
         "human-date": "^1.4.0",
         "jwt-decode": "^2.2.0",
         "md5": "^2.2.1",
@@ -2889,59 +2889,6 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/@jest/core/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/@jest/environment": {
       "version": "27.5.1",
       "dev": true,
@@ -3121,65 +3068,12 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/@jest/transform/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/@jest/transform/node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/@jest/types": {
@@ -3815,7 +3709,7 @@
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -3836,7 +3730,7 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3876,7 +3770,7 @@
     },
     "node_modules/@types/express": {
       "version": "4.17.17",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -3887,7 +3781,7 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.17.34",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -3936,7 +3830,6 @@
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4002,12 +3895,11 @@
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "12.7.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/numeral": {
@@ -4050,7 +3942,7 @@
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/ramda": {
@@ -4064,7 +3956,7 @@
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -4218,7 +4110,7 @@
     },
     "node_modules/@types/send": {
       "version": "0.17.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -4235,7 +4127,7 @@
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "*",
@@ -5036,27 +4928,6 @@
         "deep-equal": "^2.0.5"
       }
     },
-    "node_modules/arr-diff": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-flatten": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
       "dev": true,
@@ -5098,13 +4969,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/array-unique": {
-      "version": "0.3.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/array.prototype.flat": {
@@ -5176,13 +5040,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/assign-symbols": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "dev": true,
@@ -5204,16 +5061,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/attr-accept": {
@@ -5509,32 +5356,6 @@
       "version": "1.0.2",
       "license": "MIT"
     },
-    "node_modules/base": {
-      "version": "0.11.2",
-      "license": "MIT",
-      "dependencies": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/base/node_modules/define-property": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/batch": {
       "version": "0.6.1",
       "dev": true,
@@ -5634,39 +5455,14 @@
       }
     },
     "node_modules/braces": {
-      "version": "2.3.2",
-      "license": "MIT",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "fill-range": "^7.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/braces/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/braces/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -5731,24 +5527,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cache-base": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/call-bind": {
@@ -5953,43 +5731,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chokidar/node_modules/braces": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/fill-range": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/is-number": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/chokidar/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "license": "ISC",
@@ -6027,88 +5768,6 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/class-utils": {
-      "version": "0.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/define-property": {
-      "version": "0.2.5",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/is-accessor-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/is-data-descriptor": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/is-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/kind-of": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/classnames": {
       "version": "2.3.2",
@@ -6242,17 +5901,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/collection-visit": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -6325,10 +5973,6 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/component-emitter": {
-      "version": "1.3.0",
       "license": "MIT"
     },
     "node_modules/compressible": {
@@ -6439,13 +6083,6 @@
       "version": "1.0.6",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/copy-descriptor": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/core-js": {
       "version": "3.30.1",
@@ -7257,6 +6894,7 @@
     },
     "node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -7266,13 +6904,6 @@
       "version": "10.4.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/decompress-response": {
       "version": "4.2.1",
@@ -7366,17 +6997,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-property": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -8366,36 +7986,6 @@
         "ajv": "^8.8.2"
       }
     },
-    "node_modules/eslint-webpack-plugin/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint-webpack-plugin/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint-webpack-plugin/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/eslint-webpack-plugin/node_modules/jest-worker": {
       "version": "28.1.3",
       "dev": true,
@@ -8413,18 +8003,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/eslint-webpack-plugin/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/eslint-webpack-plugin/node_modules/schema-utils": {
       "version": "4.0.1",
@@ -8456,17 +8034,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/eslint-webpack-plugin/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/eslint/node_modules/argparse": {
@@ -8666,108 +8233,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-brackets": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/define-property": {
-      "version": "0.2.5",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-accessor-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-data-descriptor": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/kind-of": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/expect": {
       "version": "27.5.1",
       "dev": true,
@@ -8845,61 +8310,6 @@
       "version": "3.0.2",
       "license": "MIT"
     },
-    "node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob/node_modules/define-property": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -8918,59 +8328,6 @@
       },
       "engines": {
         "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fast-glob/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fast-glob/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/fast-glob/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -9090,33 +8447,14 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "4.0.0",
-      "license": "MIT",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "to-regex-range": "^5.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fill-range/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -9227,13 +8565,6 @@
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/for-in": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
@@ -9359,16 +8690,6 @@
       "funding": {
         "type": "patreon",
         "url": "https://www.patreon.com/infusion"
-      }
-    },
-    "node_modules/fragment-cache": {
-      "version": "0.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "map-cache": "^0.2.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/fresh": {
@@ -9540,13 +8861,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-value": {
-      "version": "2.0.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/glob": {
@@ -9780,39 +9094,6 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "license": "ISC"
-    },
-    "node_modules/has-value": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-values": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-values/node_modules/kind-of": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/hast-to-hyperscript": {
       "version": "9.0.1",
@@ -10193,16 +9474,26 @@
       "license": "MIT"
     },
     "node_modules/http-proxy-middleware": {
-      "version": "0.19.2",
-      "license": "MIT",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
       "dependencies": {
+        "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
-        "micromatch": "^3.1.10"
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
       }
     },
     "node_modules/https-proxy-agent": {
@@ -10398,16 +9689,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/is-accessor-descriptor": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-alphabetical": {
       "version": "1.0.4",
       "license": "MIT",
@@ -10520,16 +9801,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-data-descriptor": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-date-object": {
       "version": "1.0.5",
       "license": "MIT",
@@ -10551,18 +9822,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-descriptor": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "dev": true,
@@ -10575,16 +9834,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-extendable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -10652,13 +9901,11 @@
       }
     },
     "node_modules/is-number": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -10673,16 +9920,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-obj": {
@@ -10703,23 +9940,12 @@
     },
     "node_modules/is-plain-obj": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -10877,13 +10103,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-windows": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-word-character": {
       "version": "1.0.4",
       "license": "MIT",
@@ -10911,13 +10130,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -11210,54 +10422,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-config/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-config/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-config/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/jest-config/node_modules/jest-get-type": {
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/jest-config/node_modules/pretty-format": {
@@ -11271,17 +10441,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/jest-diff": {
@@ -11420,59 +10579,6 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/jest-jasmine2": {
@@ -11668,48 +10774,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-message-util/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/jest-message-util/node_modules/pretty-format": {
       "version": "27.5.1",
       "dev": true,
@@ -11721,17 +10785,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/jest-mock": {
@@ -12137,17 +11190,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-watch-typeahead/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-watch-typeahead/node_modules/emittery": {
       "version": "0.10.2",
       "dev": true,
@@ -12157,25 +11199,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
-    },
-    "node_modules/jest-watch-typeahead/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-watch-typeahead/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/jest-watch-typeahead/node_modules/jest-message-util": {
@@ -12270,18 +11293,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-watch-typeahead/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/jest-watch-typeahead/node_modules/pretty-format": {
       "version": "28.1.3",
       "dev": true,
@@ -12358,17 +11369,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/jest-watch-typeahead/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/jest-watcher": {
@@ -12579,6 +11579,7 @@
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12796,23 +11797,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/map-cache": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/map-visit": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "object-visit": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/markdown-escapes": {
       "version": "1.0.4",
       "license": "MIT",
@@ -12918,25 +11902,15 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "3.1.10",
-      "license": "MIT",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -13106,17 +12080,6 @@
       "version": "4.0.0",
       "license": "ISC"
     },
-    "node_modules/mixin-deep": {
-      "version": "1.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "dev": true,
@@ -13153,6 +12116,7 @@
     },
     "node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -13196,26 +12160,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/nanomatch": {
-      "version": "1.2.13",
-      "license": "MIT",
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/natural-compare": {
@@ -13404,77 +12348,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-copy": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/define-property": {
-      "version": "0.2.5",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/is-accessor-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/is-data-descriptor": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/is-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "dev": true,
@@ -13510,16 +12383,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-visit": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object.assign": {
@@ -13596,16 +12459,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.pick": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object.values": {
@@ -13835,13 +12688,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/pascalcase": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -14059,13 +12905,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/posix-character-classes": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/postcss": {
@@ -16194,17 +15033,6 @@
         "@babel/runtime": "^7.8.4"
       }
     },
-    "node_modules/regex-not": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/regex-parser": {
       "version": "2.2.11",
       "dev": true,
@@ -16369,13 +15197,6 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "node_modules/repeat-element": {
-      "version": "1.1.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "license": "MIT",
@@ -16456,10 +15277,6 @@
       "version": "3.0.0",
       "license": "MIT"
     },
-    "node_modules/resolve-url": {
-      "version": "0.2.1",
-      "license": "MIT"
-    },
     "node_modules/resolve-url-loader": {
       "version": "4.0.0",
       "dev": true,
@@ -16522,13 +15339,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/retry": {
@@ -16675,13 +15485,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safe-regex": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.1.10"
-      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
@@ -16987,36 +15790,6 @@
       "version": "2.0.0",
       "license": "ISC"
     },
-    "node_modules/set-value": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/set-value/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/set-value/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "dev": true,
@@ -17110,151 +15883,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/snapdragon": {
-      "version": "0.8.2",
-      "license": "MIT",
-      "dependencies": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-node": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-node/node_modules/define-property": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-util": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-util/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/define-property": {
-      "version": "0.2.5",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/is-accessor-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/is-data-descriptor": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/is-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/kind-of": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "dev": true,
@@ -17323,17 +15951,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-resolve": {
-      "version": "0.5.3",
-      "license": "MIT",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "dev": true,
@@ -17350,10 +15967,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/source-map-url": {
-      "version": "0.4.1",
-      "license": "MIT"
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
@@ -17438,16 +16051,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/split-string": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "dev": true,
@@ -17488,86 +16091,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/static-extend": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/define-property": {
-      "version": "0.2.5",
-      "license": "MIT",
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/is-accessor-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/is-data-descriptor": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/is-descriptor": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/kind-of": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/statuses": {
@@ -18081,28 +16604,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tailwindcss/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tailwindcss/node_modules/glob-parent": {
       "version": "6.0.2",
       "dev": true,
@@ -18112,37 +16613,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/tapable": {
@@ -18361,48 +16831,15 @@
         "node": ">=4"
       }
     },
-    "node_modules/to-object-path": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-object-path/node_modules/kind-of": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-regex": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "license": "MIT",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "^7.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {
@@ -18723,26 +17160,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/union-value": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/union-value/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "dev": true,
@@ -18854,50 +17271,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/unset-value": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-value": {
-      "version": "0.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "get-value": "^2.0.3",
-        "has-values": "^0.1.4",
-        "isobject": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-values": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/isarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/upath": {
       "version": "1.2.0",
       "dev": true,
@@ -18944,23 +17317,12 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/urix": {
-      "version": "0.1.0",
-      "license": "MIT"
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/use": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -19446,75 +17808,10 @@
         "ajv": "^8.8.2"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-proxy": "^1.17.8",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webpack-dev-server/node_modules/micromatch": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/webpack-dev-server/node_modules/schema-utils": {
       "version": "4.0.1",
@@ -19532,17 +17829,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
@@ -21910,41 +20196,6 @@
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "@jest/environment": {
@@ -22078,42 +20329,9 @@
         "write-file-atomic": "^3.0.0"
       },
       "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "dev": true
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
         }
       }
     },
@@ -22497,7 +20715,7 @@
     },
     "@types/body-parser": {
       "version": "1.19.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -22515,7 +20733,7 @@
     },
     "@types/connect": {
       "version": "3.4.35",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/node": "*"
       }
@@ -22550,7 +20768,7 @@
     },
     "@types/express": {
       "version": "4.17.17",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -22560,7 +20778,7 @@
     },
     "@types/express-serve-static-core": {
       "version": "4.17.34",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -22602,7 +20820,6 @@
     },
     "@types/http-proxy": {
       "version": "1.17.11",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -22658,11 +20875,10 @@
     },
     "@types/mime": {
       "version": "1.3.2",
-      "dev": true
+      "devOptional": true
     },
     "@types/node": {
-      "version": "12.7.2",
-      "dev": true
+      "version": "12.7.2"
     },
     "@types/numeral": {
       "version": "0.0.28"
@@ -22696,7 +20912,7 @@
     },
     "@types/qs": {
       "version": "6.9.7",
-      "dev": true
+      "devOptional": true
     },
     "@types/ramda": {
       "version": "0.29.3",
@@ -22709,7 +20925,7 @@
     },
     "@types/range-parser": {
       "version": "1.2.4",
-      "dev": true
+      "devOptional": true
     },
     "@types/react": {
       "version": "16.14.40",
@@ -22842,7 +21058,7 @@
     },
     "@types/send": {
       "version": "0.17.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -22857,7 +21073,7 @@
     },
     "@types/serve-static": {
       "version": "1.15.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -23374,15 +21590,6 @@
         "deep-equal": "^2.0.5"
       }
     },
-    "arr-diff": {
-      "version": "4.0.0"
-    },
-    "arr-flatten": {
-      "version": "1.1.0"
-    },
-    "arr-union": {
-      "version": "3.1.0"
-    },
     "array-buffer-byte-length": {
       "version": "1.0.0",
       "dev": true,
@@ -23409,9 +21616,6 @@
     "array-union": {
       "version": "2.1.0",
       "dev": true
-    },
-    "array-unique": {
-      "version": "0.3.2"
     },
     "array.prototype.flat": {
       "version": "1.3.1",
@@ -23459,9 +21663,6 @@
       "version": "2.0.6",
       "dev": true
     },
-    "assign-symbols": {
-      "version": "1.0.0"
-    },
     "ast-types-flow": {
       "version": "0.0.7",
       "dev": true
@@ -23477,9 +21678,6 @@
     "at-least-node": {
       "version": "1.0.0",
       "dev": true
-    },
-    "atob": {
-      "version": "2.1.2"
     },
     "attr-accept": {
       "version": "2.2.2"
@@ -23668,26 +21866,6 @@
     "balanced-match": {
       "version": "1.0.2"
     },
-    "base": {
-      "version": "0.11.2",
-      "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        }
-      }
-    },
     "batch": {
       "version": "0.6.1",
       "dev": true
@@ -23762,29 +21940,11 @@
       }
     },
     "braces": {
-      "version": "2.3.2",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1"
-        }
+        "fill-range": "^7.0.1"
       }
     },
     "browser-process-hrtime": {
@@ -23819,20 +21979,6 @@
     "bytes": {
       "version": "3.0.0",
       "dev": true
-    },
-    "cache-base": {
-      "version": "1.0.1",
-      "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
-      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -23937,29 +22083,6 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0"
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "chownr": {
@@ -23979,62 +22102,6 @@
     "cjs-module-lexer": {
       "version": "1.2.2",
       "dev": true
-    },
-    "class-utils": {
-      "version": "0.3.6",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0"
-        }
-      }
     },
     "classnames": {
       "version": "2.3.2"
@@ -24125,13 +22192,6 @@
       "version": "1.0.1",
       "dev": true
     },
-    "collection-visit": {
-      "version": "1.0.0",
-      "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
-      }
-    },
     "color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -24178,9 +22238,6 @@
     "commondir": {
       "version": "1.0.1",
       "dev": true
-    },
-    "component-emitter": {
-      "version": "1.3.0"
     },
     "compressible": {
       "version": "2.0.18",
@@ -24252,9 +22309,6 @@
     "cookie-signature": {
       "version": "1.0.6",
       "dev": true
-    },
-    "copy-descriptor": {
-      "version": "0.1.1"
     },
     "core-js": {
       "version": "3.30.1",
@@ -24811,6 +22865,7 @@
     },
     "debug": {
       "version": "2.6.9",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -24818,9 +22873,6 @@
     "decimal.js": {
       "version": "10.4.3",
       "dev": true
-    },
-    "decode-uri-component": {
-      "version": "0.2.2"
     },
     "decompress-response": {
       "version": "4.2.1",
@@ -24886,13 +22938,6 @@
       "requires": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
-      }
-    },
-    "define-property": {
-      "version": "2.0.2",
-      "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
       }
     },
     "delayed-stream": {
@@ -25590,24 +23635,6 @@
             "fast-deep-equal": "^3.1.3"
           }
         },
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "dev": true
-        },
         "jest-worker": {
           "version": "28.1.3",
           "dev": true,
@@ -25620,14 +23647,6 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
         },
         "schema-utils": {
           "version": "4.0.1",
@@ -25644,13 +23663,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         }
       }
@@ -25727,74 +23739,6 @@
       "version": "0.1.2",
       "dev": true
     },
-    "expand-brackets": {
-      "version": "2.1.4",
-      "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1"
-        },
-        "kind-of": {
-          "version": "5.1.0"
-        }
-      }
-    },
     "expect": {
       "version": "27.5.1",
       "dev": true,
@@ -25861,43 +23805,6 @@
     "extend": {
       "version": "3.0.2"
     },
-    "extend-shallow": {
-      "version": "3.0.2",
-      "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      }
-    },
-    "extglob": {
-      "version": "2.0.4",
-      "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1"
-        }
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "dev": true
@@ -25911,41 +23818,6 @@
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "fast-json-stable-stringify": {
@@ -26031,23 +23903,11 @@
       "dev": true
     },
     "fill-range": {
-      "version": "4.0.0",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1"
-        }
+        "to-regex-range": "^5.0.1"
       }
     },
     "finalhandler": {
@@ -26117,9 +23977,6 @@
       "requires": {
         "is-callable": "^1.1.3"
       }
-    },
-    "for-in": {
-      "version": "1.0.2"
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.3",
@@ -26192,12 +24049,6 @@
     "fraction.js": {
       "version": "4.2.0",
       "dev": true
-    },
-    "fragment-cache": {
-      "version": "0.2.1",
-      "requires": {
-        "map-cache": "^0.2.2"
-      }
     },
     "fresh": {
       "version": "0.5.2",
@@ -26297,9 +24148,6 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
-    },
-    "get-value": {
-      "version": "2.0.6"
     },
     "glob": {
       "version": "7.2.3",
@@ -26438,29 +24286,6 @@
     },
     "has-unicode": {
       "version": "2.0.1"
-    },
-    "has-value": {
-      "version": "1.0.0",
-      "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
-      }
-    },
-    "has-values": {
-      "version": "1.0.0",
-      "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "4.0.0",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
     },
     "hast-to-hyperscript": {
       "version": "9.0.1",
@@ -26723,12 +24548,15 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "0.19.2",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
       "requires": {
+        "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
-        "micromatch": "^3.1.10"
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
       }
     },
     "https-proxy-agent": {
@@ -26847,12 +24675,6 @@
       "version": "2.0.1",
       "dev": true
     },
-    "is-accessor-descriptor": {
-      "version": "1.0.0",
-      "requires": {
-        "kind-of": "^6.0.0"
-      }
-    },
     "is-alphabetical": {
       "version": "1.0.4"
     },
@@ -26916,12 +24738,6 @@
         "has": "^1.0.3"
       }
     },
-    "is-data-descriptor": {
-      "version": "1.0.0",
-      "requires": {
-        "kind-of": "^6.0.0"
-      }
-    },
     "is-date-object": {
       "version": "1.0.5",
       "requires": {
@@ -26931,23 +24747,9 @@
     "is-decimal": {
       "version": "1.0.4"
     },
-    "is-descriptor": {
-      "version": "1.0.2",
-      "requires": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
-      }
-    },
     "is-docker": {
       "version": "2.2.1",
       "dev": true
-    },
-    "is-extendable": {
-      "version": "1.0.1",
-      "requires": {
-        "is-plain-object": "^2.0.4"
-      }
     },
     "is-extglob": {
       "version": "2.1.1"
@@ -26981,18 +24783,9 @@
       "dev": true
     },
     "is-number": {
-      "version": "3.0.0",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -27010,14 +24803,7 @@
       "dev": true
     },
     "is-plain-obj": {
-      "version": "3.0.0",
-      "dev": true
-    },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
+      "version": "3.0.0"
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -27104,9 +24890,6 @@
     "is-whitespace-character": {
       "version": "1.0.4"
     },
-    "is-windows": {
-      "version": "1.0.2"
-    },
     "is-word-character": {
       "version": "1.0.4"
     },
@@ -27123,9 +24906,6 @@
     "isexe": {
       "version": "2.0.0",
       "dev": true
-    },
-    "isobject": {
-      "version": "3.0.1"
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -27311,35 +25091,9 @@
           "version": "5.2.0",
           "dev": true
         },
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "dev": true
-        },
         "jest-get-type": {
           "version": "27.5.1",
           "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
         },
         "pretty-format": {
           "version": "27.5.1",
@@ -27348,13 +25102,6 @@
             "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         }
       }
@@ -27452,41 +25199,6 @@
         "jest-worker": "^27.5.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
       }
     },
     "jest-jasmine2": {
@@ -27616,32 +25328,6 @@
           "version": "5.2.0",
           "dev": true
         },
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
         "pretty-format": {
           "version": "27.5.1",
           "dev": true,
@@ -27649,13 +25335,6 @@
             "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         }
       }
@@ -27944,26 +25623,8 @@
           "version": "5.2.0",
           "dev": true
         },
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
         "emittery": {
           "version": "0.10.2",
-          "dev": true
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
           "dev": true
         },
         "jest-message-util": {
@@ -28034,14 +25695,6 @@
             }
           }
         },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
         "pretty-format": {
           "version": "28.1.3",
           "dev": true,
@@ -28085,13 +25738,6 @@
               "version": "6.0.1",
               "dev": true
             }
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         }
       }
@@ -28232,7 +25878,8 @@
       "version": "1.1.0"
     },
     "kind-of": {
-      "version": "6.0.3"
+      "version": "6.0.3",
+      "dev": true
     },
     "kleur": {
       "version": "3.0.3",
@@ -28380,15 +26027,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "map-cache": {
-      "version": "0.2.2"
-    },
-    "map-visit": {
-      "version": "1.0.0",
-      "requires": {
-        "object-visit": "^1.0.0"
-      }
-    },
     "markdown-escapes": {
       "version": "1.0.4"
     },
@@ -28457,21 +26095,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "3.1.10",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime": {
@@ -28573,13 +26202,6 @@
         }
       }
     },
-    "mixin-deep": {
-      "version": "1.3.2",
-      "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      }
-    },
     "mkdirp": {
       "version": "0.5.6",
       "dev": true,
@@ -28603,7 +26225,8 @@
       "version": "1.6.5"
     },
     "ms": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -28628,22 +26251,6 @@
     "nanoid": {
       "version": "3.3.6",
       "dev": true
-    },
-    "nanomatch": {
-      "version": "1.2.13",
-      "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -28764,53 +26371,6 @@
     "object-assign": {
       "version": "4.1.1"
     },
-    "object-copy": {
-      "version": "0.1.0",
-      "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0"
-            }
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "object-hash": {
       "version": "3.0.0",
       "dev": true
@@ -28828,12 +26388,6 @@
     },
     "object-keys": {
       "version": "1.1.1"
-    },
-    "object-visit": {
-      "version": "1.0.1",
-      "requires": {
-        "isobject": "^3.0.0"
-      }
     },
     "object.assign": {
       "version": "4.1.4",
@@ -28880,12 +26434,6 @@
       "requires": {
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
-      }
-    },
-    "object.pick": {
-      "version": "1.3.0",
-      "requires": {
-        "isobject": "^3.0.1"
       }
     },
     "object.values": {
@@ -29036,9 +26584,6 @@
         }
       }
     },
-    "pascalcase": {
-      "version": "0.1.1"
-    },
     "path-exists": {
       "version": "4.0.0",
       "dev": true
@@ -29170,9 +26715,6 @@
     },
     "popper.js": {
       "version": "1.16.1"
-    },
-    "posix-character-classes": {
-      "version": "0.1.1"
     },
     "postcss": {
       "version": "8.4.23",
@@ -30372,13 +27914,6 @@
         "@babel/runtime": "^7.8.4"
       }
     },
-    "regex-not": {
-      "version": "1.0.2",
-      "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
-      }
-    },
     "regex-parser": {
       "version": "2.2.11",
       "dev": true
@@ -30490,9 +28025,6 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "repeat-element": {
-      "version": "1.1.4"
-    },
     "repeat-string": {
       "version": "1.6.1"
     },
@@ -30540,9 +28072,6 @@
     "resolve-pathname": {
       "version": "3.0.0"
     },
-    "resolve-url": {
-      "version": "0.2.1"
-    },
     "resolve-url-loader": {
       "version": "4.0.0",
       "dev": true,
@@ -30575,9 +28104,6 @@
     "resolve.exports": {
       "version": "1.1.1",
       "dev": true
-    },
-    "ret": {
-      "version": "0.1.15"
     },
     "retry": {
       "version": "0.13.1",
@@ -30656,12 +28182,6 @@
     },
     "safe-buffer": {
       "version": "5.2.1"
-    },
-    "safe-regex": {
-      "version": "1.1.0",
-      "requires": {
-        "ret": "~0.1.10"
-      }
     },
     "safe-regex-test": {
       "version": "1.0.0",
@@ -30865,26 +28385,6 @@
     "set-blocking": {
       "version": "2.0.0"
     },
-    "set-value": {
-      "version": "2.0.1",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1"
-        }
-      }
-    },
     "setprototypeof": {
       "version": "1.2.0",
       "dev": true
@@ -30938,105 +28438,6 @@
       "version": "3.0.0",
       "dev": true
     },
-    "snapdragon": {
-      "version": "0.8.2",
-      "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1"
-        },
-        "kind-of": {
-          "version": "5.1.0"
-        }
-      }
-    },
-    "snapdragon-node": {
-      "version": "2.1.1",
-      "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "1.0.0",
-          "requires": {
-            "is-descriptor": "^1.0.0"
-          }
-        }
-      }
-    },
-    "snapdragon-util": {
-      "version": "3.0.1",
-      "requires": {
-        "kind-of": "^3.2.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "sockjs": {
       "version": "0.3.24",
       "dev": true,
@@ -31080,16 +28481,6 @@
         }
       }
     },
-    "source-map-resolve": {
-      "version": "0.5.3",
-      "requires": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
     "source-map-support": {
       "version": "0.5.21",
       "dev": true,
@@ -31103,9 +28494,6 @@
           "dev": true
         }
       }
-    },
-    "source-map-url": {
-      "version": "0.4.1"
     },
     "sourcemap-codec": {
       "version": "1.4.8",
@@ -31163,12 +28551,6 @@
         }
       }
     },
-    "split-string": {
-      "version": "3.1.0",
-      "requires": {
-        "extend-shallow": "^3.0.0"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "dev": true
@@ -31196,60 +28578,6 @@
     },
     "state-toggle": {
       "version": "1.0.3"
-    },
-    "static-extend": {
-      "version": "0.1.2",
-      "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "requires": {
-            "is-descriptor": "^0.1.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0"
-        }
-      }
     },
     "statuses": {
       "version": "2.0.1",
@@ -31595,44 +28923,11 @@
         "sucrase": "^3.32.0"
       },
       "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
         "glob-parent": {
           "version": "6.0.2",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         }
       }
@@ -31763,34 +29058,12 @@
     "to-fast-properties": {
       "version": "2.0.0"
     },
-    "to-object-path": {
-      "version": "0.3.0",
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
-    "to-regex": {
-      "version": "3.0.2",
-      "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
-      }
-    },
     "to-regex-range": {
-      "version": "2.1.1",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "^7.0.0"
       }
     },
     "toidentifier": {
@@ -31986,20 +29259,6 @@
         }
       }
     },
-    "union-value": {
-      "version": "1.0.1",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "0.1.1"
-        }
-      }
-    },
     "unique-string": {
       "version": "2.0.0",
       "dev": true,
@@ -32058,37 +29317,6 @@
       "version": "1.1.1",
       "dev": true
     },
-    "unset-value": {
-      "version": "1.0.0",
-      "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
-      },
-      "dependencies": {
-        "has-value": {
-          "version": "0.3.1",
-          "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "has-values": {
-          "version": "0.1.4"
-        },
-        "isarray": {
-          "version": "1.0.0"
-        }
-      }
-    },
     "upath": {
       "version": "1.2.0",
       "dev": true
@@ -32108,18 +29336,12 @@
         "punycode": "^2.1.0"
       }
     },
-    "urix": {
-      "version": "0.1.0"
-    },
     "url-parse": {
       "version": "1.5.10",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "use": {
-      "version": "3.1.1"
     },
     "use-callback-ref": {
       "version": "1.3.0",
@@ -32427,46 +29649,9 @@
             "fast-deep-equal": "^3.1.3"
           }
         },
-        "braces": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "http-proxy-middleware": {
-          "version": "2.0.6",
-          "dev": true,
-          "requires": {
-            "@types/http-proxy": "^1.17.8",
-            "http-proxy": "^1.18.1",
-            "is-glob": "^4.0.1",
-            "is-plain-obj": "^3.0.0",
-            "micromatch": "^4.0.2"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "dev": true
-        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "dev": true
-        },
-        "micromatch": {
-          "version": "4.0.5",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.2",
-            "picomatch": "^2.3.1"
-          }
         },
         "schema-utils": {
           "version": "4.0.1",
@@ -32476,13 +29661,6 @@
             "ajv": "^8.9.0",
             "ajv-formats": "^2.1.1",
             "ajv-keywords": "^5.1.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         },
         "ws": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "d3": "^4.13.0",
     "date-fns": "^2.27.0",
     "history": "^4.10.1",
-    "http-proxy-middleware": "^0.19.1",
+    "http-proxy-middleware": "2.0.6",
     "human-date": "^1.4.0",
     "jwt-decode": "^2.2.0",
     "md5": "^2.2.1",

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,9 +1,9 @@
-const proxy = require('http-proxy-middleware');
+const { createProxyMiddleware }  = require('http-proxy-middleware');
 
 // We must manually configure our own proxy as the default behaviour
 // (proxy everything without `Accept: text-html`) breaks PDF preview
 module.exports = function(app) {
-  app.use(proxy('/api', { target: 'http://localhost:9001/' }));
-  app.use(proxy('/setup', { target: 'http://localhost:9001/' }));
-  app.use(proxy('/third-party', { target: 'http://localhost:9001/' }));
+  app.use('/api', createProxyMiddleware({ target: 'http://localhost:9001/', changeOrigin: true }));
+  app.use('/setup', createProxyMiddleware({ target: 'http://localhost:9001/', changeOrigin: true }));
+  app.use('/third-party', createProxyMiddleware({ target: 'http://localhost:9001/', changeOrigin: true }));
 };


### PR DESCRIPTION
## What does this change?
Resolves https://security.snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660

## How to test
Tested on my local machine - the dev environment still worked. Also tested in playground

## Have we considered potential risks?
As far as I understand we only use http-proxy-middleware to support runnning locally on port 3000. So if this breaks anything it will be the giant local development setup. 