### PR TITLE
Fix file uploads to public workspaces followed by 2 or more people

### DIFF
--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -423,7 +423,7 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
          |
          |MATCH (parentNode)-[:PART_OF]->(workspace: Workspace {id: {workspaceId}})<-[:FOLLOWING]-(user: User)
          |  WHERE user.username = {currentUser} OR workspace.isPublic
-         |WITH parentNode, workspace
+         |WITH DISTINCT parentNode, workspace
          |
          |MATCH (currentUser:User {username: {currentUser}})
          |


### PR DESCRIPTION
## What does this change?
We recently encountered a bug in giant where if a workspace was both public and shared with more than one person (where the owner counts as 1) then it became impossible to upload files to it via the giant UI.

The problem is with this bit of the query in `addResourceToWorkspaceFolder`:

```
MATCH (parentNode)-[:PART_OF]->(workspace: Workspace {id: {workspaceId}})<-[:FOLLOWING]-(user: User)
  WHERE user.username = {currentUser} OR workspace.isPublic
```

When the above conditions are true, this query will return multiple rows, all referring to the same workspace.

This would result in the later CREATE command to get executed three times, resulting in an error `org.neo4j.driver.v1.exceptions.ClientException: Node(123) already exists with label `WorkspaceNode` and property `id` = 'id123'`

By ensuring that the pairs of parentFolder,workspace are distinct, we can prevent this problem. We do this using the WITH DISTINCT filter - see https://neo4j.com/docs/cypher-manual/current/clauses/with/#remove-duplicate-values


## How to test
I've tested this locally, will do it on playground as well. The steps are:

 - create a workspace, share it with someone elese, make it public
 - Try to upload a file

Before this change, you should get an error. After, it will work. Example workspace on playground https://playground.pfi.gutools.co.uk/workspaces/3e5ce81d-59a9-41a1-aa43-aba6b058dcce