### PR TITLE
Upgrade to latest aws sdk 1.12.643 due to snyk vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val compilerFlags = Seq(
   "-Xfatal-warnings"
 )
 
-val awsVersion = "1.12.428"
+val awsVersion = "1.12.643"
 val log4jVersion = "2.20.0"
 val slf4jVersion = "2.0.7"
 // To match what the main app gets from scalatestplus-play transitively


### PR DESCRIPTION

## What does this change?

Upgrades to latest v1 of aws sdk - fix for https://security.snyk.io/vuln/SNYK-JAVA-SOFTWAREAMAZONION-6153869

## How to test

Compiled locally, running snyk GHA shows vulnerability now gone. 

