### PR TITLE
fix SNYK-JAVA-ORGPOSTGRESQL-6252740 by upgrading postgresql

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,7 @@ lazy val backend = (project in file("backend"))
 
       // postgres
       "org.scalikejdbc" %% "scalikejdbc"       % "4.0.0",
-      "org.postgresql"  %  "postgresql"        % "42.5.4",
+      "org.postgresql"  %  "postgresql"        % "42.7.2",
 
       // Test dependencies
 


### PR DESCRIPTION
## What does this change?

Upgraded to `postgresql` to `42.7.2` due to the SQL ingestion vulnerability [SNYK-JAVA-ORGPOSTGRESQL-6252740](https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-6252740)

## How to test
Tested on CODE - see https://playground.pfi.gutools.co.uk/settings/my-uploads?currentWorkspace=all

