### PR TITLE
Upgrade elasticsearch sdk to version 7.17

### DIFF
--- a/backend/app/services/ElasticsearchSyntax.scala
+++ b/backend/app/services/ElasticsearchSyntax.scala
@@ -2,13 +2,14 @@ package services
 
 import com.sksamuel.elastic4s.{ElasticClient, ElasticRequest, Executor, Functor, Handler, HttpClient, RequestFailure, RequestSuccess}
 import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.fields.{ObjectField, TextField}
 import com.sksamuel.elastic4s.http.{JavaClient, JavaClientExceptionWrapper}
 import com.sksamuel.elastic4s.requests.bulk.BulkCompatibleRequest
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.indexes.CreateIndexResponse
 import com.sksamuel.elastic4s.requests.indexes.admin.IndexExistsResponse
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
-import com.sksamuel.elastic4s.requests.mappings.{MappingDefinition, ObjectField, TextField}
+import com.sksamuel.elastic4s.requests.mappings.{MappingDefinition}
 import com.sksamuel.elastic4s.requests.update.{UpdateByQueryRequest, UpdateRequest}
 import model.Language
 import org.apache.http.{ContentTooLongException, HttpHost}
@@ -48,9 +49,9 @@ trait ElasticsearchSyntax { this: Logging =>
   def emptyMultiLanguageField(name: String): ObjectField = objectField(name)
 
   def multiLanguageField(name: String, language: Language): ObjectField = {
-    objectField(name).fields(
+    ObjectField(name, properties = Seq(
       singleLanguageField(language.key, language)
-    )
+    ))
   }
 
   def multiLanguageValue(languages: List[Language], value: Any): Map[String, Any] = languages.map { lang =>

--- a/backend/app/services/index/ElasticsearchPages.scala
+++ b/backend/app/services/index/ElasticsearchPages.scala
@@ -2,12 +2,14 @@ package services.index
 
 import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.fields.ObjectField
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.requests.searches.{HighlightField, MultisearchResponseItem}
 import model.index.{Page, PageResult, PagesSummary}
 import model.{Language, Languages, Uri}
 import services.ElasticsearchSyntax
 import services.index.HitReaders.{PageHitReader, RichFieldMap}
+import services.table.TableRowFields
 import utils.Logging
 import utils.attempt.{Attempt, ElasticSearchQueryFailure, MultipleFailures, NotFoundFailure}
 
@@ -22,12 +24,12 @@ class ElasticsearchPages(val client: ElasticClient, indexNamePrefix: String)(imp
         keywordField(PagesFields.resourceId),
         intField(PagesFields.page),
         emptyMultiLanguageField(PagesFields.value),
-        objectField(PagesFields.dimensions).fields(
+        ObjectField(PagesFields.dimensions, properties = Seq(
           floatField(PagesFields.width),
           floatField(PagesFields.height),
           floatField(PagesFields.top),
           floatField(PagesFields.bottom)
-        )
+        ))
       )
     ).flatMap { _ =>
       Attempt.sequence(Languages.all.map(addLanguage))

--- a/backend/app/services/index/ElasticsearchPages.scala
+++ b/backend/app/services/index/ElasticsearchPages.scala
@@ -9,7 +9,6 @@ import model.index.{Page, PageResult, PagesSummary}
 import model.{Language, Languages, Uri}
 import services.ElasticsearchSyntax
 import services.index.HitReaders.{PageHitReader, RichFieldMap}
-import services.table.TableRowFields
 import utils.Logging
 import utils.attempt.{Attempt, ElasticSearchQueryFailure, MultipleFailures, NotFoundFailure}
 

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -641,7 +641,7 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
 
   override def deleteWorkspace(workspaceId: String): Attempt[Unit] = {
     executeUpdateByQuery {
-      updateByQuerySync(indexName,
+      updateByQuery(indexName,
         nestedQuery(IndexFields.workspacesField,
           termQuery(s"${IndexFields.workspacesField}.${IndexFields.workspaces.workspaceId}", workspaceId)
         )
@@ -683,7 +683,7 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
   }
 
   private def buildUpdateWorkspaceQuery(blobUri: Uri): UpdateByQueryRequest = {
-    updateByQuerySync(indexName,
+    updateByQuery(indexName,
       boolQuery().should(
         termQuery("_id", blobUri.value),
         // Also recursively add anything that is a child of this blob to the workspace They won't appear in the tree

--- a/backend/app/services/index/SearchContext.scala
+++ b/backend/app/services/index/SearchContext.scala
@@ -1,7 +1,8 @@
 package services.index
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.searches.queries.{BoolQuery, Query}
+import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
+import com.sksamuel.elastic4s.requests.searches.queries.{Query}
 import model.annotations.{WorkspaceEntry, WorkspaceLeaf}
 import model.frontend.{TreeEntry, TreeLeaf, TreeNode}
 import model.index.SearchParameters

--- a/backend/app/services/table/Table.scala
+++ b/backend/app/services/table/Table.scala
@@ -2,6 +2,7 @@ package services.table
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.ElasticClient
+import com.sksamuel.elastic4s.fields.ObjectField
 import model.Uri
 import model.index.TableRow
 import services.ElasticsearchSyntax
@@ -23,10 +24,10 @@ class ElasticsearchTable(override val client: ElasticClient, tableIndexName: Str
         textField(TableRowFields.tableId),
         intField(TableRowFields.rowIndex),
         textField(TableRowFields.sheetName),
-        objectField(TableRowFields.cellsField).fields(
+        ObjectField(TableRowFields.cellsField, properties = Seq(
           textField(TableRowFields.cells.key),
           textField(TableRowFields.cells.value)
-        )
+        ))
       )
     ).map { _ => this }
 

--- a/backend/test/test/integration/DockerElasticsearchService.scala
+++ b/backend/test/test/integration/DockerElasticsearchService.scala
@@ -11,7 +11,7 @@ trait DockerElasticsearchService extends DockerKit {
 
   override val StartContainersTimeout: FiniteDuration = 10.minutes
 
-  val elasticsearchContainer = DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:7.9.3")
+  val elasticsearchContainer = DockerContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.9")
     .withPorts(DefaultElasticsearchHttpPort -> Some(ExposedElasticsearchHttpPort))
     .withEnv("discovery.type=single-node", s"http.publish_port=$ExposedElasticsearchHttpPort", "xpack.security.enabled=false")
     .withReadyChecker(

--- a/build.sbt
+++ b/build.sbt
@@ -116,8 +116,8 @@ lazy val backend = (project in file("backend"))
       // dependency to tikka or another library
       "org.bouncycastle" % "bcutil-jdk15on" % "1.70",
       "commons-io" % "commons-io" % "2.6",
-      "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.9.1",
-      "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "7.9.2",
+      "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "7.17.4",
+      "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "7.17.9",
       "org.apache.pekko" %% "pekko-cluster-typed" % "1.0.1", // Needs to match pekko version in Play
       "org.neo4j.driver" % "neo4j-java-driver" % "1.6.3",
       "com.pff" % "java-libpst" % "0.9.3",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - 7687:7687
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.9
     container_name: pfi-elasticsearch
     environment:
       - discovery.type=single-node


### PR DESCRIPTION
## What does this change?
Currently on Giant we are in a bit of a messy state. We're running version 7.17.9 of elasticsearch in production, but using version 7.9.1 of the elastic4s SDK. This PR resolves that.

This PR includes many of the changes initially made in https://github.com/guardian/giant/pull/187 - once it's merged https://github.com/guardian/giant/pull/187 should contain many fewer code changes

Changes included:
 - Bumping the version of elasticsearch being used to run giant locally in docker-compose.yaml and the version used to run integration tests
 - The way objectfields works has changed, leading to a small syntax change all over the place. It was hard to track down what had happened here but I eventually spotted this  [random bit of markdown](https://github.com/sksamuel/elastic4s/blob/67ff0c23aa9057d9bf49a3bb9c98a0c194fc2adb/docs/version8migration.md?plain=1#L4) - `FieldDefinition removed in favour of ElasticField`
 - Some other minor syntax changes

## How to test
This has been tested locally, on playground (against es8) and on prod (against es 7.17)
