### PR TITLE
Upgrade elasticsearch SDK to version 8.11

### DIFF
--- a/backend/app/services/index/ElasticsearchPages.scala
+++ b/backend/app/services/index/ElasticsearchPages.scala
@@ -9,6 +9,7 @@ import model.index.{Page, PageResult, PagesSummary}
 import model.{Language, Languages, Uri}
 import services.ElasticsearchSyntax
 import services.index.HitReaders.{PageHitReader, RichFieldMap}
+import services.table.TableRowFields
 import utils.Logging
 import utils.attempt.{Attempt, ElasticSearchQueryFailure, MultipleFailures, NotFoundFailure}
 

--- a/backend/app/services/index/ElasticsearchPages.scala
+++ b/backend/app/services/index/ElasticsearchPages.scala
@@ -9,7 +9,6 @@ import model.index.{Page, PageResult, PagesSummary}
 import model.{Language, Languages, Uri}
 import services.ElasticsearchSyntax
 import services.index.HitReaders.{PageHitReader, RichFieldMap}
-import services.table.TableRowFields
 import utils.Logging
 import utils.attempt.{Attempt, ElasticSearchQueryFailure, MultipleFailures, NotFoundFailure}
 

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -641,7 +641,7 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
 
   override def deleteWorkspace(workspaceId: String): Attempt[Unit] = {
     executeUpdateByQuery {
-      updateByQuery(indexName,
+      updateByQuerySync(indexName,
         nestedQuery(IndexFields.workspacesField,
           termQuery(s"${IndexFields.workspacesField}.${IndexFields.workspaces.workspaceId}", workspaceId)
         )
@@ -683,7 +683,7 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
   }
 
   private def buildUpdateWorkspaceQuery(blobUri: Uri): UpdateByQueryRequest = {
-    updateByQuery(indexName,
+    updateByQuerySync(indexName,
       boolQuery().should(
         termQuery("_id", blobUri.value),
         // Also recursively add anything that is a child of this blob to the workspace They won't appear in the tree

--- a/backend/test/test/integration/DockerElasticsearchService.scala
+++ b/backend/test/test/integration/DockerElasticsearchService.scala
@@ -11,7 +11,7 @@ trait DockerElasticsearchService extends DockerKit {
 
   override val StartContainersTimeout: FiniteDuration = 10.minutes
 
-  val elasticsearchContainer = DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.9")
+  val elasticsearchContainer = DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:8.11.2")
     .withPorts(DefaultElasticsearchHttpPort -> Some(ExposedElasticsearchHttpPort))
     .withEnv("discovery.type=single-node", s"http.publish_port=$ExposedElasticsearchHttpPort", "xpack.security.enabled=false")
     .withReadyChecker(

--- a/build.sbt
+++ b/build.sbt
@@ -116,8 +116,8 @@ lazy val backend = (project in file("backend"))
       // dependency to tikka or another library
       "org.bouncycastle" % "bcutil-jdk15on" % "1.70",
       "commons-io" % "commons-io" % "2.6",
-      "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.17.4",
-      "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "7.17.9",
+      "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "8.11.4",
+      "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "8.6.2",
       "org.apache.pekko" %% "pekko-cluster-typed" % "1.0.1", // Needs to match pekko version in Play
       "org.neo4j.driver" % "neo4j-java-driver" % "1.6.3",
       "com.pff" % "java-libpst" % "0.9.3",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - 7687:7687
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.9
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.2
     container_name: pfi-elasticsearch
     environment:
       - discovery.type=single-node


### PR DESCRIPTION
## What does this change?
(Draft PR pending upgrade to ES8)

Following from https://github.com/guardian/giant/pull/190 This PR drags giant's elasticsearch code into the future, ready to support elasticsearch 8.

Key changes:
 - version number bumps in build.sbt, docker-compose, elasticsearch docker service
 - Replacing [deprecated updateByQuery](https://github.com/sksamuel/elastic4s/blob/83162ceb97be3e023f7644fce637e2da0678896c/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/UpdateApi.scala#L11)

## How to test
Tested locally and on playground. Make sure you have run https://github.com/guardian/giant/pull/190 (now merged into main) locally before trying this as you need your local DB to already be on 7.17 to work

Deploying on PROD:
 - ideally it would be good to use rest compatability mode https://www.elastic.co/guide/en/elasticsearch/reference/8.11/rest-api-compatibility.html so that we could upgrade the DB without breaking giant, and then apply this PR afterwards. Unfortunately I can't find any support for compatability mode anywhere in the elastic4s documentation - opened an issue https://github.com/sksamuel/elastic4s/issues/2978 in case anyone has a suggestion. 

HOWEVER, we appear to be succesfully running sdk 7.17 against elasticsearch 8 on playground, so maybe we don't need compatability mode


