### PR TITLE
attempt to render 2000 children in workspace tree

### DIFF
--- a/frontend/src/js/util/resourceUtils.ts
+++ b/frontend/src/js/util/resourceUtils.ts
@@ -2,7 +2,7 @@ import { BasicResource, BasicResourceWithSingleBlobChild, HighlightableText, Res
 import { HighlightsState } from '../types/redux/GiantState';
 
 // safety-valve against a large flat structure slowing down the browser
-export const MAX_NUMBER_OF_CHILDREN = 1100;
+export const MAX_NUMBER_OF_CHILDREN = 2000;
 
 export function hasSingleBlobChild(resource: BasicResource): resource is BasicResourceWithSingleBlobChild {
     return !!(


### PR DESCRIPTION
## What does this change?

Bumps the max number of children in a tree viewer to 2000.

## Why?

We have an important workspace with too many entries per directory.