### PR TITLE
Add workspace search log

### DIFF
--- a/backend/app/controllers/api/Search.scala
+++ b/backend/app/controllers/api/Search.scala
@@ -23,6 +23,7 @@ class Search(override val controllerComponents: AuthControllerComponents, userMa
   def search() = ApiAction.attempt { req: UserIdentityRequest[_] =>
     val q = req.queryString.getOrElse("q", Seq("")).head
     val proposedParams = Search.buildSearchParameters(q, req)
+    proposedParams.workspaceContext.map(wc => logger.info(req.user.asLogMarker, s"Performing workspace search"))
 
     buildSearch(req.user, proposedParams, proposedParams.workspaceContext).flatMap { case (verifiedParams, context) =>
       val returnEmptyResult = Search.shouldReturnEmptyResult(proposedParams, verifiedParams, context)

--- a/backend/app/controllers/api/Search.scala
+++ b/backend/app/controllers/api/Search.scala
@@ -23,7 +23,10 @@ class Search(override val controllerComponents: AuthControllerComponents, userMa
   def search() = ApiAction.attempt { req: UserIdentityRequest[_] =>
     val q = req.queryString.getOrElse("q", Seq("")).head
     val proposedParams = Search.buildSearchParameters(q, req)
-    proposedParams.workspaceContext.map(wc => logger.info(req.user.asLogMarker, s"Performing workspace search"))
+    logger.info(s"searching. workspace context is ${proposedParams.workspaceContext.isDefined}")
+    if (proposedParams.workspaceContext.isDefined){
+      logger.info(req.user.asLogMarker, "Performing workspace search")
+    }
 
     buildSearch(req.user, proposedParams, proposedParams.workspaceContext).flatMap { case (verifiedParams, context) =>
       val returnEmptyResult = Search.shouldReturnEmptyResult(proposedParams, verifiedParams, context)

--- a/backend/app/controllers/api/Search.scala
+++ b/backend/app/controllers/api/Search.scala
@@ -23,10 +23,7 @@ class Search(override val controllerComponents: AuthControllerComponents, userMa
   def search() = ApiAction.attempt { req: UserIdentityRequest[_] =>
     val q = req.queryString.getOrElse("q", Seq("")).head
     val proposedParams = Search.buildSearchParameters(q, req)
-    logger.info(s"searching. workspace context is ${proposedParams.workspaceContext.isDefined}")
-    if (proposedParams.workspaceContext.isDefined){
-      logger.info(req.user.asLogMarker, "Performing workspace search")
-    }
+    proposedParams.workspaceContext.map(wc => logger.info(req.user.asLogMarker, s"Performing workspace search"))
 
     buildSearch(req.user, proposedParams, proposedParams.workspaceContext).flatMap { case (verifiedParams, context) =>
       val returnEmptyResult = Search.shouldReturnEmptyResult(proposedParams, verifiedParams, context)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds a log with user email when they perform a workspace search

## Why
We would like to know how much this new feature is used