### PR TITLE
Don't fail external reprocess job if there are no errors to reprocess.

### DIFF
--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -1057,7 +1057,9 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
       val relationshipsDeleted = counters.relationshipsDeleted()
       val propertiesSet = counters.propertiesSet()
 
-      if (relationshipsDeleted  < 1 || propertiesSet < 1 ) {
+      // if the blob has an EXTRACTION_FAILURE relation then that will be deleted and we expect to set at least one property
+      // (1 property if there is a TODO, more if there's a PROCESSING_EXTERNALLY relation to replace with a TODO)
+      if (relationshipsDeleted != 0 && propertiesSet < 1 ) {
         Attempt.Left(IllegalStateFailure(
           s"When re-running failed external extractors for blob ${uri.value}, ${relationshipsDeleted} relations were deleted and ${propertiesSet} TODOs had their attempts reset to 0. We expected at least one EXTRACTION_FAILED relation to be deleted and one counter reset."
         ))

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -1061,7 +1061,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
       // (1 property if there is a TODO, more if there's a PROCESSING_EXTERNALLY relation to replace with a TODO)
       if (relationshipsDeleted != 0 && propertiesSet < 1 ) {
         Attempt.Left(IllegalStateFailure(
-          s"When re-running failed external extractors for blob ${uri.value}, ${relationshipsDeleted} relations were deleted and ${propertiesSet} TODOs had their attempts reset to 0. We expected at least one EXTRACTION_FAILED relation to be deleted and one counter reset."
+          s"When re-running failed external extractors for blob ${uri.value}, ${relationshipsDeleted} relations were deleted and ${propertiesSet} properties were set. Where an EXTRACTION_FAILED relation to an external extractor exists, we expect at least one relation to be deleted and one counter reset."
         ))
       }  else {
         logger.info(


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/giant/pull/275 introduced a bug where if you send a file (blob) for reprocessing that doesn't have an EXTRACTION_FAILURE relation with an external extractor then an error is returned every time. This resolves that by changing the error condition - if we haven't deleted any relations then we don't have to worry about how many counters were reset.

## How to test
Reprocessing is completely broken on PROD right now, this will fix that
