### PR TITLE
Use arm64 ami

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,7 +12,7 @@ deployments:
     parameters:
       amiEncrypted: true
       amiTags:
-        Recipe: investigations-giant-app-java11
+        Recipe: investigations-giant-app-arm
         AmigoStage: PROD
         Encrypted: pfi-playground
 


### PR DESCRIPTION
We can save some money and hopefully boost performance by moving to graviton instances. Once testing is complete on a graviton AMI, this PR will tell riffraff to use a graviton ami when deploying giant

Depends on https://github.com/guardian/investigations-platform/pull/481