### PR TITLE
Don't fail markAsComplete if there is already a failure relationship

### DIFF
--- a/backend/app/extraction/Worker.scala
+++ b/backend/app/extraction/Worker.scala
@@ -149,7 +149,7 @@ class Worker(
 
   private def markExternalAsProcessing(params: ExtractionParams, blob: Blob, extractor: Extractor): Unit = {
     manifest.markExternalAsProcessing(params, blob, extractor).leftMap { failure =>
-      logger.error(s"Failed to mark '${blob.uri.value}' processed by '${extractor.name}' as complete: ${failure.msg}")
+      logger.error(s"Failed to mark '${blob.uri.value}' processed by '${extractor.name}' as processing: ${failure.msg}")
     }
   }
 

--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -619,7 +619,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
       val counters = result.summary().counters()
 
       if (counters.relationshipsCreated() != 1 || counters.relationshipsDeleted() != 1) {
-        Left(IllegalStateFailure(s"Unexpected number of creates/deletes in markAsComplete. Created: ${counters.relationshipsCreated()}. Deleted: ${counters.relationshipsDeleted()}"))
+        Left(IllegalStateFailure(s"Unexpected number of creates/deletes in external markAsComplete. Created: ${counters.relationshipsCreated()}. Deleted: ${counters.relationshipsDeleted()}"))
       } else {
         Right(())
       }
@@ -671,7 +671,10 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
 
     val counters = result.summary().counters()
 
-    if(counters.relationshipsCreated() != 1 || counters.relationshipsDeleted() != 1) {
+    if (counters.relationshipsCreated != 1 && counters.relationshipsDeleted() == 1) {
+      logger.warn(s"Deleted TODO but didn't create a PROCESSED relationship in markAsComplete for blob ${blob.uri.value} / extractor ${extractor.name}. This may be because it was already marked as PROCESSED.")
+      Right(())
+    } else if(counters.relationshipsCreated() != 1 || counters.relationshipsDeleted() != 1) {
       Left(IllegalStateFailure(s"Unexpected number of creates/deletes in markAsComplete. Created: ${counters.relationshipsCreated()}. Deleted: ${counters.relationshipsDeleted()}"))
     } else {
       Right(())
@@ -726,7 +729,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
     val counters = result.summary().counters()
 
     if (counters.relationshipsCreated() != 1 || counters.relationshipsDeleted() != 1) {
-      Left(IllegalStateFailure(s"Unexpected number of creates/deletes in markAsComplete. Created: ${counters.relationshipsCreated()}. Deleted: ${counters.relationshipsDeleted()}"))
+      Left(IllegalStateFailure(s"Unexpected number of creates/deletes in external markAsComplete. Created: ${counters.relationshipsCreated()}. Deleted: ${counters.relationshipsDeleted()}"))
     } else {
       Right(())
     }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Giant is getting into an infinite loop when it tries to markAsComplete a blob in this situation:

<img width="552" height="399" alt="Screenshot 2025-09-04 at 17 38 12" src="https://github.com/user-attachments/assets/859c87b2-5c23-4b53-a10e-3ca2231a065a" />

We have millions of errors like this in the logs:

Failed to mark 'URI' processed by 'OcrMyPdfImageExtractor' as complete: Unexpected number of creates/deletes in markAsComplete. Created: 0. Deleted: 1

In this scenario, when markAsComplete returns a `Left` then the whole transaction gets rolled back, the TODO remains, and giant tries to run the extractor again. sad times. 

This PR gets giant to just WARN instead of rolling back the whole transaction.

Leaving this in draft as some team discussion and further digging to understand how we got into this state required I think.

## How to test
