### PR TITLE
Upgrade to actions-riff-raff v4

### DIFF
--- a/.github/workflows/postgres-build.yml
+++ b/.github/workflows/postgres-build.yml
@@ -24,10 +24,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
 
       - uses: actions/setup-node@v3
         with:
@@ -40,8 +36,10 @@ jobs:
           npm ci
           npm run synth
 
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           app: postgres
           contentDirectories: |
             cloudformation:


### PR DESCRIPTION
## What does this change?
- Follow directions in actions-riff-raff to upgrade from version 2 to 4.
  - [v2 to v3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0)
  - [v3 to v4](https://github.com/guardian/actions-riff-raff?tab=readme-ov-file#migrating-from-v3-to-v4)



## Why?
v4 avoids the need for configure-aws-credentials which stores aws credentials in an environment variables, allowing other, possibly malicious, actions to access them.