### PR TITLE
upgrading tika to 2.9.1 to fix SNYK-JAVA-ORGAPACHECOMMONS-6254296

### DIFF
--- a/backend/app/extraction/archives/ZipExtractor.scala
+++ b/backend/app/extraction/archives/ZipExtractor.scala
@@ -32,7 +32,7 @@ class ZipExtractor(scratch: ScratchSpace, ingestionServices: IngestionServices) 
     val extractionRootPath = scratch.createWorkingDir(s"zip/${blob.uri.value}/")
     logger.info(s"Running ZIP extractor on '${blob.uri.value}' in temporary working directory '$extractionRootPath'")
 
-    val zipFile = new ZipFile(file)
+    val zipFile = ZipFile.builder().setFile(file).get()
     val builder = IngestionContextBuilder(blob.uri, params)
 
     val result = Either.catchNonFatal {

--- a/backend/app/extraction/email/olm/OlmEmailExtractor.scala
+++ b/backend/app/extraction/email/olm/OlmEmailExtractor.scala
@@ -31,7 +31,7 @@ class OlmEmailExtractor(scratch: ScratchSpace, ingestion: IngestionServices) ext
 
     val context = IngestionContextBuilder(blob.uri, params)
 
-    val zipFile = new ZipFile(scratchFile)
+    val zipFile = ZipFile.builder().setFile(scratchFile).get()
     logger.info(s"Loaded OLM '${blob.uri.value}'")
 
     try {

--- a/build.sbt
+++ b/build.sbt
@@ -128,9 +128,9 @@ lazy val backend = (project in file("backend"))
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the
       // conf/org/apache/tika/mimecustom-mimetypes.xml file
-      // (Seems to be OK as of 2.7.0: https://tika.apache.org/2.7.0/parser_guide.html)
-      "org.apache.tika" % "tika-parsers-standard-package" % "2.7.0",
-      "org.apache.tika" % "tika-core" % "2.7.0",
+      // (Seems to be OK as of 2.9.1: https://tika.apache.org/2.9.1/parser_guide.html)
+      "org.apache.tika" % "tika-parsers-standard-package" % "2.9.1",
+      "org.apache.tika" % "tika-core" % "2.9.1",
       "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-core" % log4jVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -128,16 +128,10 @@ lazy val backend = (project in file("backend"))
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the
       // conf/org/apache/tika/mimecustom-mimetypes.xml file
-<<<<<<< Updated upstream
-      // (Seems to be OK as of 2.9.1: https://tika.apache.org/2.9.1/parser_guide.html)
-      "org.apache.tika" % "tika-parsers-standard-package" % "2.9.1",
-      "org.apache.tika" % "tika-core" % "2.9.1",
-=======
       // (Seems to be OK as of 2.7.0: https://tika.apache.org/2.7.0/parser_guide.html)
       "org.apache.tika" % "tika-parsers-standard-package" % "2.7.0",
       "org.apache.tika" % "tika-core" % "2.7.0",
       "org.apache.commons" % "commons-compress" % "1.26.0",
->>>>>>> Stashed changes
       "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-core" % log4jVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -128,9 +128,16 @@ lazy val backend = (project in file("backend"))
       "com.pff" % "java-libpst" % "0.9.3",
       // NOTE: When you update tika you need to check if there are any updates required to be made to the
       // conf/org/apache/tika/mimecustom-mimetypes.xml file
+<<<<<<< Updated upstream
       // (Seems to be OK as of 2.9.1: https://tika.apache.org/2.9.1/parser_guide.html)
       "org.apache.tika" % "tika-parsers-standard-package" % "2.9.1",
       "org.apache.tika" % "tika-core" % "2.9.1",
+=======
+      // (Seems to be OK as of 2.7.0: https://tika.apache.org/2.7.0/parser_guide.html)
+      "org.apache.tika" % "tika-parsers-standard-package" % "2.7.0",
+      "org.apache.tika" % "tika-core" % "2.7.0",
+      "org.apache.commons" % "commons-compress" % "1.26.0",
+>>>>>>> Stashed changes
       "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-core" % log4jVersion,


### PR DESCRIPTION
## What does this change?

Upgrading `commons-compress` to fix https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-6254296

(previously tried upgrading `tika` but is uses conflicting versions of `jackson-databind` to `play` which results in a runtime error ([tika uses 2.15.2](https://mvnrepository.com/artifact/org.apache.tika/tika-parsers-standard/2.9.1), [play uses 2.14.3](https://mvnrepository.com/artifact/org.playframework/play_3/3.0.2))

## How to test 

Deployed and tested to CODE



