### PR TITLE
Log relevant ids when adding an item to a workspace

### DIFF
--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -405,6 +405,8 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
     val sizePart = if (size.isDefined) ", size: {size}" else ""
     val mimeTypePart = if(mimeType.isDefined) ", mimeType: {mimeType}" else ""
 
+    logger.info(s"Adding resource with id $nodeId to workspace $workspaceId with parent $folderId")
+
     val params = List(
       "parentFolderId", folderId,
       "workspaceId", workspaceId,


### PR DESCRIPTION
## What does this change?
Currently we are getting errors when trying to upload files to certain large workspaces. This PR aims to make debugging that situation a bit easier as I think there might be some kind of race condition going on - seeing this log line more than once would give an idea of whether that is happening.


## How to test
