### PR TITLE
Hotfix type error in download modal

### DIFF
--- a/frontend/src/js/components/viewer/DownloadModal.js
+++ b/frontend/src/js/components/viewer/DownloadModal.js
@@ -169,7 +169,7 @@ Email Body:
             types.push({value: 'preview', label: 'PDF Preview'});
         }
 
-        if (this.props.resource.text.contents) {
+        if (this.props.resource.text && this.props.resource.text.contents) {
             types.push({value: 'extractedText', label: 'Extracted Text'});
         }
 


### PR DESCRIPTION
## What does this change?
Fixes type error in DownloadModal component when props.resource.text is undefined

## How to test
Testing in prod
