### PR TITLE
Remove message group id for remote ingest sqs messages

### DIFF
--- a/backend/app/model/ingestion/RemoteIngest.scala
+++ b/backend/app/model/ingestion/RemoteIngest.scala
@@ -36,7 +36,6 @@ object RemoteIngest extends Logging {
     val sendMessageRequest = new SendMessageRequest()
       .withQueueUrl(config.taskQueueUrl)
       .withMessageBody(jobJson)
-      .withMessageGroupId(job.id)
     try {
       amazonSQSClient.sendMessage(sendMessageRequest)
       Right(job.id)


### PR DESCRIPTION
## What does this change?
In preparation for de-fifoing the media download service task queue, this PR gets rid of the message group id from messages giant sends to the media download service. The message group id is used to determine message ordering in a FIFO queue. 

## How to test
The easiest way to test would be to:
 - First make sure https://github.com/guardian/transcription-service/pull/199 has been merged
 - Update /pfi/pfi-playground/rex/mediaDownload/taskQueueUrl
 - Update https://github.com/guardian/giant/pull/286 so that it includes the changes in this PR then deploy to playground
 - Test that remote ingest is still working on playground

Depends on https://github.com/guardian/transcription-service/pull/199