### PR TITLE
Don't make pfi-cli deploy artifacts public

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -60,3 +60,10 @@ deployments:
       bucket: pfi-playground-dist
       cacheControl: private
       publicReadAcl: false
+
+  pfi-public-downloads:
+    type: aws-s3
+    parameters:
+      bucket: investigations-public-dist
+      cacheControl: private
+      publicReadAcl: false


### PR DESCRIPTION
## What does this change?
Currently all giant deploys are being marked as failing. This is because we locked down the permissions of the bucket investigations-public-dist so that public ACLs aren't allowed

I think the idea with deploying the pfi-cli to this bucket was to make it easier to grab a recent version of the cli to perform an ingest. These days allowing public ACLs for objects in s3 buckets triggers FSBP related warnings from security hub. 

## How to test
I've tested this and verified that the deploy no longer has a big ugly error. Here's a previous error example https://riffraff.gutools.co.uk/deployment/view/f60886c9-2aad-4828-ace5-12b80570750e