### PR TITLE
fix the breaking change in http-proxy-middleware upgrade

### DIFF
--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -3,7 +3,7 @@ const { createProxyMiddleware }  = require('http-proxy-middleware');
 // We must manually configure our own proxy as the default behaviour
 // (proxy everything without `Accept: text-html`) breaks PDF preview
 module.exports = function(app) {
-  app.use('/api', createProxyMiddleware({ target: 'http://localhost:9001/', changeOrigin: true }));
-  app.use('/setup', createProxyMiddleware({ target: 'http://localhost:9001/', changeOrigin: true }));
-  app.use('/third-party', createProxyMiddleware({ target: 'http://localhost:9001/', changeOrigin: true }));
+  app.use('/api', createProxyMiddleware({ target: 'http://localhost:9001/api', changeOrigin: true }));
+  app.use('/setup', createProxyMiddleware({ target: 'http://localhost:9001/setup', changeOrigin: true }));
+  app.use('/third-party', createProxyMiddleware({ target: 'http://localhost:9001/third-party', changeOrigin: true }));
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The version upgrade of `http-proxy-middleware` in this PR https://github.com/guardian/giant/pull/222 was causing issues in local run and couldn't proxy the requests to the correct target. This is because of a breaking change in V3 as explained in https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md#removed-requrl-patching  that When proxy is mounted on a path, this path should be provided in the target. 
```
// before
app.use('/user', proxy({ target: 'http://www.example.org' }));

// after
app.use('/user', proxy({ target: 'http://www.example.org/user' }));
```