### PR TITLE
Fix reprocessing for external ingest jobs - break up rerunFailedExternalExtractorsForBlob

### DIFF
--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -1048,7 +1048,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
       """
         |MATCH (blob :Blob:Resource {uri: {uri}})<-[failure :EXTRACTION_FAILURE]-(failedExtractor :Extractor {external: true})
         |MATCH (blob)<-[processing_externally :PROCESSING_EXTERNALLY]-(failedExtractor)
-        |MERGE (blob)<-[todo:TODO]-(extractor)
+        |MERGE (blob)<-[todo:TODO]-(failedExtractor)
         |ON CREATE SET todo = processing_externally, todo.attempts = 0
         |DELETE processing_externally
       """.stripMargin,


### PR DESCRIPTION
## What does this change?
This PR aims to get reprocessing worked for failed external transcription jobs. It hopefully does a better job of what https://github.com/guardian/giant/pull/275 should have done.

What it does is take each of the 3 cypher queries that were previously bundled up into one neo4j request in rerunFailedExternalExtractorsForBlob, and pull them out into a separate function with separate error handling. This is good because:

 - it fixes a bug where if a blob had no TODO relation to the extractor then the reprocessing would fail
 - The error messaging is more precise about what's gone wrong - whereas previously with all 3 queries bundled up into the same request we could only make vague assertions about what should/shouldn't happen. 

## How to test
I've tested this on playground using files in this workspace https://playground.pfi.gutools.co.uk/workspaces/146ace05-76b0-4a7a-8a17-78742074b20d
