### PR TITLE
Use correct string for transcription failure status

### DIFF
--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -76,8 +76,10 @@ object TranscriptionOutput {
   implicit val transcriptionOutputReads: Reads[TranscriptionOutput] = new Reads[TranscriptionOutput] {
     def reads(json: JsValue): JsResult[TranscriptionOutput] = {
       (json \ "status").as[String] match {
+        // NOTE: These statuses are defined in the transcription service:
+        // https://github.com/guardian/transcription-service/blob/main/packages/common/src/types.ts
         case "SUCCESS" => json.validate[TranscriptionOutputSuccess]
-        case "FAILURE" => json.validate[TranscriptionOutputFailure]
+        case "TRANSCRIPTION_FAILURE" => json.validate[TranscriptionOutputFailure]
         case other     => JsError(s"Unknown status type: $other")
       }
     }


### PR DESCRIPTION
## What does this change?
These strings are out of date - in https://github.com/guardian/transcription-service/pull/107 I changes the string text of the 'failure' status from FAILURE to TRANSCRIPTION_FAILURE. 

Currently this results in failure feedback from the transcription service failing to parse. 

I'm going to do a follow up PR to the transcription service to add a comment reminding us to keep giant/transcription service in sync.

Side note: this might happen a bit less if we used protobuf/thrift to do our models rather than duplicating them across the two projects. BUT, rule of three etc, maybe it's easier to keep the typescript/scala in sync for now...

## How to test
I wasn't going to bother testing this change as it is definitely broken now, and I'm confident this will solve the problem