### PR TITLE
Set external transcription engine to whisperx

### DIFF
--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -27,7 +27,7 @@ case class CombinedOutputUrl(url: String, key: String)
 case class TranscriptionJob(id: String, originalFilename: String, inputSignedUrl: String, sentTimestamp: String,
                             userEmail: String, transcriptDestinationService: String, outputBucketUrls: OutputBucketUrls,
                             combinedOutputUrl: CombinedOutputUrl, languageCode: String, translate: Boolean,
-                            translationOutputBucketUrls: OutputBucketUrls, diarize: Boolean = false, engine: String = "whisperx")
+                            translationOutputBucketUrls: OutputBucketUrls, diarize: Boolean, engine: String)
 object OutputBucketUrls {
   implicit val formats = Json.format[OutputBucketUrls]
 }
@@ -177,7 +177,9 @@ class ExternalTranscriptionExtractor(index: Index, transcribeConfig: TranscribeC
         combinedOutputUrl = CombinedOutputUrl(url = combinedOutputUrl,key = combinedOutputKey),
         languageCode = "auto",
         translate = true,
-        translationOutputBucketUrls = translationOutputSignedUrls)
+        translationOutputBucketUrls = translationOutputSignedUrls,
+        diarize = false,
+        engine = "whisperx")
     }
 
     transcriptionJob.flatMap {

--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -27,7 +27,7 @@ case class CombinedOutputUrl(url: String, key: String)
 case class TranscriptionJob(id: String, originalFilename: String, inputSignedUrl: String, sentTimestamp: String,
                             userEmail: String, transcriptDestinationService: String, outputBucketUrls: OutputBucketUrls,
                             combinedOutputUrl: CombinedOutputUrl, languageCode: String, translate: Boolean,
-                            translationOutputBucketUrls: OutputBucketUrls, diarize: Boolean = false, engine: String = "whispercpp")
+                            translationOutputBucketUrls: OutputBucketUrls, diarize: Boolean = false, engine: String = "whisperx")
 object OutputBucketUrls {
   implicit val formats = Json.format[OutputBucketUrls]
 }


### PR DESCRIPTION
## What does this change?
We've been having some problems with our whisper.cpp transcription service, so let's switch giant to using whisperx.

Deployments steps:
 - Deploy this change
<hope that no audio/video files get uploaded to giant here>
 - update the param /pfi/pfi-giant/rex/transcribe/transcriptionServiceQueueUrl to the correct queue


## How to test
Tested on playground, it seems to work - although there's a 12 minute startup penalty for the whisperx runners unfortunately