### PR TITLE
Fix routing which was causing multiple workspace renders (and possible cause of taking down Neo4j in large workspace)

### DIFF
--- a/frontend/src/js/App.js
+++ b/frontend/src/js/App.js
@@ -91,9 +91,7 @@ class App extends React.Component {
                     <Route path='/settings/features' component={FeatureSwitches} />
                     <Route path='/settings/about' component={About} />
                     <Route path='/settings/uploads' component={WeeklyUploadsFeed} />
-                    <Route path='/workspaces/:id'  component={Workspaces} />
-                    <Route path='/workspaces/:id/:workspaceLocation'  component={Workspaces} />
-                    <Route path='/workspaces/:id' component={Workspaces} />
+                    <Route path='/workspaces/:id/:workspaceLocation?'  component={Workspaces} />
                     <Route exact path='/workspaces' component={CaptureFromUrl} />
 
                     <Route path = '/settings/my-uploads' component={MyUploads} />


### PR DESCRIPTION
## What does this change?
We had a duplicate route that was causing multiple workspace renders but also I should have used an optional segment as per https://reactrouter.com/start/framework/routing\#optional-segments  - so fixing that.

## How to test
Will test on playground

