### PR TITLE
Fix js caching issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,11 @@ ThisBuild / scalaVersion := "2.13.9"
 
 import com.gu.riffraff.artifact.BuildInfo
 import play.sbt.PlayImport.PlayKeys._
+import sbt.Package.FixedTimestamp
+
+// needed to correctly set Last-Modified headers, fixing asset caching
+// See https://github.com/guardian/grid/pull/3600/commits/01c904e4c47c5a4443c48354b92ada3e17533895
+ThisBuild / packageOptions += FixedTimestamp(Package.keepTimestamps)
 
 val compilerFlags = Seq(
   "-unchecked",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## Background
For ages we've had an issue where after a deployment any user who had recently used Giant would see a loading screen forever the next time they went to Giant. They would need to do a hard refresh after each deployment to get around the issue.

<img width="575" alt="Screenshot 2024-01-17 at 14 10 22" src="https://github.com/guardian/giant/assets/17057932/7303e4a3-42fb-4445-9fff-90647ec75af4">

We worked out that this was a caching problem where the browser was loading a cached version on `index.html` which contained a script tag pointing to the old js bundle which, after the last deployment, no longer existed.

In #179 we added cache control header `no-cache` to the response when `index.html` is requested, which seemed to fix the issue for a while.

The `no-cache` header made it so that the server would revalidate on each request that the client's [Etag header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) matched that of the current version `index.html`. By default, Play [generates Etags](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) based only on the filename and last modified date of the resource. Due to an [SBT issue](https://github.com/sbt/sbt/pull/6237) introduced in v1.4, all resources' last modified date are set to Jan 1 2010, meaning that `index.html`'s Etag wasn't modified when it's contents were updated by a deployment.

## What does this change?
Copies @andrew-nowak's very well-documented fix in [this commit](https://github.com/guardian/grid/pull/3600/commits/01c904e4c47c5a4443c48354b92ada3e17533895) which restores the expected behaviour of Last-Modified header dates. This fixes the caching issue because Play uses updated last modified date values for `index.html` and generates a new Etag value for each new version of the file, ending our caching woes.

## Before
response when fetching `index.html` contains incorrect Last-Modified date header
<img width="677" alt="Screenshot 2024-01-17 at 12 02 18" src="https://github.com/guardian/giant/assets/17057932/3867c4a5-0119-43f8-900b-5ad11d117cd4">

## After
correct Last-Modified header
<img width="865" alt="Screenshot 2024-01-17 at 14 10 56" src="https://github.com/guardian/giant/assets/17057932/cdedbb9f-0ad7-4ee4-a001-338a1486034f">



<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested in CODE by deploying https://github.com/guardian/giant/tree/test-js-caching-issue multiple times with small changes to its js code (updating and removing a console.log line). After each deployment, a browser with a cached version of index.html loads the new file, receiving a 200 rather than a 304, with updated Last-Modified and Etag headers. The new js bundle is fetched as expected.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
No more Loading error

