### PR TITLE
Add copy to clipboard option to workspace context menu

### DIFF
--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -28,7 +28,7 @@ import { listUsers } from '../../actions/users/listUsers';
 import DocumentIcon from 'react-icons/lib/ti/document';
 import {Icon, Loader, Menu, Popup} from 'semantic-ui-react';
 import WorkspaceSummary from './WorkspaceSummary';
-import {ColumnsConfig, isTreeLeaf, isTreeNode, TreeEntry, TreeLeaf, TreeNode} from '../../types/Tree';
+import {ColumnsConfig, isTreeLeaf, isTreeNode, TreeEntry, TreeLeaf} from '../../types/Tree';
 import {isWorkspaceLeaf, Workspace, WorkspaceEntry} from '../../types/Workspaces';
 import { GiantState } from '../../types/redux/GiantState';
 import { GiantDispatch } from '../../types/redux/GiantDispatch';
@@ -503,23 +503,28 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
         });
     };
 
-    findEntry (entryId: string, root: TreeEntry<WorkspaceEntry>): TreeEntry<WorkspaceEntry>[] | undefined {
-        if (root.id === entryId) {
-            return [root]
+    /**
+     * Searches through tree beginning at startNode for entryId, if successful returns an array of nodes between startNode and entryId
+     * @param entryId
+     * @param startNode
+     */
+    getEntryTreeNodes (entryId: string, startNode: TreeEntry<WorkspaceEntry>): TreeEntry<WorkspaceEntry>[] | undefined {
+        if (startNode.id === entryId) {
+            return [startNode]
         }
-        if (isTreeNode(root)) {
-            for (const child of root.children) {
-                const result = this.findEntry(entryId, child)
+        if (isTreeNode(startNode)) {
+            for (const child of startNode.children) {
+                const result = this.getEntryTreeNodes(entryId, child)
                 if (result !== undefined) {
-                    return [root, ...result]
+                    return [startNode, ...result]
                 }
             }
         }
         return undefined
     }
 
-    getEntryPath (entryId: string, root: TreeEntry<WorkspaceEntry>): string {
-        const pathArray = this.findEntry(entryId, root)
+    getEntryPath (entryId: string, workspaceRootNode: TreeEntry<WorkspaceEntry>): string {
+        const pathArray = this.getEntryTreeNodes(entryId, workspaceRootNode)
         if (pathArray) {
             const path = pathArray.map(p => p.name).join("/")
             console.log(path)

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -501,7 +501,8 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
         const items = [
             // or 'pencil alternate'
             { key: "rename", content: "Rename", icon: "pen square" },
-            { key: "remove", content: "Remove from workspace", icon: "trash" },         
+            { key: "remove", content: "Remove from workspace", icon: "trash" },
+            {key : "copyFilename", content: "Copy filename", icon: "copy"}
         ];
         
         if (entry.data.addedBy.username === currentUser.username && isWorkspaceLeaf(entry.data)) {
@@ -526,6 +527,10 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                     if (menuItemProps.content === 'Remove from workspace') {
                         this.props.deleteItem(workspaceId, entry.id);
                         this.props.resetFocusedAndSelectedEntries();
+                    }
+
+                    if (menuItemProps.content === 'Copy filename') {
+                        navigator.clipboard.writeText(entry.name);
                     }
 
 


### PR DESCRIPTION
## What does this change?
This adds two new context menu options to the workspace view in giant - 'Copy file name' and 'Copy file path' 

They look like this:

https://github.com/guardian/giant/assets/3606555/c4064d2f-545a-4f2d-a225-4023ed1d56db

## How to test
Tested on playground and locally. There's a recursive function used to generate the file path, maybe it should have some tests? We actually don't appear to have _any_  client side tests in giant so that feels a bit of a stretch
