### PR TITLE
reprocess instead of upload if uploaded file already exist

### DIFF
--- a/backend/app/commands/CreateIngestion.scala
+++ b/backend/app/commands/CreateIngestion.scala
@@ -23,11 +23,9 @@ case class CreateIngestion(data: CreateIngestionRequest, collectionUri: Uri, man
     val current = ingestionUri.flatMap(uri => manifest.getIngestion(uri))
 
     current.map { c =>
-      println(s"ingestion ${c.uri} already exists")
       Uri(c.uri)
     }.recoverWith {
       case f: NotFoundFailure =>
-        println(s"error getting ingestion - ${f.msg}")
         createIngestion(ingestionId, ingestionUri)
     }
   }

--- a/backend/app/commands/CreateIngestion.scala
+++ b/backend/app/commands/CreateIngestion.scala
@@ -2,7 +2,7 @@ package commands
 
 import java.nio.file.Paths
 
-import model.{CreateIngestionRequest, Language, Languages, Uri}
+import model.{CreateIngestionRequest, Languages, Uri}
 import services.index.{Index, Pages}
 import services.manifest.Manifest
 import utils.{Logging, UriCleaner}
@@ -13,22 +13,49 @@ import scala.concurrent.ExecutionContext
 case class CreateIngestion(data: CreateIngestionRequest, collectionUri: Uri, manifest: Manifest, index: Index, pages: Pages)
                           (implicit ec: ExecutionContext) extends AttemptCommand[Uri] with Logging {
   def process(): Attempt[Uri] = {
+    val (ingestionId, ingestionUri) = provideIngestionUri()
 
-    val providedDisplayName = data.name.toAttempt {
+    createIngestion(ingestionId, ingestionUri)
+  }
+
+  def createOrGet(): Attempt[Uri] = {
+    val (ingestionId, ingestionUri) = provideIngestionUri()
+    val current = ingestionUri.flatMap(uri => manifest.getIngestion(uri))
+
+    current.map { c =>
+      println(s"ingestion ${c.uri} already exists")
+      Uri(c.uri)
+    }.recoverWith {
+      case f: NotFoundFailure =>
+        println(s"error getting ingestion - ${f.msg}")
+        createIngestion(ingestionId, ingestionUri)
+    }
+  }
+
+  private def provideIngestionUri(): (Attempt[String], Attempt[Uri]) = {
+    val providedDisplayName = getProvidedDisplayName()
+
+    val ingestionId = providedDisplayName.map(d => UriCleaner.clean(d))
+    val ingestionUri = ingestionId.map(id => collectionUri.chain(id))
+    (ingestionId, ingestionUri)
+  }
+
+  private def createIngestion(ingestionId: Attempt[String], ingestionUri: Attempt[Uri]): Attempt[Uri] = {
+    val langs = data.languages.flatMap(Languages.getByKey)
+    for {
+      id <- ingestionId
+      uri <- ingestionUri
+      rootPath = data.path.map(Paths.get(_))
+      languages <- if (langs.nonEmpty) Attempt.Right(langs) else Attempt.Left(ClientFailure("No valid languages specified"))
+      uri <- manifest.insertIngestion(collectionUri, uri, id, rootPath, languages, data.fixed.getOrElse(true), data.default.getOrElse(false))
+    } yield uri
+  }
+
+  private def getProvidedDisplayName(): Attempt[String] = {
+    data.name.toAttempt {
       manifest.getIngestionCount(collectionUri).map { i =>
         s"Ingestion ${(i + 1).toString}"
       }
     }
-
-    val langs = data.languages.flatMap(Languages.getByKey)
-
-    for {
-      display <- providedDisplayName
-      id = UriCleaner.clean(display)
-      ingestionUri = collectionUri.chain(id)
-      rootPath = data.path.map(Paths.get(_))
-      languages <- if (langs.nonEmpty) Attempt.Right(langs) else Attempt.Left(ClientFailure("No valid languages specified"))
-      uri <- manifest.insertIngestion(collectionUri, ingestionUri, id, rootPath, languages, data.fixed.getOrElse(true), data.default.getOrElse(false))
-    } yield uri
   }
 }

--- a/backend/app/commands/CreateIngestion.scala
+++ b/backend/app/commands/CreateIngestion.scala
@@ -13,37 +13,39 @@ import scala.concurrent.ExecutionContext
 case class CreateIngestion(data: CreateIngestionRequest, collectionUri: Uri, manifest: Manifest, index: Index, pages: Pages)
                           (implicit ec: ExecutionContext) extends AttemptCommand[Uri] with Logging {
   def process(): Attempt[Uri] = {
-    val (ingestionId, ingestionUri) = provideIngestionUri()
+    val idUri = provideIngestionUri()
 
-    createIngestion(ingestionId, ingestionUri)
+    idUri.flatMap {
+      case (id, uri) => createIngestion(id, uri)
+    }
   }
 
   def createOrGet(): Attempt[Uri] = {
-    val (ingestionId, ingestionUri) = provideIngestionUri()
-    val current = ingestionUri.flatMap(uri => manifest.getIngestion(uri))
+    val ingestionTuple = provideIngestionUri()
+    val current = ingestionTuple.flatMap(idUri => manifest.getIngestion(idUri._2))
 
     current.map { c =>
       Uri(c.uri)
     }.recoverWith {
       case f: NotFoundFailure =>
-        createIngestion(ingestionId, ingestionUri)
+        ingestionTuple.flatMap{case (id, uri) => createIngestion(id, uri)}
     }
   }
 
-  private def provideIngestionUri(): (Attempt[String], Attempt[Uri]) = {
+  private def provideIngestionUri(): Attempt[(String, Uri)] = {
     val providedDisplayName = getProvidedDisplayName()
 
-    val ingestionId = providedDisplayName.map(d => UriCleaner.clean(d))
-    val ingestionUri = ingestionId.map(id => collectionUri.chain(id))
-    (ingestionId, ingestionUri)
+    providedDisplayName.map(name => {
+      val id = UriCleaner.clean(name)
+      val uri = collectionUri.chain(id)
+      (id, uri)
+    })
   }
 
-  private def createIngestion(ingestionId: Attempt[String], ingestionUri: Attempt[Uri]): Attempt[Uri] = {
+  private def createIngestion(id: String, uri: Uri): Attempt[Uri] = {
     val langs = data.languages.flatMap(Languages.getByKey)
+    val rootPath = data.path.map(Paths.get(_))
     for {
-      id <- ingestionId
-      uri <- ingestionUri
-      rootPath = data.path.map(Paths.get(_))
       languages <- if (langs.nonEmpty) Attempt.Right(langs) else Attempt.Left(ClientFailure("No valid languages specified"))
       uri <- manifest.insertIngestion(collectionUri, uri, id, rootPath, languages, data.fixed.getOrElse(true), data.default.getOrElse(false))
     } yield uri

--- a/backend/app/commands/IngestFile.scala
+++ b/backend/app/commands/IngestFile.scala
@@ -24,13 +24,13 @@ object IngestFileResult {
 
 class IngestFile(collectionUri: Uri, ingestionUri: Uri, uploadId: String, workspace: Option[WorkspaceItemUploadContext],
                  username: String, temporaryFilePath: Path, originalPath: Path, lastModifiedTime: Option[String],
-                 manifest: Manifest, esEvents: Events, ingestionServices: IngestionServices, annotations: Annotations)(implicit ec: ExecutionContext) extends AttemptCommand[IngestFileResult] {
+                 manifest: Manifest, esEvents: Events, ingestionServices: IngestionServices, annotations: Annotations, fingerPrint: Option[String] = None)(implicit ec: ExecutionContext) extends AttemptCommand[IngestFileResult] {
 
   override def process(): Attempt[IngestFileResult] = {
     for {
       ingestion <- getIngestion()
 
-      fileUri = FingerprintServices.createFingerprintFromFile(temporaryFilePath.toFile)
+      fileUri = fingerPrint.getOrElse(FingerprintServices.createFingerprintFromFile(temporaryFilePath.toFile))
       // workspace will only be defined for user uploads. If it is defined we want to add a WorkspaceUpload ingestion event
       workspaceEvent = workspace.map(w =>
         IngestionEvent.workspaceUploadEvent(fileUri, ingestionUri.value, w.workspaceName, EventStatus.Started)

--- a/backend/app/controllers/api/Collections.scala
+++ b/backend/app/controllers/api/Collections.scala
@@ -122,7 +122,7 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
     }
   }
 
-  def uploadFile(collection: Uri) = ApiAction.attempt(parse.temporaryFile) { req =>
+  def uploadFileWithNewIngestion(collection: Uri) = ApiAction.attempt(parse.temporaryFile) { req =>
     users.canSeeCollection(req.user.username, collection).flatMap {
       case true =>
         (req.headers.get(CONTENT_LOCATION), req.headers.get("X-PFI-Upload-Id"), req.headers.get("X-PFI-Ingestion-Name")) match {

--- a/backend/app/controllers/api/Collections.scala
+++ b/backend/app/controllers/api/Collections.scala
@@ -8,6 +8,7 @@ import model.ingestion.WorkspaceItemUploadContext
 import model.manifest.CollectionWithUsers
 import model.user.UserPermission.CanPerformAdminOperations
 import model.{CreateCollectionRequest, CreateIngestionRequest, CreateIngestionResponse, Uri, VerifyRequest}
+import play.api.libs.Files
 import play.api.libs.json._
 import play.api.mvc._
 import services.{FingerprintServices, S3Config}
@@ -104,52 +105,47 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
     }
   }
 
-  def uploadIngestionFile(collection: String, ingestion: String) = ApiAction.attempt(parse.temporaryFile) { req =>
+  def uploadIngestionFile(collection: String, ingestion: String) = ApiAction.attempt(parse.temporaryFile) { req: UserIdentityRequest[Files.TemporaryFile] =>
     users.canSeeCollection(req.user.username, Uri(collection)).flatMap {
       case true =>
         (req.headers.get(CONTENT_LOCATION), req.headers.get("X-PFI-Upload-Id")) match {
           case (Some(rawOriginalPath), Some(uploadId)) =>
-            val originalPath = URLDecoder.decode(rawOriginalPath, "UTF-8")
-            val lastModifiedTime = req.headers.get("X-PFI-Last-Modified")
             val maybeWorkspaceContext = buildWorkspaceItemContext(req.headers)
-            val temporaryFilePath = req.body.path
-            val fingerprint = FingerprintServices.createFingerprintFromFile(temporaryFilePath.toFile)
-
-            val childrenWithSameUri = manifest.getWorkspaceChildrenWithUri(maybeWorkspaceContext, fingerprint)
-
-            childrenWithSameUri.flatMap { blobs =>
-              if (blobs.length > 0) {
-                println(s"number of existing children is ${blobs.length} ")
-                val uri = Uri(fingerprint)
-
-                for {
-                  _ <- manifest.rerunFailedExtractorsForBlob(uri)
-                  _ <- manifest.rerunSuccessfulExtractorsForBlob(uri)
-                } yield {
-                  Created(Json.toJson(blobs.head))
-                }
-              } else {
-                println("No children found")
-                new IngestFile(
-                  Uri(collection),
-                  Uri(collection).chain(ingestion),
-                  uploadId,
-                  workspace = maybeWorkspaceContext,
-                  req.user.username,
-                  temporaryFilePath = req.body.path,
-                  originalPath = Paths.get(originalPath),
-                  lastModifiedTime,
-                  manifest, esEvents, ingestionServices, annotations
-                ).process().map { result =>
-                  Created(Json.toJson(result))
-                }
-              }
-            }
-
+            processIngestion(req, Uri(collection), Uri(collection).chain(ingestion), uploadId, maybeWorkspaceContext, rawOriginalPath)
           case _ =>
             Attempt.Right(BadRequest(s"Missing $CONTENT_LOCATION or X-PFI-Upload-Id header"))
         }
 
+      case false =>
+        // GitHub-style error - a thing exists but we can't see it so tell the user it doesn't exist
+        Attempt.Left(NotFoundFailure(s"$collection does not exist"))
+    }
+  }
+
+  def uploadFile(collection: Uri) = ApiAction.attempt(parse.temporaryFile) { req =>
+    users.canSeeCollection(req.user.username, collection).flatMap {
+      case true =>
+        (req.headers.get(CONTENT_LOCATION), req.headers.get("X-PFI-Upload-Id"), req.headers.get("X-PFI-Ingestion-Name")) match {
+          case (Some(rawOriginalPath), Some(uploadId), Some(ingestionName)) =>
+            val maybeWorkspaceContext = buildWorkspaceItemContext(req.headers)
+            val temporaryFilePath = req.body.path
+            val fingerprint = FingerprintServices.createFingerprintFromFile(temporaryFilePath.toFile)
+
+            val filesWithSameFingerprint = manifest.getWorkspaceChildrenWithUri(maybeWorkspaceContext, fingerprint)
+            filesWithSameFingerprint.flatMap { blobs =>
+              if (blobs.length > 0) {
+                reprocess(fingerprint, blobs.head)
+              } else {
+                val ingestionAttempt = createIngestionIfNotExists(collection, ingestionName)
+
+                ingestionAttempt.flatMap { ingestion =>
+                  processIngestion(req, collection, Uri(ingestion.uri), uploadId, maybeWorkspaceContext, rawOriginalPath)
+                }
+              }
+            }
+          case _ =>
+            Attempt.Right(BadRequest(s"Missing $CONTENT_LOCATION or X-PFI-Upload-Id header"))
+        }
       case false =>
         // GitHub-style error - a thing exists but we can't see it so tell the user it doesn't exist
         Attempt.Left(NotFoundFailure(s"$collection does not exist"))
@@ -220,5 +216,51 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
     workspaceNodeId = UUID.randomUUID().toString
   } yield {
     WorkspaceItemUploadContext(workspaceId, workspaceNodeId, workspaceParentNodeId, workspaceName)
+  }
+
+  private def createIngestionIfNotExists(collection: Uri, ingestionName: String) = {
+    // TODO: the language fixed values used to come from client. Though the only variable was the ingestion name
+    val data = CreateIngestionRequest(None, Some(ingestionName), List("english"), Some(false), None)
+    val command = CreateIngestion(data, collection, manifest, index, pages)
+    for {
+      id <- command.createOrGet()
+    } yield {
+      CreateIngestionResponse(
+        uri = id.value,
+        bucket = s3Config.buckets.ingestion,
+        region = s3Config.region,
+        endpoint = s3Config.endpoint
+      )
+    }
+  }
+
+  private def reprocess(fingerprint: String, ingestFile: IngestFileResult) = {
+    val uri = Uri(fingerprint)
+
+    for {
+      _ <- manifest.rerunFailedExtractorsForBlob(uri)
+      _ <- manifest.rerunSuccessfulExtractorsForBlob(uri)
+    } yield {
+      Created(Json.toJson(ingestFile))
+    }
+  }
+
+  private def processIngestion(req: UserIdentityRequest[Files.TemporaryFile], collection: Uri, ingestionUri: Uri, uploadId: String,
+                               maybeWorkspaceContext: Option[WorkspaceItemUploadContext], rawOriginalPath: String) = {
+    val originalPath = URLDecoder.decode(rawOriginalPath, "UTF-8")
+    val lastModifiedTime = req.headers.get("X-PFI-Last-Modified")
+    new IngestFile(
+      collection,
+      ingestionUri,
+      uploadId,
+      workspace = maybeWorkspaceContext,
+      req.user.username,
+      temporaryFilePath = req.body.path,
+      originalPath = Paths.get(originalPath),
+      lastModifiedTime,
+      manifest, esEvents, ingestionServices, annotations
+    ).process().map { result =>
+      Created(Json.toJson(result))
+    }
   }
 }

--- a/backend/app/controllers/api/Collections.scala
+++ b/backend/app/controllers/api/Collections.scala
@@ -139,7 +139,7 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
                 val ingestionAttempt = createIngestionIfNotExists(collection, ingestionName)
 
                 ingestionAttempt.flatMap { ingestion =>
-                  processIngestion(req, collection, Uri(ingestion.uri), uploadId, maybeWorkspaceContext, rawOriginalPath)
+                  processIngestion(req, collection, Uri(ingestion.uri), uploadId, maybeWorkspaceContext, rawOriginalPath, Some(fingerprint))
                 }
               }
             }
@@ -246,7 +246,7 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
   }
 
   private def processIngestion(req: UserIdentityRequest[Files.TemporaryFile], collection: Uri, ingestionUri: Uri, uploadId: String,
-                               maybeWorkspaceContext: Option[WorkspaceItemUploadContext], rawOriginalPath: String) = {
+                               maybeWorkspaceContext: Option[WorkspaceItemUploadContext], rawOriginalPath: String, fingerprint: Option[String] = None) = {
     val originalPath = URLDecoder.decode(rawOriginalPath, "UTF-8")
     val lastModifiedTime = req.headers.get("X-PFI-Last-Modified")
     new IngestFile(
@@ -258,7 +258,7 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
       temporaryFilePath = req.body.path,
       originalPath = Paths.get(originalPath),
       lastModifiedTime,
-      manifest, esEvents, ingestionServices, annotations
+      manifest, esEvents, ingestionServices, annotations, fingerprint
     ).process().map { result =>
       Created(Json.toJson(result))
     }

--- a/backend/app/services/manifest/Manifest.scala
+++ b/backend/app/services/manifest/Manifest.scala
@@ -1,12 +1,14 @@
 package services.manifest
 
+import commands.IngestFileResult
+
 import java.nio.file.Path
 import extraction.{ExtractionParams, Extractor}
 import model._
 import model.annotations.WorkspaceMetadata
 import model.frontend.{BasicResource, ExtractionFailures, ResourcesForExtractionFailure}
 import model.frontend.email.EmailNeighbours
-import model.ingestion.{IngestionFile, WorkspaceItemContext}
+import model.ingestion.{IngestionFile, WorkspaceItemContext, WorkspaceItemUploadContext}
 import model.manifest._
 import services.manifest.Manifest.WorkCounts
 import utils.attempt.{Attempt, Failure}
@@ -89,4 +91,6 @@ trait Manifest extends WorkerManifest {
   def deleteBlob(uri: Uri): Attempt[Unit]
 
   def deleteResourceAndDescendants(uri: Uri): Attempt[Unit]
+
+  def getWorkspaceChildrenWithUri(workspaceNodeId: Option[WorkspaceItemUploadContext], childUri: String): Attempt[List[IngestFileResult]]
 }

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -1119,8 +1119,6 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
       ).map { result: StatementResult =>
         val children = result.list().asScala.toList
 
-        println(s"children number is ${children.length}")
-
         val childrenUris = children.map { c =>
           val node = c.get("child")
           val uri = node.get("uri").asString()

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -8,6 +8,7 @@ POST          /api/collections                                              cont
 DELETE        /api/collections/:collection                                  controllers.api.Collections.deleteCollection(collection: model.Uri)
 POST          /api/collections/:collection                                  controllers.api.Collections.newIngestion(collection: model.Uri)
 POST          /api/collections/:collection/:ingestion                       controllers.api.Collections.uploadIngestionFile(collection, ingestion)
+POST          /api/collections/ingestion/upload/:collection                 controllers.api.Collections.uploadFile(collection: model.Uri)
 DELETE        /api/collections/:collection/:ingestion                       controllers.api.Collections.deleteIngestion(collection, ingestion)
 POST          /api/collections/:collection/:ingestion/verifyFiles           controllers.api.Collections.verifyFiles(collection, ingestion)
 

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -8,7 +8,7 @@ POST          /api/collections                                              cont
 DELETE        /api/collections/:collection                                  controllers.api.Collections.deleteCollection(collection: model.Uri)
 POST          /api/collections/:collection                                  controllers.api.Collections.newIngestion(collection: model.Uri)
 POST          /api/collections/:collection/:ingestion                       controllers.api.Collections.uploadIngestionFile(collection, ingestion)
-POST          /api/collections/ingestion/upload/:collection                 controllers.api.Collections.uploadFile(collection: model.Uri)
+POST          /api/collections/ingestion/upload/:collection                 controllers.api.Collections.uploadFileWithNewIngestion(collection: model.Uri)
 DELETE        /api/collections/:collection/:ingestion                       controllers.api.Collections.deleteIngestion(collection, ingestion)
 POST          /api/collections/:collection/:ingestion/verifyFiles           controllers.api.Collections.verifyFiles(collection, ingestion)
 

--- a/frontend/src/js/components/Uploads/UploadFiles.tsx
+++ b/frontend/src/js/components/Uploads/UploadFiles.tsx
@@ -179,7 +179,7 @@ async function uploadFiles(target: WorkspaceTarget, files: Map<string, UploadFil
                 }
 
                 const metadata = await buildWorkspaceUploadMetadata(path, target, workspaceFolderCache);
-                const result = await uploadFileWithNewIngestion(target.collectionUri, target.ingestionName, uploadId, file, path, metadata, onProgress);
+                await uploadFileWithNewIngestion(target.collectionUri, target.ingestionName, uploadId, file, path, metadata, onProgress);
 
                 dispatch({ type: "Set_Upload_State", file: path, state: { description: 'uploaded' }});
             } catch(e) {
@@ -192,9 +192,6 @@ async function uploadFiles(target: WorkspaceTarget, files: Map<string, UploadFil
             await nextFile(target, files.slice(1));
         }
     }
-
-    // TODO: Investigate where this storage is used
-    //setPreference('defaultUploadTarget', result.id);
 
     const sortedFiles = sortBy(Array.from(files.entries()), ([key]) => key);
     await nextFile(target, sortedFiles);

--- a/frontend/src/js/components/Uploads/UploadFiles.tsx
+++ b/frontend/src/js/components/Uploads/UploadFiles.tsx
@@ -8,7 +8,7 @@ import { Button, Form, Progress } from 'semantic-ui-react';
 import { getUploadTarget, WorkspaceTarget } from './UploadTarget';
 import { setPreference } from '../../actions/preferences';
 import { getCollection } from '../../actions/collections/getCollection';
-import { uploadFileToIngestion } from '../../services/CollectionsApi';
+import { uploadFileWithNewIngestion } from '../../services/CollectionsApi';
 import history from '../../util/history';
 import { displayRelativePath } from '../../util/workspaceUtils';
 import { Collection } from '../../types/Collection';
@@ -179,7 +179,7 @@ async function uploadFiles(target: WorkspaceTarget, files: Map<string, UploadFil
                 }
 
                 const metadata = await buildWorkspaceUploadMetadata(path, target, workspaceFolderCache);
-                await uploadFileToIngestion(target.ingestion, uploadId, file, path, metadata, onProgress);
+                const result = await uploadFileWithNewIngestion(target.collectionUri, target.ingestionName, uploadId, file, path, metadata, onProgress);
 
                 dispatch({ type: "Set_Upload_State", file: path, state: { description: 'uploaded' }});
             } catch(e) {
@@ -193,7 +193,8 @@ async function uploadFiles(target: WorkspaceTarget, files: Map<string, UploadFil
         }
     }
 
-    setPreference('defaultUploadTarget', target.id);
+    // TODO: Investigate where this storage is used
+    //setPreference('defaultUploadTarget', result.id);
 
     const sortedFiles = sortBy(Array.from(files.entries()), ([key]) => key);
     await nextFile(target, sortedFiles);

--- a/frontend/src/js/components/Uploads/UploadFiles.tsx
+++ b/frontend/src/js/components/Uploads/UploadFiles.tsx
@@ -6,7 +6,6 @@ import FilePicker from './FilePicker';
 import FileList from './FileList';
 import { Button, Form, Progress } from 'semantic-ui-react';
 import { getUploadTarget, WorkspaceTarget } from './UploadTarget';
-import { setPreference } from '../../actions/preferences';
 import { getCollection } from '../../actions/collections/getCollection';
 import { uploadFileWithNewIngestion } from '../../services/CollectionsApi';
 import history from '../../util/history';

--- a/frontend/src/js/components/Uploads/UploadTarget.ts
+++ b/frontend/src/js/components/Uploads/UploadTarget.ts
@@ -1,11 +1,10 @@
 import { Collection } from '../../types/Collection';
 import { TreeEntry, isTreeNode } from '../../types/Tree';
 import { WorkspaceEntry, Workspace } from '../../types/Workspaces';
-import { createNewIngestion } from '../../services/CollectionsApi';
 
 export type WorkspaceTarget = {
-    id: string,
-    ingestion: string,
+    collectionUri: string,
+    ingestionName: string,
     workspace: Workspace,
     workspaceEntry: TreeEntry<WorkspaceEntry>
 }
@@ -21,18 +20,12 @@ export function getDefaultCollection(username: string, collections: Collection[]
     });
 }
 
-async function createUploadIngestion(collection: Collection): Promise<string> {
-    const ingestionName = `${new Date().toISOString()}`;
-    const newIngestion = await createNewIngestion(collection.uri, `Upload ${ingestionName}`);
-    return newIngestion.uri;
-}
-
-export async function getUploadTarget(
+export function getUploadTarget(
     username: string,
     workspace: Workspace,
     collections: Collection[],
     focusedEntry: TreeEntry<WorkspaceEntry> | null,
-): Promise<WorkspaceTarget> {
+): WorkspaceTarget {
 
     const defaultCollection = getDefaultCollection(username, collections);
     if (!defaultCollection) {
@@ -44,11 +37,10 @@ export async function getUploadTarget(
         throw new Error(`No workspace entry in either focused entry ${focusedEntry} or root of workspace ${workspace.id}, cannot upload to workspace`);
     }
 
-    const ingestionUri = await createUploadIngestion(defaultCollection);
-
+    const ingestionName = `Upload ${new Date().toISOString()}`; 
     return {
-        id: `${workspace.id}-${ingestionUri}`,
-        ingestion: ingestionUri,
+        collectionUri: defaultCollection.uri,
+        ingestionName,
         workspace,
         workspaceEntry
     }

--- a/frontend/src/js/services/CollectionsApi.ts
+++ b/frontend/src/js/services/CollectionsApi.ts
@@ -40,3 +40,9 @@ export function uploadFileToIngestion(ingestionName: string, uploadId: string, f
       `/api/collections/${ingestionName}`, uploadId, file, path, workspace, onProgress
     ).then((res: any) => JSON.parse(res));
 }
+
+export function uploadFileWithNewIngestion(collectionUri: string, ingestionName: string, uploadId: string, file: File, path: string, workspace?: WorkspaceUploadMetadata, onProgress?: ProgressHandler) {
+    return authUploadWithProgress(
+      `/api/collections/ingestion/upload/${collectionUri}`, uploadId, file, path, workspace, onProgress, ingestionName
+    ).then((res: any) => JSON.parse(res));
+}

--- a/frontend/src/js/services/CollectionsApi.ts
+++ b/frontend/src/js/services/CollectionsApi.ts
@@ -25,22 +25,6 @@ export function fetchCollection(uri: string): Promise<Collection | undefined> {
     });
 }
 
-type CreateIngestionResponse = { uri: string, bucket: string, region: string, endpoint?: string };
-
-export function createNewIngestion(collectionUri: string, ingestionName: string): Promise<CreateIngestionResponse> {
-    return authFetch(`/api/collections/${collectionUri}`, {
-        headers: new Headers({'Content-Type': 'application/json'}),
-        method: 'POST',
-        body: JSON.stringify({fixed: false, languages: ['english'], name: ingestionName })
-    }).then(res => res.json());
-}
-
-export function uploadFileToIngestion(ingestionName: string, uploadId: string, file: File, path: string, workspace?: WorkspaceUploadMetadata, onProgress?: ProgressHandler) {
-    return authUploadWithProgress(
-      `/api/collections/${ingestionName}`, uploadId, file, path, workspace, onProgress
-    ).then((res: any) => JSON.parse(res));
-}
-
 export function uploadFileWithNewIngestion(collectionUri: string, ingestionName: string, uploadId: string, file: File, path: string, workspace?: WorkspaceUploadMetadata, onProgress?: ProgressHandler) {
     return authUploadWithProgress(
       `/api/collections/ingestion/upload/${collectionUri}`, uploadId, file, path, workspace, onProgress, ingestionName

--- a/frontend/src/js/util/auth/authUploadWithProgress.ts
+++ b/frontend/src/js/util/auth/authUploadWithProgress.ts
@@ -11,7 +11,8 @@ export default function authUploadWithProgress(
   file: File,
   path: string,
   workspace?: WorkspaceUploadMetadata,
-  onProgress?: ProgressHandler
+  onProgress?: ProgressHandler,
+  ingestionName?: string
 ) {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -34,7 +35,8 @@ export default function authUploadWithProgress(
       retryInitialCount,
       resolve,
       reject,
-      workspace
+      workspace,
+      ingestionName
     );
   });
 }
@@ -48,7 +50,8 @@ const processRequest = (
   retryCount: number,
   resolve: (value: unknown) => void,
   reject: (reason?: any) => void,
-  workspace?: WorkspaceUploadMetadata
+  workspace?: WorkspaceUploadMetadata,
+  ingestionName?: string
 ) => {
   xhr.onloadend = () => {
     handleResponseFromAuthRequest(
@@ -68,7 +71,8 @@ const processRequest = (
           uploadId,
           resolve,
           reject,
-          workspace
+          workspace,
+          ingestionName
         );
       } else {
         console.error(
@@ -79,7 +83,7 @@ const processRequest = (
     }
   };
 
-  sendRequest(xhr, url, file, path, uploadId, retryCount, workspace);
+  sendRequest(xhr, url, file, path, uploadId, retryCount, workspace, ingestionName);
 };
 
 const retryRequest = (
@@ -91,7 +95,8 @@ const retryRequest = (
   uploadId: string,
   resolve: (value: unknown) => void,
   reject: (reason?: any) => void,
-  workspace?: WorkspaceUploadMetadata
+  workspace?: WorkspaceUploadMetadata,
+  ingestionName?: string
 ) => {
   const limit = retryCount ? Math.pow(2, retryCount - 1) * 1000 : 0;
   const pause = Math.random() * limit;
@@ -106,7 +111,8 @@ const retryRequest = (
       retryCount,
       resolve,
       reject,
-      workspace
+      workspace,
+      ingestionName
     );
   }, pause);
 };
@@ -118,7 +124,8 @@ const sendRequest = (
   path: string,
   uploadId: string,
   retryCount: number,
-  workspace?: WorkspaceUploadMetadata
+  workspace?: WorkspaceUploadMetadata,
+  ingestionName?: string
 ) => {
   xhr.open("POST", url);
 
@@ -139,6 +146,10 @@ const sendRequest = (
       workspace.parentNodeId
     );
     xhr.setRequestHeader("X-PFI-Workspace-Name", workspace.workspaceName);
+  }
+
+  if(ingestionName) {
+    xhr.setRequestHeader("X-PFI-Ingestion-Name", ingestionName);
   }
   xhr.setRequestHeader("X-PFI-Last-Modified", file.lastModified.toString());
   xhr.setRequestHeader("X-PFI-Retry-Count", retryCount.toString());


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adds a new api endpoint to upload files so that it would not create new nodes if the file already exists.
- expects a new header `X-PFI-Ingestion-Name`
- using the file fingerprint, checks if same file already exists in the same workspace path
- reprocess the file if already exists
- if file doesn't already exist, it checks if there's already an ingestion with same name as retrieved from header `X-PFI-Ingestion-Name`
- If ingestion doesn't already exist, it creates ingestion, otherwise it uses the existing ingestion
- It processes the ingest file 
![image](https://github.com/guardian/giant/assets/15894063/5131312d-5141-4782-9789-4b3529e6ef34)

As can be seen in the video when the same file is uploaded in a workspace path that already has that file, file is reprocessed. But if that file is uploaded into a different path of the same workspace, the file upload does occur. 

https://github.com/guardian/giant/assets/15894063/5104db8e-a425-4c03-a2ac-2d29f6c74d91



<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
The old upload endpoint is untouched and can be used as it could previously. This was tested by undoing the UI changes and do the file uploads with the old UI which is still making request to the old endpoint and it worked fine. 

The new endpoint was also tested in these scenario:
- upload same file in the same workspace path
- upload same file in a different workspace path e.g. different folder
- upload multiple files when one or some of them already exists in the same workspace path but some of them are new
- upload a folder with files that already exist in the workspace (in this scenario file within the folder are all uploaded)
- upload a folder with duplicate files (in this scenario duplicate files are not uploaded)
