### PR TITLE
MERGE rather than CREATE in addResourceToWorkspaceFolder

### DIFF
--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -429,7 +429,7 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
          |
          |MATCH (currentUser:User {username: {currentUser}})
          |
-         |CREATE (file: WorkspaceNode {id: {fileId}, name: {fileName}, type: 'file', icon: {icon}, uri: {blobUri}, addedOn: {addedOn}$sizePart$mimeTypePart})
+         |MERGE (file: WorkspaceNode {id: {fileId}, name: {fileName}, type: 'file', icon: {icon}, uri: {blobUri}, addedOn: {addedOn}$sizePart$mimeTypePart})
          |
          |CREATE (file)<-[:CREATED]-(currentUser)
          |CREATE (file)-[:PARENT]->(parentNode)


### PR DESCRIPTION
## What does this change?
There is something strange going on with uploads to certain workspaces on PROD - we get an error like this:

`org.neo4j.driver.v1.exceptions.ClientException: Node(123) already exists with label `WorkspaceNode` and property `id` = 'id123'`

The CREATE within this query should only ever be executed once for each nodeId, but the above error is making me wonder whether somehow it is being executed twice.

I don't want to leave this change in permanently, but in the short term it could help unblock uploads to these workspaces, and I think seems harmless.

## How to test
Deploy to PROD, check if it fixes issues with the relevant workspaces