### PR TITLE
upgrade elastic/charts from v57 to v66

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "giant-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@elastic/charts": "57.0.0",
+        "@elastic/charts": "66.1.0",
         "@elastic/datemath": "^5.0.3",
         "@elastic/eui": "77.2.0",
         "@emotion/css": "^11.11.2",
@@ -2494,13 +2494,13 @@
       }
     },
     "node_modules/@elastic/charts": {
-      "version": "57.0.0",
-      "resolved": "https://registry.npmjs.org/@elastic/charts/-/charts-57.0.0.tgz",
-      "integrity": "sha512-MBfPsRasEJX+OsbFk6DWEbajyKPb3aCYh5FBdvsvoIea4m76pFPjG4N0gZarRHTkkDTv6h+hiSjya0pkkyaqgA==",
+      "version": "66.1.0",
+      "resolved": "https://registry.npmjs.org/@elastic/charts/-/charts-66.1.0.tgz",
+      "integrity": "sha512-oiNsCFfuqZCrDMmPX8RlGEtULhddOJFkN8pxNavD9x9JIwSB6R0gaw29aWJxwnUeROwq241yDijaOpXmIo/lQQ==",
       "dependencies": {
-        "@popperjs/core": "^2.4.0",
+        "@popperjs/core": "^2.11.8",
         "bezier-easing": "^2.1.0",
-        "chroma-js": "^2.1.0",
+        "chroma-js": "^2.4.2",
         "classnames": "^2.2.6",
         "d3-array": "^1.2.4",
         "d3-cloud": "^1.2.5",
@@ -2514,7 +2514,6 @@
         "react-redux": "^7.1.0",
         "redux": "^4.0.4",
         "reselect": "^4.0.0",
-        "resize-observer-polyfill": "^1.5.1",
         "ts-debounce": "^4.0.0",
         "utility-types": "^3.10.0",
         "uuid": "^9"
@@ -18937,11 +18936,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
-    },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@elastic/charts": "57.0.0",
+    "@elastic/charts": "66.1.0",
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "77.2.0",
     "@emotion/css": "^11.11.2",

--- a/frontend/src/js/components/SearchResults/visualizations/TimeHistogram.js
+++ b/frontend/src/js/components/SearchResults/visualizations/TimeHistogram.js
@@ -94,6 +94,11 @@ export default class TimeHistogram extends React.Component {
                     <EuiSettings
                         showLegend={false}
                         onElementClick={(event) => queryByDate(event[0][0].datum)}
+                        theme={{
+                            background: {
+                                color: "transparent"
+                            }                   
+                        }}
                     />
                     <Tooltip
                         headerFormatter={(tooltipData) => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Upgrade elastic/charts from `v57.0.0` to `v66.1.0`. The only usage of this dependancy is in `TimeHistogram.js` and the upgrade does not have any breaking changes in our code base apart from the chart colour which I fixed. 

I updated this as an attempt to fix the `d3-color` vulnerability in https://github.com/guardian/giant/security/dependabot/2 that's suggesting the vulnerable version is introduced by elastic/charts. But it seems that this vulnerebility is also introduced by `d3-scale` which is also a sub dependancy of the latest version of elastic/charts. So this change doesn't seem to be fixing the main issue  of d3-color vulnerability. But it's still good to have the most recent version 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
tested locally