### PR TITLE
add elasticsearch ami update with version 8

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,6 +26,16 @@ deployments:
         AmigoStage: PROD
         Encrypted: pfi-playground
 
+  pfi-elasticsearch-ami-update:
+    type: ami-cloudformation-parameter
+    app: elasticsearch
+    parameters:
+      amiEncrypted: true
+      amiTags:
+        Recipe: investigations-elasticsearch-8-arm64
+        AmigoStage: PROD
+        Encrypted: pfi-playground
+
   pfi:
     type: autoscaling
     parameters:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR is reverting the change that was done in https://github.com/guardian/giant/pull/184 but instead of `investigations-elasticsearch-7-arm64` it uses the `investigations-elasticsearch-8-arm64` recipe in amigo. 

We have already updated the elasticsearch version in all giant elasticsearch instances. And we have also updated the elasticsearch version in giant code base through https://github.com/guardian/giant/pull/187
