### PR TITLE
Revert "Bump max upload size via ui to 300mb"

### DIFF
--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -6,7 +6,7 @@ play {
   }
 
   # When updating this value, also update MAX_FILE_UPLOAD_SIZE_MBYTES in UploadFiles.tsx
-  http.parser.maxDiskBuffer = 300MB
+  http.parser.maxDiskBuffer = 250MB
 
   # Disable CSRF if there is an Authorization header
   filters {

--- a/frontend/src/js/components/Uploads/UploadFiles.tsx
+++ b/frontend/src/js/components/Uploads/UploadFiles.tsx
@@ -20,7 +20,7 @@ import { getWorkspace } from '../../actions/workspaces/getWorkspace';
 import { useDispatch } from 'react-redux';
 import { AppActionType } from '../../types/redux/GiantActions';
 
-const MAX_FILE_UPLOAD_SIZE_MBYTES = 300 // should correspond to http.parser.maxDiskBuffer in application.conf
+const MAX_FILE_UPLOAD_SIZE_MBYTES = 250 // should correspond to http.parser.maxDiskBuffer in application.conf
 const MAX_FILE_UPLOAD_SIZE_BYTES = MAX_FILE_UPLOAD_SIZE_MBYTES*1024*1024
 
 


### PR DESCRIPTION
This reverts commit ee6ce182c16da6bd18a871761bdfca7b548bc76c - when messing around with the built in browser vscode I accidentally committed the change to main. oops! I'll enable branch protection now...