### PR TITLE
Yield control of backups to aws backup

### DIFF
--- a/postgres/cdk/lib/giant.ts
+++ b/postgres/cdk/lib/giant.ts
@@ -56,7 +56,6 @@ export class Giant extends GuStack {
 			allocatedStorage: dbStorage,
 			maxAllocatedStorage: dbStorage + 20,
 			autoMinorVersionUpgrade: true,
-			backupRetention: Duration.days(14),
 			instanceType: InstanceType.of(
 				InstanceClass.T4G,
 				this.stage === 'PROD' ? InstanceSize.MICRO : InstanceSize.MICRO,
@@ -64,6 +63,7 @@ export class Giant extends GuStack {
 			instanceIdentifier: `giant-db-${this.stage}`,
 			databaseName: 'giant',
 			deletionProtection: true,
+			deleteAutomatedBackups: false,
 			cloudwatchLogsExports: ['postgresql'],
 			iamAuthentication: true,
 			multiAz: false,


### PR DESCRIPTION
## What does this change?

Removing legacy automated backup settings to prevent cloudformation drift, as they are now handled by aws-backups

## How to test

