### PR TITLE
Remove deprecated bootstrap.system_call_filter setting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms4g -Xmx4g"
       - xpack.security.enabled=false
-      - bootstrap.system_call_filter=false
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
## What does this change?
Following the upgrade to ES8 #187  this setting is no longer valid