### PR TITLE
Tidy up highlighting for giant plain text view

### DIFF
--- a/frontend/src/stylesheets/components/_document.scss
+++ b/frontend/src/stylesheets/components/_document.scss
@@ -195,21 +195,12 @@
 
 result-highlight {
   position: relative;
-  display: inline-block;
   font-weight: bold;
   font-style: italic;
   z-index: 1;
-
-  &:before {
-      content: " ";
-      position:absolute;
-      width: calc(100% + 5px);
-      left: -3px;
-      top: 1px;
-      height: 100%;
-      z-index: -1;
-      background-color: $highlightColour;
-  }
+  background: linear-gradient(lighten($highlightColour, 20%)) 0/100% calc(16px) no-repeat;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 result-highlight.result-highlight--focused {
@@ -258,38 +249,6 @@ comment-highlight.comment-highlight--focused {
   &:before {
     background-color: hotpink;
   }
-}
-
-result-highlight {
-    position: relative;
-    display: inline-block;
-    font-weight: bold;
-    font-style: italic;
-    z-index: 1;
-
-    &:nth-of-type(4n-3)::before {
-        transform: rotate(-3deg);
-    }
-
-    &:nth-of-type(4n-2)::before {
-        transform: rotate(2deg);
-    }
-
-    &:nth-of-type(4n-1)::before {
-        transform: rotate(-1deg);
-    }
-
-    &:before {
-        content: " ";
-        position:absolute;
-        width: calc(100% + 5px);
-        left: -3px;
-        top: 1px;
-        height: 100%;
-        z-index: -1;
-        transform: rotate(2deg);
-        background-color: $highlightColour;
-    }
 }
 
 comment-highlight {


### PR DESCRIPTION
## What does this change?
I need to do a bit more history on this because it's possible that there was a very good reason highlighting was working the way it was before. BUT this pr fixes an issue where if you have a multi line highlight then the highlight messes up the flow of the text.

Heavily inspired by https://stackoverflow.com/questions/70008968/css-custom-text-highlight-that-works-across-multiple-lines

Before:
<img width="575" height="346" alt="Screenshot 2025-08-07 at 14 49 49" src="https://github.com/user-attachments/assets/1227971f-e08d-4926-9a95-bc99e44a34f4" />

After:
<img width="714" height="552" alt="Screenshot 2025-08-07 at 14 49 30" src="https://github.com/user-attachments/assets/58842e0d-2777-4cf9-9b05-fb0cc5912b8b" />

This pr also removes some duplicated code - result-highlight was repeated twice, looks like maybe an accident when it was moved from typography.scss to document.scss here https://github.com/guardian/pfi/pull/818


## How to test
I've tested this locally, will try out on playground as well