### PR TITLE
Fix bug in getRemoteIngestJob neo4j query

### DIFF
--- a/backend/app/services/ingestion/Neo4jRemoteIngestStore.scala
+++ b/backend/app/services/ingestion/Neo4jRemoteIngestStore.scala
@@ -111,7 +111,7 @@ class Neo4jRemoteIngestStore(driver: Driver, executionContext: ExecutionContext,
   override def getRemoteIngestJob(id: String): Attempt[RemoteIngest] = attemptTransaction { tx =>
     val query =
       s"""
-        |MATCH (ri:RemoteIngest {id: $id})
+        |MATCH (ri:RemoteIngest {id: ${"$id"}})
         |MATCH (addedBy :User)-[:CREATED]->(ri)
         |$returnFields
       """.stripMargin


### PR DESCRIPTION
## What does this change?
We're using string interpolation in this query to avoid duplication of 'returnFields'. Unfortunately both scala and neo4j use the same special character for string interpolation ($) so we end up with our id parameter getting added inline, without quotes, which breaks the query, resulting in an error like this:

```
Failed to ingest remote file for job with id 21a65064-13db-4c61-a41e-24053c849d33: UnknownFailure(org.neo4j.driver.v1.exceptions.ClientException: invalid literal number (line 2, column 29 (offset: 29))
"MATCH (ri:RemoteIngest {id: 21a65064-13db-4c61-a41e-24053c849d33})"
                             ^)
```


## How to test
Run a remote ingest, check it works