### PR TITLE
Make recipient address an optional field, fall back to unknown

### DIFF
--- a/backend/app/services/index/HitReaders.scala
+++ b/backend/app/services/index/HitReaders.scala
@@ -248,7 +248,7 @@ object HitReaders {
 
   private def readRecipient(fields: FieldMap): Recipient = Recipient(
     fields.optMultiLanguageField(metadata.recipients.name),
-    fields.field(metadata.recipients.address)
+    fields.optField(metadata.recipients.address).getOrElse("unknown")
   )
 
   private def readMetadata(fields: FieldMap): Map[String, Seq[String]] = {


### PR DESCRIPTION
## What does this change?
We are experiencing an issue on giant where we have ingested an email which is missing the recipient address field. This is resulting in an error when users attempt to search for terms contained within that email (see stack trace below). 

This PR makes the address field optional when we attempt to parse the field from elasticsearch.

TODO: read this bit of code in more detail to have a clearer understanding of what it's doing - I am guessing our assumption was that becuase we wrote the email to elasticsearch using giant we should be able to rely on the recipient address field being there. Need to undestand this better - the issue might be that we are interpreting something in the index as an email which is in fact not an email...


```
java.util.NoSuchElementException: key not found: address
	at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:223)
	at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:219)
	at services.index.HitReaders$RichFieldMap.field(HitReaders.scala:24)
	at services.index.HitReaders$.readRecipient(HitReaders.scala:251)
	at services.index.HitReaders$.$anonfun$readEmailResult$1(HitReaders.scala:192)
	at scala.Option.map(Option.scala:242)
	at services.index.HitReaders$.services$index$HitReaders$$readEmailResult(HitReaders.scala:192)
	at services.index.HitReaders$SearchResultHitReader$.read(HitReaders.scala:86)
	at com.sksamuel.elastic4s.Hit.safeTo(Hit.scala:37)
	at com.sksamuel.elastic4s.Hit.safeTo$(Hit.scala:37)
	at com.sksamuel.elastic4s.requests.searches.SearchHit.safeTo(SearchHit.scala:9)
	at com.sksamuel.elastic4s.Hit.to(Hit.scala:30)
	at com.sksamuel.elastic4s.Hit.to$(Hit.scala:30)
	at com.sksamuel.elastic4s.requests.searches.SearchHit.to(SearchHit.scala:9)
	at com.sksamuel.elastic4s.requests.searches.SearchResponse.$anonfun$to$1(SearchResponse.scala:62)
	at scala.collection.ArrayOps$.map$extension(ArrayOps.scala:934)
	at com.sksamuel.elastic4s.requests.searches.SearchResponse.to(SearchResponse.scala:62)
	at services.index.ElasticsearchResources.$anonfun$query$1(ElasticsearchResources.scala:424)
	...
```




## How to test
Tested on PROD!