### PR TITLE
Tidy up akka removal

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -61,7 +61,6 @@ class AppComponents(context: Context, config: Config)
   override def httpFilters: Seq[EssentialFilter] = {
     super.httpFilters.filterNot(disabledFilters.contains) ++ Seq(
       new AllowFrameFilter,
-      //Note: still using akka (instead of pekko) materializer from Play as both filters extend Play's Filter, so the types need to match
       new RequestLoggingFilter(materializer),
       new ReadOnlyFilter(config.app, materializer)
     )

--- a/backend/app/commands/GetPagePreview.scala
+++ b/backend/app/commands/GetPagePreview.scala
@@ -18,7 +18,6 @@ class GetPagePreview(uri: Uri, language: Language, pageNumber: Int,
       pageData <- previewStorage.get(previewUri).toAttempt
     } yield {
       // StreamConverters.fromInputStream will close the stream for us once it's done
-      // HttpEntity comes from Play and expects an akka ByteString so here we use akka here
       HttpEntity.Streamed(StreamConverters.fromInputStream(() => pageData), None, Some("application/pdf"))
     }
   }

--- a/backend/app/controllers/api/Previews.scala
+++ b/backend/app/controllers/api/Previews.scala
@@ -55,7 +55,6 @@ class Previews(override val controllerComponents: AuthControllerComponents, val 
   private def downloadResult(uri: Uri, filename: Option[String], rangeHeader: Option[String]): Attempt[Result] = {
     previews.getPreviewObject(uri).map {
       case ObjectData(data, ObjectMetadata(size, mimeType)) =>
-        // RangeResult comes from Play and expects source to be an akka Source so we use akka here rather than pekko
         val source = StreamConverters.fromInputStream(() => data)
 
         // The RangeResult API understands how to encode non-ascii filenames

--- a/backend/app/utils/AwsDiscovery.scala
+++ b/backend/app/utils/AwsDiscovery.scala
@@ -79,7 +79,7 @@ object AwsDiscovery extends Logging {
       ),
       underlying = config.underlying
         .withValue("play.http.secret.key", fromAnyRef(readSSMParameter("pfi/playSecret", stack, stage, ssmClient)))
-        .withValue("pekko.actor.provider", fromAnyRef("local")) // disable Akka clustering, we query EC2 directly
+        .withValue("pekko.actor.provider", fromAnyRef("local")) // disable Pekko clustering, we query EC2 directly
     )
 
     val jsonLoggingProperties = Map(

--- a/backend/app/utils/RequestLoggingFilter.scala
+++ b/backend/app/utils/RequestLoggingFilter.scala
@@ -1,7 +1,7 @@
 package utils
 
 import java.net.URI
-import org.apache.pekko.stream.Materializer // use akka Materializer rather than pekko as this is what Filter expects
+import org.apache.pekko.stream.Materializer
 import org.slf4j.LoggerFactory
 import play.api.mvc.{Filter, RequestHeader, Result}
 

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -37,7 +37,7 @@ class PekkoWorkerControl(actorSystem: ActorSystem) extends WorkerControl {
     WorkerDetails(members, cluster.selfUniqueAddress.toString)
   }
 
-  // We don't manually spin up and down the Akka cluster, it's done for us
+  // We don't manually spin up and down the Pekko cluster, it's done for us
   override def start(scheduler: Scheduler)(implicit ec: ExecutionContext): Unit = {}
   override def stop(): Future[Unit] = Future.successful(())
 }

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -30,7 +30,7 @@ play {
   # TODO MRB: We can remove font-src when we get rid of Semantic UI (it @imports a Google font)
   filters.headers.contentSecurityPolicy = "font-src 'self' default-src blob: data: 'self' 'unsafe-inline'"
 
-  akka.actor-system = "pfi"
+  pekko.actor-system = "pfi"
 }
 
 pekko {

--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ lazy val backend = (project in file("backend"))
       "commons-io" % "commons-io" % "2.6",
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.9.1",
       "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "7.9.2",
-      "org.apache.pekko" %% "pekko-cluster-typed" % "1.0.1", // Pekko should be compatible with akka 2.6. Needs to match akka version in Play
+      "org.apache.pekko" %% "pekko-cluster-typed" % "1.0.1", // Needs to match pekko version in Play
       "org.neo4j.driver" % "neo4j-java-driver" % "1.6.3",
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the

--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -45,8 +45,8 @@ fi
 if $CLUSTERED; then
     echo "Setting up investigations cluster"
     cat << EOF > "$SITECONFDIR/site.conf"
-akka.remote.netty.tcp.hostname = "`hostname`"
-akka.cluster.seed-nodes = ["akka.tcp://pfi@investigations-01:1234"]
+pekko.remote.netty.tcp.hostname = "`hostname`"
+pekko.cluster.seed-nodes = ["pekko.tcp://pfi@investigations-01:1234"]
 
 neo4j.url = "bolt://investigations-02:7687"
 EOF


### PR DESCRIPTION
## What does this change?
I noticed that when you run giant locally it starts logging this over and over again:

```
[WARN] 2023-12-18 10:47:27 GMT - org.apache.pekko.remote.artery.InboundHandshake$$anon$2 - application-pekko.actor.default-dispatcher-7 - Dropping Handshake Request from [pekko://application@localhost:1234#-6954875545553276590] addressed to unknown local address [pekko://pfi@localhost:1234]. Local address is [pekko://application@localhost:1234]. Check that the sending system uses the same address to contact recipient system as defined in the 'pekko.remote.artery.canonical.hostname' of the recipient system. The name of the ActorSystem must also match.
```

This is because of some bits and pieces missed when I removed Akka here https://github.com/guardian/giant/pull/180. This PR finishes the 'pekkoification' by:
 - Fixing the `actor-system` property in the application.conf file (this is the thing that caused the above bug)
 - Updating any other config references to `akka.`
 - Updating/removing various comments

## How to test
I've tested this locally and on playground.

## How can we measure success?
Logs a wee bit more readable