### PR TITLE
Update to use jammy recipe for neo4j in riff-raff.yaml

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -22,7 +22,7 @@ deployments:
     parameters:
       amiEncrypted: true
       amiTags:
-        Recipe: investigations-neo4j
+        Recipe: investigations-neo4j-jammy
         AmigoStage: PROD
         Encrypted: pfi-playground
 


### PR DESCRIPTION
## What does this change?

Updates to use `investigations-neo4j-jammy` recipe as focal (20.04) is out of LTS

## How to test

Tested on playground. 

## TODO

Update in [`CreateStack.scala` in investigations platform ](https://github.com/guardian/investigations-platform/blob/c9f0a6a1e703959013237a8095abec82604026d1/giant-deploy/src/main/scala/com/gu/commands/CreateStack.scala#L25)

