### PR TITLE
update build runner to the giant one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   CI:
-    runs-on: 4core-ubuntu-latest-arm-coverdrop
+    runs-on: 4core-ubuntu-latest-arm-giant
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of this PR https://github.com/guardian/giant/pull/220 we updated the build action config to use an arm based runner but the name of the runner was `4core-ubuntu-latest-arm-coverdrop`. We then created another runner without the coverdrop in its title, and this PR is the change in build config to use the new runner `4core-ubuntu-latest-arm-giant` 
