### PR TITLE
Search in workspace folder

### DIFF
--- a/backend/app/controllers/api/PagesController.scala
+++ b/backend/app/controllers/api/PagesController.scala
@@ -49,7 +49,7 @@ class PagesController(val controllerComponents: AuthControllerComponents, manife
   // Get language and highlight data for a given page
   def getPageData(uri: Uri, pageNumber: Int, sq: Option[String], fq: Option[String]) = ApiAction.attempt { req =>
     for {
-      response <- frontendPageFromQuery(uri, pageNumber, req.user.username, sq.map(Chips.parseQueryString), fq)
+      response <- frontendPageFromQuery(uri, pageNumber, req.user.username, sq.map(Chips.parseQueryString(_).query), fq)
     } yield {
       Ok(Json.toJson(response))
     }
@@ -150,7 +150,7 @@ class PagesController(val controllerComponents: AuthControllerComponents, manife
   // It behaves identically to the findInDocument endpoint, except that it expects its query to be in
   // a JSON format that may contain chips, and it returns highlight ids with a different prefix.
   def searchInDocument(uri: Uri, q: String) = ApiAction.attempt { req =>
-    getHighlights(uri, Chips.parseQueryString(q), req.user.username, isSearch = true).map(highlights =>
+    getHighlights(uri, Chips.parseQueryString(q).query, req.user.username, isSearch = true).map(highlights =>
       Ok(Json.toJson(highlights))
     )
   }

--- a/backend/app/controllers/api/Resource.scala
+++ b/backend/app/controllers/api/Resource.scala
@@ -38,7 +38,7 @@ class Resource(val controllerComponents: AuthControllerComponents, manifest: Man
 
     val resourceFetchMode = (basic, parsedChips) match {
       case (true, _) => ResourceFetchMode.Basic
-      case (false, pt) => ResourceFetchMode.WithData(pt.map(_.query))
+      case (false, pc) => ResourceFetchMode.WithData(pc.map(_.query))
     }
 
     val decodedUri = Uri(UriEncoding.decodePath(uri.value, StandardCharsets.UTF_8))

--- a/backend/app/model/frontend/Chip.scala
+++ b/backend/app/model/frontend/Chip.scala
@@ -17,7 +17,7 @@ case class DateChip(name: String, template: String) extends Chip
 case class ExclusiveDateChip(name: String, template: String) extends Chip
 case class DropdownChip(name: String, options: List[DropdownOption], template: String) extends Chip
 
-case class WorkspaceFolderChip(name: String, template: String, workspaceId: String, folderId: String) extends Chip
+case class WorkspaceFolderChip(name: String, t: String, workspaceId: String, folderId: String)
 
 object WorkspaceFolderChip {
   implicit val workspaceFolderChip = Json.format[WorkspaceFolderChip]
@@ -37,7 +37,6 @@ object Chip {
         case JsString("dropdown") => dropdownChipFormat.reads(json)
         case JsString("date") => dateChipFormat.reads(json)
         case JsString("date_ex") => exclusiveDateChipFormat.reads(json)
-        case JsString("workspace_folder") => WorkspaceFolderChip.workspaceFolderChip.reads(json)
         case other => JsError(s"Unexpected type in chip $other")
       }
     }
@@ -48,7 +47,6 @@ object Chip {
         case r: DateChip => dateChipFormat.writes(r) + ("type", JsString("date")) - "template"
         case r: ExclusiveDateChip => exclusiveDateChipFormat.writes(r) + ("type", JsString("date_ex")) - "template"
         case r: DropdownChip => dropdownChipFormat.writes(r) + ("type", JsString("dropdown")) - "template"
-        case r: WorkspaceFolderChip => WorkspaceFolderChip.workspaceFolderChip.writes(r) + ("t", JsString("workspace_folder")) - "template"
         case other => throw new UnsupportedOperationException(s"Unable to serialize chip of type ${other.getClass.toString}")
       }
     }

--- a/backend/app/model/frontend/Chip.scala
+++ b/backend/app/model/frontend/Chip.scala
@@ -17,6 +17,12 @@ case class DateChip(name: String, template: String) extends Chip
 case class ExclusiveDateChip(name: String, template: String) extends Chip
 case class DropdownChip(name: String, options: List[DropdownOption], template: String) extends Chip
 
+case class WorkspaceFolderChip(name: String, template: String, workspaceId: String, folderId: String) extends Chip
+
+object WorkspaceFolderChip {
+  implicit val workspaceFolderChip = Json.format[WorkspaceFolderChip]
+}
+
 object Chip {
   private val plainChipFormat = Json.format[TextChip]
   private val dateChipFormat = Json.format[DateChip]
@@ -31,6 +37,7 @@ object Chip {
         case JsString("dropdown") => dropdownChipFormat.reads(json)
         case JsString("date") => dateChipFormat.reads(json)
         case JsString("date_ex") => exclusiveDateChipFormat.reads(json)
+        case JsString("workspace_folder") => WorkspaceFolderChip.workspaceFolderChip.reads(json)
         case other => JsError(s"Unexpected type in chip $other")
       }
     }
@@ -41,6 +48,7 @@ object Chip {
         case r: DateChip => dateChipFormat.writes(r) + ("type", JsString("date")) - "template"
         case r: ExclusiveDateChip => exclusiveDateChipFormat.writes(r) + ("type", JsString("date_ex")) - "template"
         case r: DropdownChip => dropdownChipFormat.writes(r) + ("type", JsString("dropdown")) - "template"
+        case r: WorkspaceFolderChip => WorkspaceFolderChip.workspaceFolderChip.writes(r) +  ("type", JsString("workspace_folder")) - "template"
         case other => throw new UnsupportedOperationException(s"Unable to serialize chip of type ${other.getClass.toString}")
       }
     }

--- a/backend/app/model/frontend/Chip.scala
+++ b/backend/app/model/frontend/Chip.scala
@@ -48,7 +48,7 @@ object Chip {
         case r: DateChip => dateChipFormat.writes(r) + ("type", JsString("date")) - "template"
         case r: ExclusiveDateChip => exclusiveDateChipFormat.writes(r) + ("type", JsString("date_ex")) - "template"
         case r: DropdownChip => dropdownChipFormat.writes(r) + ("type", JsString("dropdown")) - "template"
-        case r: WorkspaceFolderChip => WorkspaceFolderChip.workspaceFolderChip.writes(r) +  ("type", JsString("workspace_folder")) - "template"
+        case r: WorkspaceFolderChip => WorkspaceFolderChip.workspaceFolderChip.writes(r) + ("t", JsString("workspace_folder")) - "template"
         case other => throw new UnsupportedOperationException(s"Unable to serialize chip of type ${other.getClass.toString}")
       }
     }

--- a/backend/app/model/frontend/Chip.scala
+++ b/backend/app/model/frontend/Chip.scala
@@ -58,7 +58,8 @@ object Chips {
     // find WorkspaceSearchContextParams
     val workspaceFolder = parsedQ match {
       case JsArray(value) => value.collectFirst {
-        case JsObject(o) => WorkspaceSearchContextParams(o.get("workspaceId").map(_.validate[String].get).get, o.get("folderId").map(_.validate[String].get).get)
+        case JsObject(o) if o.get("t").map(_.validate[String].get).get == "workspace_folder" => 
+            WorkspaceSearchContextParams(o.get("workspaceId").map(_.validate[String].get).get, o.get("folderId").map(_.validate[String].get).get)
       }
       case _ => None
     }

--- a/backend/app/model/frontend/Chip.scala
+++ b/backend/app/model/frontend/Chip.scala
@@ -56,12 +56,13 @@ object Chip {
 case class ParsedChips (query: String, workspace: Option[WorkspaceSearchContextParams])
 
 object Chips {
-  // TODO - when the index supports attempts we can uncomment these lines to make this attempty
-  //def parseQueryString(q: String): Attempt[String] = {
+  // TODO - when the index supports attempts, make this function attempty
   def parseQueryString(q: String): ParsedChips = {
-    //Attempt.catchNonFatal {
     val parsedQ = Json.parse(q)
-    // find WorkspaceSearchContextParams
+    // workspace_folder chips need to be handled separately from the rest.
+    // Instead of transforming the chips to a query string, we need to use
+    // workspace and folder IDs to find a list of blob so filter for. Look for
+    // those IDs here, then skip workspace_folder when building the query.
     val workspaceFolder = parsedQ match {
       case JsArray(value) => value.collectFirst {
         case JsObject(o) if o.get("t").map(_.validate[String].get).get == "workspace_folder" => 
@@ -101,9 +102,6 @@ object Chips {
       case _ => throw new UnsupportedOperationException("Outer json type must be an array")
     }
     ParsedChips(query, workspaceFolder)
-    //  } {
-    //  case s: Exception => ClientFailure(s"Invalid query: ${s.getMessage}")
-    //}
   }
 
   val all: List[Chip] = List(

--- a/backend/app/model/index/SearchParameters.scala
+++ b/backend/app/model/index/SearchParameters.scala
@@ -1,5 +1,7 @@
 package model.index
 
+import services.index.WorkspaceSearchContextParams
+
 trait SortBy
 case object Relevance extends SortBy
 case object SizeAsc extends SortBy
@@ -15,7 +17,9 @@ case class SearchParameters(q: String,
                             end: Option[Long],
                             page: Int,
                             pageSize: Int,
-                            sortBy: SortBy) {
+                            sortBy: SortBy,
+                            workspaceContext: Option[WorkspaceSearchContextParams] = None
+                           ) {
   def from: Int = (page - 1) * pageSize
   def size: Int = pageSize
 }

--- a/backend/test/controllers/api/WorkspaceSearchITest.scala
+++ b/backend/test/controllers/api/WorkspaceSearchITest.scala
@@ -69,7 +69,7 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
     asUser("barry") { controllers =>
       val folderId = itemIds.f
       val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
-      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
+      val request = FakeRequest("GET", s"""/query?q=[${q},"*"]""")
 
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults]
       // TODO: This is only 0 because Barry cannot see anything at all (he has no workspaces or collections of his own).
@@ -83,7 +83,7 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
     asUser("paul") { controllers =>
       val folderId = itemIds.`f/h`
       val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
-      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
+      val request = FakeRequest("GET", s"""/query?q=[${q},"*"]""")
 
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults].results
       results should have length(1)
@@ -96,7 +96,7 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
     asUser("paul") { controllers =>
       val folderId = itemIds.`f`
       val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
-      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
+      val request = FakeRequest("GET", s"""/query?q=[${q},"*"]""")
 
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults].results
 
@@ -112,7 +112,7 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
     asUser("paul") { controllers =>
       val folderId = itemIds.`f/g`
       val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
-      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
+      val request = FakeRequest("GET", s"""/query?q=[${q},"*"]""")
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults].results
 
       results.map(_.uri) should contain only(
@@ -132,7 +132,7 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
       )
 
       val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
-      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
+      val request = FakeRequest("GET", s"""/query?q=[${q},"*"]""")
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults]
 
       results.hits should be(0)
@@ -147,7 +147,7 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
     asUser("barry") { implicit controllers =>
       val folderId = itemIds.`f/h`
       val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
-      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
+      val request = FakeRequest("GET", s"""/query?q=[${q},"*"]""")
 
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults].results
       results should have length(1)

--- a/backend/test/controllers/api/WorkspaceSearchITest.scala
+++ b/backend/test/controllers/api/WorkspaceSearchITest.scala
@@ -68,7 +68,8 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
   test("Barry can't search inside a folder in Paul's workspace") {
     asUser("barry") { controllers =>
       val folderId = itemIds.f
-      val request = FakeRequest("GET", s"""/query?q=["*"]&workspaceId=${paulWorkspace.id}&workspaceFolderId=${folderId}""")
+      val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
+      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
 
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults]
       // TODO: This is only 0 because Barry cannot see anything at all (he has no workspaces or collections of his own).
@@ -110,8 +111,8 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
 
     asUser("paul") { controllers =>
       val folderId = itemIds.`f/g`
-      val request = FakeRequest("GET", s"""/query?q=["*"]&workspaceId=${paulWorkspace.id}&workspaceFolderId=${folderId}""")
-
+      val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
+      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults].results
 
       results.map(_.uri) should contain only(
@@ -130,7 +131,8 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
         itemId = itemIds.`f/h/1.txt`.nodeId
       )
 
-      val request = FakeRequest("GET", s"""/query?q=["*"]&workspaceId=${paulWorkspace.id}&workspaceFolderId=${folderId}""")
+      val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
+      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults]
 
       results.hits should be(0)
@@ -144,7 +146,8 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
 
     asUser("barry") { implicit controllers =>
       val folderId = itemIds.`f/h`
-      val request = FakeRequest("GET", s"""/query?q=["*"]&workspaceId=${paulWorkspace.id}&workspaceFolderId=${folderId}""")
+      val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
+      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
 
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults].results
       results should have length(1)

--- a/backend/test/controllers/api/WorkspaceSearchITest.scala
+++ b/backend/test/controllers/api/WorkspaceSearchITest.scala
@@ -14,6 +14,9 @@ import test.integration.{ElasticsearchTestService, ItemIds, Neo4jTestService}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import org.scalatest.funsuite.AnyFunSuite
+import model.frontend.WorkspaceFolderChip._
+import model.frontend.WorkspaceFolderChip
+import play.api.libs.json._
 
 class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with ElasticsearchTestService with BeforeAndAfterEach {
   final implicit override def patience: PatienceConfig = PatienceConfig(Span(30, Seconds), Span(250, Millis))
@@ -78,7 +81,8 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
   test("Paul can search in a folder in his workspace") {
     asUser("paul") { controllers =>
       val folderId = itemIds.`f/h`
-      val request = FakeRequest("GET", s"""/query?q=["*"]&workspaceId=${paulWorkspace.id}&workspaceFolderId=${folderId}""")
+      val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
+      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
 
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults].results
       results should have length(1)
@@ -90,7 +94,8 @@ class WorkspaceSearchITest extends AnyFunSuite with Neo4jTestService with Elasti
   test("Paul can see results from nested folders in his workspace") {
     asUser("paul") { controllers =>
       val folderId = itemIds.`f`
-      val request = FakeRequest("GET", s"""/query?q=["*"]&workspaceId=${paulWorkspace.id}&workspaceFolderId=${folderId}""")
+      val q = Json.toJson(WorkspaceFolderChip("workspace", "workspace_folder", paulWorkspace.id, folderId))
+      val request = FakeRequest("GET", s"""/query?q=[${q}]""")
 
       val results = contentAsJson(controllers.search.search().apply(request)).as[SearchResults].results
 

--- a/frontend/src/js/components/UtilComponents/InputSupper/Chip.js
+++ b/frontend/src/js/components/UtilComponents/InputSupper/Chip.js
@@ -84,7 +84,8 @@ export default class Chip extends React.Component {
     }
 
     onNegateClicked = () => {
-        this.props.onNegateClicked(this.props.index);
+        if (this.props.type !== 'workspace_folder')
+            this.props.onNegateClicked(this.props.index);
     }
 
     refHandler = (element) => {
@@ -95,6 +96,8 @@ export default class Chip extends React.Component {
         switch (this.props.type) {
             case 'text':
                 return <InputChip ref={this.refHandler} value={this.props.value} onChange={this.onChange} onKeyDown={this.onKeyDownText} onFocus={this.onFocus}/>;
+            case 'workspace_folder':
+                return <WorkspaceFolderChip ref={this.refHandler} value={this.props.value} onChange={this.onChange} onKeyDown={this.onKeyDownDropdown} onFocus={this.onFocus}/>
             case 'date':
                 return <DateChip ref={this.refHandler} value={this.props.value} onChange={this.onChange} onKeyDown={this.onKeyDownText} dateMode='from_start'/>;
             case 'date_ex':
@@ -157,6 +160,54 @@ class UnknownChip extends React.Component {
             </div>
         );
     }
+}
+
+class WorkspaceFolderChip extends React.Component {
+    static propTypes = {
+        value: PropTypes.string.isRequired,
+        onFocus: PropTypes.func.isRequired,
+        onChange: PropTypes.func.isRequired,
+        onKeyDown: PropTypes.func.isRequired
+    }
+
+    focus = () => {
+        this.textInput.focus();
+    }
+
+    focusEnd = () => {
+        this.textInput.focus();
+        this.textInput.input.selectionStart = this.textInput.input.selectionEnd = this.textInput.input.value.length;
+    }
+
+    select = () => {
+        this.textInput.select();
+    }
+
+    onChange = (e) => {
+        this.props.onChange(e.target.value);
+    }
+
+    onKeyDown = (e) => {
+        const inputStart = this.textInput.input.selectionStart;
+        const inputEnd = this.textInput.input.selectionEnd;
+
+        this.props.onKeyDown(e, inputStart, inputEnd);
+    }
+
+    render() {
+        return (
+            <AutosizeInput ref={i => this.textInput = i}
+                type='text'
+                inputClassName='input-supper__inline-input input-supper__inline-input--chip'
+                value={this.props.value}
+                onChange={this.onChange}
+                onKeyDown={this.onKeyDown}
+                onFocus={this.props.onFocus}
+                disabled={true}
+                />
+        );
+    }
+
 }
 
 class InputChip extends React.Component {

--- a/frontend/src/js/components/UtilComponents/InputSupper/index.js
+++ b/frontend/src/js/components/UtilComponents/InputSupper/index.js
@@ -71,7 +71,9 @@ export default class InputSupper extends React.Component {
                     name: e.n,
                     value: e.v,
                     negate: e.op === '-',
-                    chipType: e.t
+                    chipType: e.t,
+                    workspaceId: e.workspaceId,
+                    folderId: e.folderId,
                 };
             }
 
@@ -125,7 +127,9 @@ export default class InputSupper extends React.Component {
                     n: e.name,
                     v: e.value,
                     op: e.negate ? '-' : '+',
-                    t: e.chipType
+                    t: e.chipType,
+                    workspaceId: e.workspaceId,
+                    folderId: e.folderId
                 };
             }
             return '';

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -542,7 +542,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             {key : "copyFilePath", content: copyFilePathContent, icon: "copy"},
             // or 'pencil alternate'
             { key: "rename", content: "Rename", icon: "pen square" },
-            { key: "remove", content: "Remove from workspace", icon: "trash" }
+            { key: "remove", content: "Remove from workspace", icon: "trash" },
         ];
         
         if (entry.data.addedBy.username === currentUser.username && isWorkspaceLeaf(entry.data)) {
@@ -551,6 +551,8 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
 
         if (isWorkspaceLeaf(entry.data)){
             items.push({ key: "reprocess", content: "Reprocess source file", icon: "redo" });
+        } else {
+           items.push({ key: "search", content: "Search in folder", icon: "search" })
         }
 
         return <DetectClickOutside onClickOutside={this.closeContextMenu}>
@@ -594,6 +596,11 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                     if (menuItemProps.content === 'Reprocess source file' && (isWorkspaceLeaf(entry.data))) {
                         this.props.reprocessBlob(workspaceId, entry.data.uri)
                     }
+
+                    if (menuItemProps.content === "Search in folder"){
+                        window.location.replace(`/search?filters.workspace[]=${workspace.id}`)
+                    }
+
                     setTimeout(() => this.closeContextMenu(), closeMenuDelay);
                 }}
             />

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -48,6 +48,8 @@ import { reprocessBlob } from '../../actions/workspaces/reprocessBlob';
 import { DeleteModal, DeleteStatus } from './DeleteModal';
 import { PartialUser } from '../../types/User';
 import { getMyPermissions } from '../../actions/users/getMyPermissions';
+import buildLink from '../../util/buildLink';
+import history from '../../util/history';
 
 
 type Props = ReturnType<typeof mapStateToProps>
@@ -598,7 +600,23 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                     }
 
                     if (menuItemProps.content === "Search in folder"){
-                        window.location.replace(`/search?filters.workspace[]=${workspace.id}`)
+                        history.push(
+                            buildLink("/search", {
+                                q: JSON.stringify([
+                                    "",
+                                    {
+                                        n: "Workspace Folder",
+                                        v: entry.name,
+                                        op: "+",
+                                        t: "workspace_folder",
+                                        workspaceId: workspace.id,
+                                        folderId: entry.id,
+                                    },
+                                    "*"
+                                ]),
+                                page: 1
+                            }),
+                        )
                     }
 
                     setTimeout(() => this.closeContextMenu(), closeMenuDelay);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Introduces a new "workspace folder" Chip (documented here [Search in Giant](https://docs.google.com/document/d/1uejYdU7w5GJpmg9R2u-Wi6qr1YfSg7bWHRRazDwHjUU/edit)) which allows a user to search inside a specific folder in a workspace.
  - at the moment, a "workspace folder" chip can be removed but not created or edited
- Adds a "search in folder" item to the context menu when a user right clicks on a folder in the workspace view. This links to the search view with a "workspace folder" chip pre-populated.
- Changes to the /search endpoint to handle this new chip type. Most of the logic to filter by the blobs in a folder was introduced in https://github.com/guardian/pfi/pull/811 and is repurposed here.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
- [x] tested in CODE
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Users will be able to search inside a folder inside a workspace.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Potential future changes
- We could add the ability to create and edit workspace folder chips directly from the search page with a typeahead of workspace and folder names. 

## Example
https://github.com/guardian/giant/assets/17057932/5ae08934-3080-4b0f-ae9c-8f93f3db68fd

