### PR TITLE
Increase default workspace column widths

### DIFF
--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -180,7 +180,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             name: 'Name',
             align: 'left' as const,
             style: {
-                width: '400px'
+                width: '500px'
             },
             render: (entry: TreeEntry<WorkspaceEntry>) => {
                 const workspaceId = this.props.match.params.id;
@@ -212,7 +212,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             name: 'Added By',
             align: 'left' as const,
             style: {
-                width: '150px',
+                width: '170px',
             },
             render: (entry: TreeEntry<WorkspaceEntry>) =>
                 <React.Fragment>
@@ -262,7 +262,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             name: 'Processing Stage',
             align: 'center' as const,
             style: {
-                width: '120px',
+                width: '220px',
             },
             render: (entry: TreeEntry<WorkspaceEntry>) => (
                 this.renderStatus(entry)


### PR DESCRIPTION


## What does this change?

Increased default name, added by, and processing stage column widths

## How to test

It didn't look to me like this widths had any constraints on them (e.g. they have to fit in a div of a specific width) but I'm me so please check I'm not wrong. 


