### PR TITLE
Disable elasticsearch AMI update

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,16 +26,6 @@ deployments:
         AmigoStage: PROD
         Encrypted: pfi-playground
 
-  pfi-elasticsearch-ami-update:
-    type: ami-cloudformation-parameter
-    app: elasticsearch
-    parameters:
-      amiEncrypted: true
-      amiTags:
-        Recipe: investigations-elasticsearch-7-arm64
-        AmigoStage: PROD
-        Encrypted: pfi-playground
-
   pfi:
     type: autoscaling
     parameters:


### PR DESCRIPTION
## What does this change?
As part of my 10% time I started upgrading elasticsearch to version 8. Whilst this is in progress (currently only on the playground stack) I need to disable this auto AMI update step, otherwise it will keep reverting the elasticsearch stack back to using an AMI running elasticsearch 7. 