### PR TITLE
Make the arm64 neo4j container the default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   neo4j:
-    image: ${NEO4J_IMAGE_OVERRIDE:-neo4j:3.4.0}
+    image: ${NEO4J_IMAGE_OVERRIDE:-neo4j/neo4j-arm64-experimental:3.5.30}
     container_name: pfi-neo4j
     environment:
       NEO4J_AUTH: neo4j/bob

--- a/scripts/start-backend.sh
+++ b/scripts/start-backend.sh
@@ -4,9 +4,9 @@ SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 
 ARCHITECTURE=$(uname -m)
 
-if [ "$ARCHITECTURE" == "arm64" ]; then
-  echo "Running on arm64 architecture - using experimental neo4j arm64 image."
-  export NEO4J_IMAGE_OVERRIDE=neo4j/neo4j-arm64-experimental:3.5.30
+if [ "$ARCHITECTURE" != "arm64" ]; then
+  echo "Running on x86 architecture - using standard neo4j image image."
+  export NEO4J_IMAGE_OVERRIDE=neo4j:3.4.0
 fi
 
 if (! docker stats --no-stream 1>/dev/null 2>&1); then


### PR DESCRIPTION
## What does this change?

All developers on the team are using apple silicon.This change makes the arm version of the neo4j image the default, which means we'll be able to run `docker-compose up` without having to set the NEO4J_OVERRIDE environment variable 

## How to test
Tested on my local machine. This should have no impact on playground/prod