### PR TITLE
Use combined transcript file from transcription service

### DIFF
--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -14,8 +14,9 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.MapHasAsJava
 
+// NOTE: these types need to be kept in sync with the corresponding types in the transcription service:
+// https://github.com/guardian/transcription-service/blob/main/packages/common/src/types.ts
 case class SignedUrl(url: String, key: String)
-
 object SignedUrl {
   implicit val formats = Json.format[SignedUrl]
 }
@@ -37,7 +38,6 @@ object TranscriptionJob {
   implicit val combinedOutputUrlFormat = Json.format[CombinedOutputUrl]
   implicit val formats = Json.format[TranscriptionJob]
 }
-
 case class TranscriptionMetadata(detectedLanguageCode: String)
 case class Transcripts(srt: String, text: String, json: String)
 case class TranscriptionResult(transcripts: Transcripts, transcriptTranslations: Option[Transcripts], metadata: TranscriptionMetadata)

--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -34,19 +34,16 @@ object OutputBucketKeys {
   implicit val formats = Json.format[OutputBucketKeys]
 }
 object TranscriptionJob {
+  implicit val combinedOutputUrlFormat = Json.format[CombinedOutputUrl]
   implicit val formats = Json.format[TranscriptionJob]
 }
 
 case class TranscriptionMetadata(detectedLanguageCode: String)
 case class Transcripts(srt: String, text: String, json: String)
 case class TranscriptionResult(transcripts: Transcripts, transcriptTranslations: Option[Transcripts], metadata: TranscriptionMetadata)
-object TranscriptionMetadata {
-  implicit val formats = Json.format[TranscriptionMetadata]
-}
-object Transcripts {
-  implicit val formats = Json.format[Transcripts]
-}
 object TranscriptionResult {
+  implicit val metadataFormat = Json.format[TranscriptionMetadata]
+  implicit val transcriptsFormat = Json.format[Transcripts]
   implicit val formats = Json.format[TranscriptionResult]
 }
 

--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -36,6 +36,19 @@ object TranscriptionJob {
   implicit val formats = Json.format[TranscriptionJob]
 }
 
+case class TranscriptionMetadata(detectedLanguageCode: String)
+case class Transcripts(srt: String, text: String, json: String)
+case class TranscriptionResult(transcripts: Transcripts, transcriptTranslations: Option[Transcripts], metadata: TranscriptionMetadata)
+object TranscriptionMetadata {
+  implicit val formats = Json.format[TranscriptionMetadata]
+}
+object Transcripts {
+  implicit val formats = Json.format[Transcripts]
+}
+object TranscriptionResult {
+  implicit val formats = Json.format[TranscriptionResult]
+}
+
 sealed trait TranscriptionOutput {
   def id: String
   def originalFilename: String
@@ -52,6 +65,7 @@ case class TranscriptionOutputSuccess(
                                           status: String = "SUCCESS",
                                           languageCode: String,
                                           outputBucketKeys: OutputBucketKeys,
+                                          combinedOutputKey: String,
                                           translationOutputBucketKeys: Option[OutputBucketKeys]
                                         ) extends TranscriptionOutput
 

--- a/backend/app/extraction/ExternalTranscriptionWorker.scala
+++ b/backend/app/extraction/ExternalTranscriptionWorker.scala
@@ -17,7 +17,6 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.util.Try
 
 case class TranscriptionMessageAttribute(receiveCount: Int, messageGroupId: String)
-case class TranscriptionTexts(transcript: String, translation: Option[String])
 
 class ExternalTranscriptionWorker(manifest: WorkerManifest, amazonSQSClient: AmazonSQS, transcribeConfig: TranscribeConfig, blobStorage: ObjectStorage, index: Index)(implicit executionContext: ExecutionContext)  extends Logging{
 

--- a/backend/app/extraction/TranscriptionExtractor.scala
+++ b/backend/app/extraction/TranscriptionExtractor.scala
@@ -53,7 +53,7 @@ class TranscriptionExtractor(index: Index, scratchSpace: ScratchSpace, transcrib
 
     val result = Either.catchNonFatal{
       val convertedFile = FfMpeg.convertToWav(file.toPath, ffMpegTmpDir)
-      val transcriptResult: TranscriptionResult = Whisper.invokeWhisper(convertedFile, transcribeConfig, tmpDir, stdErrLogger, translate = false)
+      val transcriptResult: WhisperResult = Whisper.invokeWhisper(convertedFile, transcribeConfig, tmpDir, stdErrLogger, translate = false)
       val translationResult = if (transcriptResult.language != "en") Some(Whisper.invokeWhisper(convertedFile, transcribeConfig, tmpDir, stdErrLogger, translate = true)) else None
 
       index.addDocumentTranscription(blob.uri, transcriptResult.text, translationResult.map(r => r.text), Languages.getByIso6391Code(transcriptResult.language)

--- a/backend/app/utils/Whisper.scala
+++ b/backend/app/utils/Whisper.scala
@@ -6,7 +6,7 @@ import java.nio.file.Path
 import scala.io.Source
 import scala.sys.process._
 
-case class TranscriptionResult(text: String, language: String)
+case class WhisperResult(text: String, language: String)
 
 object Whisper extends Logging {
   private class WhisperSubprocessCrashedException(exitCode: Int, stderr: String) extends Exception(s"Exit code: $exitCode: ${stderr}")
@@ -21,7 +21,7 @@ object Whisper extends Logging {
     outputText
   }
 
-  def invokeWhisper(audioFilePath: Path, config: TranscribeConfig, tmpDir: Path, whisperLogger: BasicStdErrLogger, translate: Boolean): TranscriptionResult = {
+  def invokeWhisper(audioFilePath: Path, config: TranscribeConfig, tmpDir: Path, whisperLogger: BasicStdErrLogger, translate: Boolean): WhisperResult = {
     val tempFile = tmpDir.resolve(s"${audioFilePath.getFileName}")
 
     val translateParam = if(translate) "--translate" else ""
@@ -34,10 +34,10 @@ object Whisper extends Logging {
         val languageSplit = whisperLogger.getOutput.split("auto-detected language: ")
         if (languageSplit.length > 1) {
           val detectedLanguage = if (translate) "en" else languageSplit(1).slice(0,2).mkString("")
-          TranscriptionResult(transcriptText, detectedLanguage)
+          WhisperResult(transcriptText, detectedLanguage)
         } else {
           logger.warn("Failed to detect language - transcription may have failed. Falling back to english.")
-          TranscriptionResult(transcriptText, "en")
+          WhisperResult(transcriptText, "en")
         }
       case _ =>
         logger.error("Whisper extraction failed")


### PR DESCRIPTION
## What does this change?
This PR gets giant to make use of the new 'combined output' file added to the transcription service output in https://github.com/guardian/transcription-service/pull/167 

As well as simplifying some of our types (no longer need for the 'bucketurls' types with srt/txt/json), this change will make it easy to start storing other output types from the transcription tool in giant. In particular we're interested in subtitle formats, which will enable us to add subtitles to giant's video player and to see the timecode of matches for giant searches. 

## How to test
I've tested this by deploying to playground, it's a bit of an 'all or nothing' change so I am fairly confident that it will work.
