### PR TITLE
Return size rather than addedOn date in size field of workspace API

### DIFF
--- a/backend/app/model/annotations/Workspace.scala
+++ b/backend/app/model/annotations/Workspace.scala
@@ -131,7 +131,7 @@ object WorkspaceEntry {
           mimeType = v.get("mimeType").asString(),
           // there are nodes in Playground where this is null, which breaks things
           // if I don't make it optional
-          size = v.get("addedOn").optionally(_.asLong()),
+          size = v.get("size").optionally(_.asLong()),
         )
       )
     }


### PR DESCRIPTION
## What does this change?
This fixes a bug where the giant workspace API uses the 'added on' date for the 'size' field, resulting in seemingly astronomical reported file sizes by the workspace API

## How to test
Size definitely is a filed in neo4j, I'll just test on playground first...