### PR TITLE
bubble up counts of files, folders, processing tasks and failures up the tree of nodes

### DIFF
--- a/backend/app/model/annotations/Workspace.scala
+++ b/backend/app/model/annotations/Workspace.scala
@@ -56,7 +56,12 @@ sealed trait WorkspaceEntry {
 case class WorkspaceNode(
   addedBy: PartialUser,
   addedOn: Option[Long],
-  maybeParentId: Option[String]
+  maybeParentId: Option[String],
+
+  descendantsLeafCount: Long,
+  descendantsNodeCount: Long,
+  descendantsProcessingTaskCount: Long,
+  descendantsFailedCount: Long
 ) extends WorkspaceEntry
 
 case class WorkspaceLeaf(
@@ -113,6 +118,10 @@ object WorkspaceEntry {
           addedBy = createdBy,
           addedOn = v.get("addedOn").optionally(_.asLong()),
           maybeParentId = maybeParentId,
+          descendantsLeafCount = 0,
+          descendantsNodeCount = 0,
+          descendantsProcessingTaskCount = 0,
+          descendantsFailedCount = 0,
         ),
         children = List.empty
       )

--- a/backend/test/services/index/SearchContextTest.scala
+++ b/backend/test/services/index/SearchContextTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.must.Matchers
 
 class SearchContextTest extends AnyFreeSpec with Matchers {
   val barry = PartialUser("barry", "Barry")
-  val folder = WorkspaceNode(barry, None, None)
+  val folder = WorkspaceNode(barry, None, None, 0, 0, 0, 0)
 
   def leaf(uri: String): WorkspaceLeaf =
     WorkspaceLeaf(barry, None, None, ProcessingStage.Processed, uri, "text/test", None)

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -29,7 +29,7 @@ import DocumentIcon from 'react-icons/lib/ti/document';
 import {Icon, Loader, Menu, Popup} from 'semantic-ui-react';
 import WorkspaceSummary from './WorkspaceSummary';
 import {ColumnsConfig, isTreeLeaf, isTreeNode, TreeEntry, TreeLeaf} from '../../types/Tree';
-import {isWorkspaceLeaf, Workspace, WorkspaceEntry} from '../../types/Workspaces';
+import {isWorkspaceLeaf, isWorkspaceNode, Workspace, WorkspaceEntry} from '../../types/Workspaces';
 import { GiantState } from '../../types/redux/GiantState';
 import { GiantDispatch } from '../../types/redux/GiantDispatch';
 import DetectClickOutside from '../UtilComponents/DetectClickOutside';
@@ -119,7 +119,9 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                     return <DocumentIcon className="file-browser__icon" />;
             }
         }
-
+        else if(isWorkspaceNode(entry.data) && entry.data.descendantsProcessingTaskCount > 0) {
+          return <Loader active inline size="tiny" className="file-browser__icon" />;
+        }
     };
 
   renderReprocessIcon = (entry: TreeEntry<WorkspaceEntry>) => {
@@ -173,6 +175,15 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
           </React.Fragment>
       )
     }
+    else if (isWorkspaceNode(entry.data)){
+      return <>
+        {entry.data.descendantsProcessingTaskCount > 0 && <em>
+          {entry.data.descendantsProcessingTaskCount} task{entry.data.descendantsProcessingTaskCount > 1 && "s"} remaining{" "}
+        </em>}
+        {entry.data.descendantsProcessingTaskCount > 0 && entry.data.descendantsFailedCount > 0 && <>&nbsp;&amp;&nbsp;</>}
+        {entry.data.descendantsFailedCount > 0 && <em>{entry.data.descendantsFailedCount} failed</em>}
+      </>
+    }
     return (<></>)
   }
 
@@ -196,6 +207,12 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                 return <React.Fragment>
                     {this.renderIcon(entry)}
                     <ItemName canEdit={canEdit} id={entry.id} name={entry.name} onFinishRename={curryRename}/>
+                    {isWorkspaceNode(entry.data) && <span style={{marginLeft: "5px", fontSize: "smaller", color: "#8b8b8b"}}>
+                      ({entry.data.descendantsNodeCount === 0 && entry.data.descendantsLeafCount === 0
+                        ? 'empty'
+                        : `${entry.data.descendantsNodeCount} folders & ${entry.data.descendantsLeafCount} files`
+                      })
+                    </span>}
                 </React.Fragment>;
             },
             sort: (a: TreeEntry<WorkspaceEntry>, b: TreeEntry<WorkspaceEntry>) => {
@@ -263,7 +280,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             name: 'Processing Stage',
             align: 'center' as const,
             style: {
-                width: '220px',
+                width: '300px',
             },
             render: (entry: TreeEntry<WorkspaceEntry>) => (
                 this.renderStatus(entry)
@@ -440,7 +457,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
     onDeleteModalOpen = (isOpen: boolean) => {
         if (isOpen)
             this.setState({deleteModalContext: {entry: this.state.deleteModalContext.entry, isOpen, status: "unconfirmed"}});
-        else 
+        else
             this.setState({deleteModalContext: {entry: null, isOpen, status: "unconfirmed"}});
     }
 
@@ -466,11 +483,11 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
         }
     }
 
-    onDeleteItem = (workspaceId: string, entry: TreeEntry<WorkspaceEntry> | null) => () => {        
+    onDeleteItem = (workspaceId: string, entry: TreeEntry<WorkspaceEntry> | null) => () => {
         if (entry && isWorkspaceLeaf(entry.data)) {
             const deleteContext = this.state.deleteModalContext;
             this.setState({deleteModalContext: {...deleteContext, status: "doing"}});
-            this.props.deleteResourceFromWorkspace(workspaceId, entry.data.uri, this.onDeleteCompleteHandler);            
+            this.props.deleteResourceFromWorkspace(workspaceId, entry.data.uri, this.onDeleteCompleteHandler);
             this.props.resetFocusedAndSelectedEntries();
         }
     }
@@ -580,7 +597,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             { key: "rename", content: "Rename", icon: "pen square" },
             { key: "remove", content: "Remove from workspace", icon: "trash" },
         ];
-        
+
         if (entry.data.addedBy.username === currentUser.username && isWorkspaceLeaf(entry.data)) {
             items.push({ key: "deleteOrRemove", content: "Delete file", icon: "trash" });
         }
@@ -762,13 +779,13 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                     )
                     : null
                 }
-                <DeleteModal 
-                    deleteItemHandler={this.onDeleteItem(this.props.match.params.id, this.state.deleteModalContext.entry)} 
-                    isOpen={this.state.deleteModalContext.isOpen} 
+                <DeleteModal
+                    deleteItemHandler={this.onDeleteItem(this.props.match.params.id, this.state.deleteModalContext.entry)}
+                    isOpen={this.state.deleteModalContext.isOpen}
                     setModalOpen={this.onDeleteModalOpen}
                     deleteStatus={this.state.deleteModalContext.status}
                     entry={this.state.deleteModalContext.entry}
-                />  
+                />
                 <RemoveFromWorkspaceModal
                     removeHandler={this.onRemoveFromWorkspace(this.props.match.params.id, this.state.removeFromWorkspaceModalContext.entry)}
                     isOpen={this.state.removeFromWorkspaceModalContext.isOpen}

--- a/frontend/src/js/types/Workspaces.ts
+++ b/frontend/src/js/types/Workspaces.ts
@@ -9,7 +9,12 @@ export interface BaseWorkspaceEntry {
     maybeParentId?: string
 }
 
-export interface WorkspaceNode extends BaseWorkspaceEntry {}
+export interface WorkspaceNode extends BaseWorkspaceEntry {
+    descendantsLeafCount:number;
+    descendantsNodeCount:number;
+    descendantsProcessingTaskCount:number;
+    descendantsFailedCount:number;
+}
 
 export interface WorkspaceLeaf extends BaseWorkspaceEntry {
     processingStage: ProcessingStage,
@@ -23,6 +28,10 @@ export type WorkspaceEntry = WorkspaceNode | WorkspaceLeaf
 
 export function isWorkspaceLeaf(workspaceEntry: WorkspaceEntry): workspaceEntry is WorkspaceLeaf {
     return (workspaceEntry as WorkspaceLeaf).uri !== undefined;
+}
+
+export function isWorkspaceNode(workspaceEntry: WorkspaceEntry): workspaceEntry is WorkspaceNode {
+    return !isWorkspaceLeaf(workspaceEntry);
 }
 
 export type WorkspaceMetadata = {

--- a/frontend/src/js/util/workspaceUtils.fixtures.ts
+++ b/frontend/src/js/util/workspaceUtils.fixtures.ts
@@ -1,4 +1,12 @@
-import { Workspace } from '../types/Workspaces';
+import {Workspace, WorkspaceNode} from '../types/Workspaces';
+
+const standardWorkspaceNodeData: WorkspaceNode = {
+    "addedBy": {"username": "joe", "displayName": "joe"},
+    descendantsNodeCount: 0,
+    descendantsLeafCount: 0,
+    descendantsProcessingTaskCount: 0,
+    descendantsFailedCount: 0
+}
 
 export const workspaceWithZeroProcessing: Workspace = {
     "id": "e174151c-c577-4abd-b52e-8d673f286a43",
@@ -63,7 +71,7 @@ export const workspaceWithZeroProcessing: Workspace = {
                                     }
                                 ],
                                 "data": {
-                                    "addedBy": {"username": "joe", "displayName": "joe"},
+                                    ...standardWorkspaceNodeData,
                                     "addedOn": 1570040730137
                                 },
                             },
@@ -121,7 +129,7 @@ export const workspaceWithZeroProcessing: Workspace = {
                             }
                         ],
                         "data": {
-                            "addedBy": {"username": "joe", "displayName": "joe"},
+                            ...standardWorkspaceNodeData,
                             "addedOn": 1570040729406
                         },
                     },
@@ -147,7 +155,7 @@ export const workspaceWithZeroProcessing: Workspace = {
                             "uri": "r4Yw9JKtZWhaGBIO_Z7zM9h4ave6RDQt7s5j1dKmyFZL2eiWtefSAxDl7M2uX9WHf8GpivuEwDWfK8nj5LW6-A",
                             "addedBy": {"username": "joe", "displayName": "joe"},
                             "mimeType": "application/pdf",
-                           "addedOn": 1570040729080,
+                            "addedOn": 1570040729080,
                             "processingStage": { type: 'processed' }
                         },
                     },
@@ -166,14 +174,12 @@ export const workspaceWithZeroProcessing: Workspace = {
                     }
                 ],
                 "data": {
-                    "addedBy": {"username": "joe", "displayName": "joe"},
+                    ...standardWorkspaceNodeData,
                     "addedOn": 1570040728798
                 },
             }
         ],
-        "data": {
-            "addedBy": {"username": "joe", "displayName": "joe"}
-        },
+        "data": standardWorkspaceNodeData,
     }
 };
 
@@ -240,7 +246,7 @@ export const workspaceWithOneProcessing: Workspace = {
                                     }
                                 ],
                                 "data": {
-                                    "addedBy": {"username": "joe", "displayName": "joe"},
+                                    ...standardWorkspaceNodeData,
                                     "addedOn": 1570040730137
                                 },
                             },
@@ -298,7 +304,7 @@ export const workspaceWithOneProcessing: Workspace = {
                             }
                         ],
                         "data": {
-                            "addedBy": {"username": "joe", "displayName": "joe"},
+                            ...standardWorkspaceNodeData,
                             "addedOn": 1570040729406
                         },
                     },
@@ -343,14 +349,12 @@ export const workspaceWithOneProcessing: Workspace = {
                     }
                 ],
                 "data": {
-                    "addedBy": {"username": "joe", "displayName": "joe"},
+                    ...standardWorkspaceNodeData,
                     "addedOn": 1570040728798
                 },
             }
         ],
-        "data": {
-            "addedBy": {"username": "joe", "displayName": "joe"}
-        },
+        "data": standardWorkspaceNodeData,
     }
 };
 
@@ -413,7 +417,7 @@ export const workspaceWithTwoProcessing: Workspace = {
                             }
                         ],
                         "data": {
-                            "addedBy": {"username": "joe", "displayName": "joe"},
+                            ...standardWorkspaceNodeData,
                             "addedOn": 1570040730137
                         },
                     },
@@ -424,7 +428,7 @@ export const workspaceWithTwoProcessing: Workspace = {
                         "data": {
                             "size": 692081,
                             "uri": "zbwf5DMlKbDyRKWr4AwOitVFM5u0slMY4F8eyKVKxKz8p8wdNEJ0Wuwd6ucl_zdk-5yQHLygmnFoI4SynmDvCQ",
-                            "addedBy": {"username": "joe", "displayName": "joe"},
+                            ...standardWorkspaceNodeData,
                             "mimeType": "application/pdf",
                             "addedOn": 1570040729993,
                             "processingStage": { type: 'processed' }
@@ -471,7 +475,7 @@ export const workspaceWithTwoProcessing: Workspace = {
                     }
                 ],
                 "data": {
-                    "addedBy": {"username": "joe", "displayName": "joe"},
+                    ...standardWorkspaceNodeData,
                     "addedOn": 1570040729406
                 },
             },
@@ -516,7 +520,7 @@ export const workspaceWithTwoProcessing: Workspace = {
             }
         ],
         "data": {
-            "addedBy": {"username": "joe", "displayName": "joe"},
+            ...standardWorkspaceNodeData,
             "addedOn": 1570040728798
         },
     }
@@ -544,12 +548,7 @@ export const workspaceWithOneProcessingBottomHeavyTree: Workspace = {
     "rootNode": {
         "id": "56d6b05a-bf94-4aac-91a8-eebe542a0eb0",
         "name": "blah",
-        "data": {
-            "addedBy": {
-                "username": "joe",
-                "displayName": "joe"
-            }
-        },
+        "data": standardWorkspaceNodeData,
         "children": [
             {
                 "id": "8ade596a-8153-4247-b25f-6e5bcf8f5132",
@@ -581,7 +580,7 @@ export const workspaceWithOneProcessingBottomHeavyTree: Workspace = {
                 "id": "8ade596a-8153-4247-b25f-6e5bcf8f5132",
                 "name": "Screenshot 2019-04-09 at 16.52.13.png",
                 "data": {
-                    "addedBy": {"username": "joe", "displayName": "joe"},
+                    ...standardWorkspaceNodeData,
                     "addedOn": 1570040728798
                 },
                 "children": [
@@ -660,13 +659,13 @@ export const workspaceWithOneProcessingBottomHeavyTree: Workspace = {
                                     }
                                 ],
                                 "data": {
-                                    "addedBy": {"username": "joe", "displayName": "joe"},
+                                    ...standardWorkspaceNodeData,
                                     "addedOn": 1570040730137
                                 },
                             }
                         ],
                         "data": {
-                            "addedBy": {"username": "joe", "displayName": "joe"},
+                            ...standardWorkspaceNodeData,
                             "addedOn": 1570040729406
                         },
                     },
@@ -698,12 +697,7 @@ export const workspaceWithZeroProcessingBottomHeavyTree: Workspace = {
     "rootNode": {
         "id": "56d6b05a-bf94-4aac-91a8-eebe542a0eb0",
         "name": "blah",
-        "data": {
-            "addedBy": {
-                "username": "joe",
-                "displayName": "joe"
-            }
-        },
+        "data": standardWorkspaceNodeData,
         "children": [
             {
                 "id": "8ade596a-8153-4247-b25f-6e5bcf8f5132",
@@ -735,7 +729,7 @@ export const workspaceWithZeroProcessingBottomHeavyTree: Workspace = {
                 "id": "8ade596a-8153-4247-b25f-6e5bcf8f5132",
                 "name": "Screenshot 2019-04-09 at 16.52.13.png",
                 "data": {
-                    "addedBy": {"username": "joe", "displayName": "joe"},
+                    ...standardWorkspaceNodeData,
                     "addedOn": 1570040728798
                 },
                 "children": [
@@ -814,13 +808,13 @@ export const workspaceWithZeroProcessingBottomHeavyTree: Workspace = {
                                     }
                                 ],
                                 "data": {
-                                    "addedBy": {"username": "joe", "displayName": "joe"},
+                                    ...standardWorkspaceNodeData,
                                     "addedOn": 1570040730137
                                 },
                             }
                         ],
                         "data": {
-                            "addedBy": {"username": "joe", "displayName": "joe"},
+                            ...standardWorkspaceNodeData,
                             "addedOn": 1570040729406
                         },
                     },
@@ -852,12 +846,7 @@ export const workspaceFlatWithZeroProcessing: Workspace = {
     "rootNode": {
         "id": "56d6b05a-bf94-4aac-91a8-eebe542a0eb0",
         "name": "blah",
-        "data": {
-            "addedBy": {
-                "username": "joe",
-                "displayName": "joe"
-            }
-        },
+        "data": standardWorkspaceNodeData,
         "children": [
             {
                 "id": "8ade596a-8153-4247-b25f-6e5bcf8f5132",
@@ -924,12 +913,7 @@ export const workspaceFlatWithOneProcessing: Workspace = {
     "rootNode": {
         "id": "56d6b05a-bf94-4aac-91a8-eebe542a0eb0",
         "name": "blah",
-        "data": {
-            "addedBy": {
-                "username": "joe",
-                "displayName": "joe"
-            }
-        },
+        "data": standardWorkspaceNodeData,
         "children": [
             {
                 "id": "8ade596a-8153-4247-b25f-6e5bcf8f5132",


### PR DESCRIPTION
## What does this change?
- expose/calculate `descendantsLeafCount`,`descendantsNodeCount, `descendantsProcessingTaskCount`, `descendantsFailedCount` when building the workspace contents for API responses
- use `descendantsLeafCount` and `descendantsNodeCount` to show subtle (smaller & grey) totals of descendant files & folders on all nodes of the tree 
  <img width="543" height="242" alt="image" src="https://github.com/user-attachments/assets/a73891e6-df31-486e-a114-41ae35346f62" />

- use `descendantsProcessingTaskCount` and `descendantsFailedCount` to show total counts of descendant 'in progress tasks' and 'failures' in the `Processing Stage' column for all nodes (which have descendant in progress / failed) tasks AND display the spinner icon on all the parent nodes of in progress tasks (so people can easily find nested jobs)
  <img width="1280" height="109" alt="image" src="https://github.com/user-attachments/assets/fc62ad97-a64f-4860-a97d-50eaa8b184e2" />

## How to test
Navigate some workspaces and see this extra detail (ideally ones, with some in-progress jobs, noting the extra detail on the parent nodes).

## Have we considered potential risks?
There may be a little performance impact on huge workspaces, but worth seeing if it's noticeable - however the counting logic is in the existing recursive function call, so not doing any extra traversing of the tree 🎉 
