### PR TITLE
Gracefully handle multiple transcription_success messages

### DIFF
--- a/backend/app/extraction/ExternalTranscriptionWorker.scala
+++ b/backend/app/extraction/ExternalTranscriptionWorker.scala
@@ -143,6 +143,7 @@ class ExternalTranscriptionWorker(manifest: WorkerManifest, amazonSQSClient: Ama
         Left(ExternalTranscriptionOutputFailure.apply(s"External transcription service failed to transcribe the file ${output.originalFilename}"))
 
       case JsError(errors) =>
+        logger.error(s"Failed to parse transcription output message: ${message.getBody}, errors: ${errors.mkString(", ")}")
         Left(JsonParseFailure(errors))
     }
   }


### PR DESCRIPTION
## What does this change?
There is a (I think rare) but possible situation where this can happen:
 - a file is uploaded to giant and transcribed externally, resulting in a relation like this:

<img width="434" height="143" alt="Screenshot 2025-08-21 at 16 46 45" src="https://github.com/user-attachments/assets/031c06b1-7147-4233-ba54-0e803e12ecf4" />

If the file is sent for reprocessing **twice**, then that relation will be replaced with a PROCESSING_EXTERNALLY relation and two transcription workers will be spun up for each reprocess job.

Both workers will finish, and then post messages on the SQS queue with the completed transcript. The first one will be happily received by giant, the next would (currently) result in an error like this:

`Failed to mark '<URI>' processed by ExternalTranscriptionExtractor as complete: Unexpected number of creates/deletes in markAsComplete. Created: 0. Deleted: 0`

Now, various things have gone wrong here - how was the file sent for reprocessing twice? Shouldn't the reprocess function detect that the file is already being processed and stop? I think maybe not - it's always nice to have the option of saying "I don't care what's happening right now, do it again" as giant ingest jobs should be idempotent. 

I think that giant should gracefully handle situations where it gets multiple success messages for the same file, which is what this PR achieves.


## How to test
I've tested this locally, there are a lot of examples on PROD currently we can try it out with