### PR TITLE
Fix genesis user creation in dev

### DIFF
--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -4,6 +4,16 @@ const { createProxyMiddleware }  = require('http-proxy-middleware');
 // (proxy everything without `Accept: text-html`) breaks PDF preview
 module.exports = function(app) {
   app.use('/api', createProxyMiddleware({ target: 'http://localhost:9001/api', changeOrigin: true }));
-  app.use('/setup', createProxyMiddleware({ target: 'http://localhost:9001/setup', changeOrigin: true }));
+  // Path rewrite required because http-proxy (unmaintained, upstream of http-proxy-middleware) adds a 
+  // trailing slash and then Play is fussy and claims the route doesn't exist
+  // https://github.com/chimurai/http-proxy-middleware/issues/1016
+  // https://github.com/guardian/giant/issues/391
+  app.use('/setup', createProxyMiddleware({
+    target: 'http://localhost:9001',
+    changeOrigin: true,
+    pathRewrite: (_, req) => {
+      return req.originalUrl;
+    },
+  }));
   app.use('/third-party', createProxyMiddleware({ target: 'http://localhost:9001/third-party', changeOrigin: true }));
 };


### PR DESCRIPTION
Fixes #391 

The create react app was not correctly proxying request to the `/setup` endpoint which the frontend uses to decide to show the "genesis user" flow on first startup.

It added a trailing slash to the proxied request and Play was fussy and complained that `/setup/` didn't exist (because it's only `/setup` in the routes).

I think this might have broken via a transitive upgrade to http-proxy, used by http-proxy-middleware. At least https://github.com/chimurai/http-proxy-middleware/issues/1016 suggests this is this case and http-proxy is not maintained.

Genesis user creation should still have been working for non dev builds as they don't use the create react app proxy.

WRT #391 I tested creating the genesis user then creating another user and was able to log in as both. Only tested in dev though.