### PR TITLE
Revert change to rerunFailedExtractorsForBlob

### DIFF
--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -996,7 +996,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
         |// we need DISTINCT because if there are multiple failures
         |// we'll get the blob and failedExtractor duplicated
         |WITH DISTINCT blob, failedExtractor
-        |MATCH (blob)<-[todo :TODO|:PROCESSING_EXTERNALLY]-(failedExtractor)
+        |MATCH (blob)<-[todo :TODO]-(failedExtractor)
         |WHERE todo.attempts > 0
         |SET todo.attempts = 0
         |""".stripMargin,


### PR DESCRIPTION
## What does this change?
This reverts commit ef471d210e81a149390fdea6c7b8b375948ec235, which was erroneously included in this PR https://github.com/guardian/giant/pull/267 (sorry)

I'll do a follow up PR with this change with a proper description etc, for now let's clean up main.