### PR TITLE
support zip for output of transcription service

### DIFF
--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -19,8 +19,8 @@ case class SignedUrl(url: String, key: String)
 object SignedUrl {
   implicit val formats = Json.format[SignedUrl]
 }
-case class OutputBucketUrls(text: SignedUrl, srt: SignedUrl, json: SignedUrl)
-case class OutputBucketKeys(text: String, srt: String, json: String)
+case class OutputBucketUrls(zip: SignedUrl)
+case class OutputBucketKeys(zip: String)
 case class TranscriptionJob(id: String, originalFilename: String, inputSignedUrl: String, sentTimestamp: String,
                             userEmail: String, transcriptDestinationService: String, outputBucketUrls: OutputBucketUrls,
                             languageCode: String, translate: Boolean, translationOutputBucketUrls: OutputBucketUrls,
@@ -118,19 +118,13 @@ class ExternalTranscriptionExtractor(index: Index, transcribeConfig: TranscribeC
   override def priority = 2
 
   private def getOutputBucketUrls(blobUri: String): Either[Failure, OutputBucketUrls] = {
-    val srtKey = s"srt/$blobUri.srt"
-    val jsonKey = s"json/$blobUri.json"
-    val textKey = s"text/$blobUri.txt"
+    val zipKey = s"zip/$blobUri.zip"
 
     val bucketUrls = for {
-      srt <- outputStorage.getUploadSignedUrl(srtKey)
-      json <- outputStorage.getUploadSignedUrl(jsonKey)
-      text <- outputStorage.getUploadSignedUrl(textKey)
+      zip <- outputStorage.getUploadSignedUrl(zipKey)
     } yield {
       OutputBucketUrls(
-        SignedUrl(text, textKey),
-        SignedUrl(srt, srtKey),
-        SignedUrl(json, jsonKey)
+        SignedUrl(zip, zipKey),
       )
     }
 


### PR DESCRIPTION
this is as a result of a change in transcription service in https://github.com/guardian/transcription-service/pull/122

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
