### PR TITLE
Return owner in getWorkspacesForBlob

### DIFF
--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -101,7 +101,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
         |MATCH (w:WorkspaceNode {uri: {uri}})-[:PART_OF]->(workspace:Workspace)
         |MATCH (creator :User)-[:CREATED]->(workspace)<-[:FOLLOWING]-(follower :User)
         |MATCH (owner :User)-[:OWNS]->(workspace)
-        |return  workspace, creator, collect(distinct follower) as followers
+        |return  workspace, creator, owner, collect(distinct follower) as followers
         |""".stripMargin,
       parameters(
         "uri", blobUri,


### PR DESCRIPTION
## What does this change?
This resolves a bug in https://github.com/guardian/giant/pull/290 - we need to actually return the owner from the neo4j query.

I noticed this issue when trying to understand why reprocessing (right click>>reprocess) was failing when I tried to reprocess a file uploaded to a workspace by someone else. This error would be thrown:

Unknown Failure: org.neo4j.driver.v1.exceptions.value.NotMultiValued: NULL is not a keyed collection
	at org.neo4j.driver.internal.value.ValueAdapter.get(ValueAdapter.java:358)
	at model.user.DBUser$.fromNeo4jValue([DBUser.scala:20](https://github.com/guardian/giant/blob/cdf12737262fa40866e15725da405b74d3df2350/backend/app/model/user/DBUser.scala#L20))
	at services.manifest.Neo4jManifest.$anonfun$getWorkspacesForBlob$3([Neo4jManifest.scala:112](https://github.com/guardian/giant/blob/cdf12737262fa40866e15725da405b74d3df2350/backend/app/services/manifest/Neo4jManifest.scala#L112))
	at scala.collection.immutable.List.map(List.scala:246)
	at services.manifest.Neo4jManifest.$anonfun$getWorkspacesForBlob$2(Neo4jManifest.scala:109)
	at utils.attempt.Attempt.$anonfun$map$1(Attempt.scala:20)

This only impacts files not uploaded by the current user as the function doesn't get called if the current user uploaded the file - see https://github.com/guardian/giant/blob/cdf12737262fa40866e15725da405b74d3df2350/backend/app/controllers/api/Blobs.scala#L130

## How to test
I tested this by deploying this change to playground then attempting to reprocess the files in https://playground.pfi.gutools.co.uk/workspaces/5e29e5a3-a131-4b99-947a-ff4672f81d0a - it worked rather than throwing the above error