### PR TITLE
bump path-to-regex to a safe version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16089,9 +16089,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "dependencies": {
         "isarray": "0.0.1"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,11 @@
     "@types/uuid": "^3.4.8",
     "react-scripts": "5.0.1"
   },
+  "overrides" :{
+    "react-router": {
+      "path-to-regexp": "1.9.0"
+    }
+  },
   "scripts": {
     "start": "GENERATE_SOURCEMAP=false react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
## What does this change?

Apply an override to the `path-to-regex` dependency to address a dependabot issue. Similar to: https://github.com/guardian/giant/pull/244/files but will survive recreation of the lock file.

## How to test

Gonna do that manually.
