### PR TITLE
Revert "Upgrades SQS to use AWS java SDK v2"

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -4,7 +4,7 @@ import cats.syntax.either._
 import com.amazonaws.client.builder.AwsClientBuilder
 import java.net.URI
 import software.amazon.awssdk.services.sns.SnsClient
-import software.amazon.awssdk.services.sqs.SqsClient
+import com.amazonaws.services.sqs.{AmazonSQSClient, AmazonSQSClientBuilder}
 import com.gu.pandomainauth
 import com.gu.pandomainauth.PublicSettings
 import controllers.AssetsComponents
@@ -81,9 +81,9 @@ class AppComponents(context: Context, config: Config)
     val s3Client = new S3Client(config.s3)(s3ExecutionContext)
 
     val sqsClient = if (config.sqs.endpoint.isDefined)
-      SqsClient.builder().endpointOverride(URI.create(config.sqs.endpoint.get)).region(config.sqs.regionV2).build()
+      AmazonSQSClientBuilder.standard().withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(config.sqs.endpoint.get, config.sqs.region)).build()
     else
-      SqsClient.builder().region(config.sqs.regionV2).build()
+      AmazonSQSClientBuilder.standard().withRegion(config.sqs.region).build()
 
     val snsClient = if (config.sqs.endpoint.isDefined)
       SnsClient.builder().endpointOverride(URI.create(config.sqs.endpoint.get)).region(config.sqs.regionV2).build()

--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -1,7 +1,7 @@
 package extraction
 
-import software.amazon.awssdk.services.sqs.SqsClient
-import software.amazon.awssdk.services.sqs.model.{MessageAttributeValue, SendMessageRequest}
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.{MessageAttributeValue, SendMessageRequest}
 import model.{English, Language, Languages}
 import model.manifest.Blob
 import org.joda.time.DateTime
@@ -98,7 +98,7 @@ object TranscriptionOutput {
 // The transcription types are matched with types in transcription service
 // https://github.com/guardian/transcription-service/blob/main/packages/common/src/types.ts
 
-class ExternalTranscriptionExtractor(index: Index, transcribeConfig: TranscribeConfig, transcriptionStorage: ObjectStorage, outputStorage: ObjectStorage, sqsClient: SqsClient)(implicit executionContext: ExecutionContext) extends ExternalExtractor with Logging {
+class ExternalTranscriptionExtractor(index: Index, transcribeConfig: TranscribeConfig, transcriptionStorage: ObjectStorage, outputStorage: ObjectStorage, amazonSQSClient: AmazonSQS)(implicit executionContext: ExecutionContext) extends ExternalExtractor with Logging {
   val mimeTypes: Set[String] = Set(
     "audio/wav",
     "audio/vnd.wave",
@@ -155,14 +155,14 @@ class ExternalTranscriptionExtractor(index: Index, transcribeConfig: TranscribeC
         try {
           logger.info(s"sending message to Transcription Service Queue")
 
-          val messageRequest = SendMessageRequest.builder()
-            .queueUrl(transcribeConfig.transcriptionServiceQueueUrl)
-            .messageBody(Json.stringify(Json.toJson(job)))
-            .messageGroupId(UUID.randomUUID().toString)
-            .messageAttributes(Map("BlobId" -> MessageAttributeValue.builder()
-              .stringValue(blob.uri.value).build()).asJava)
-            .build()
-          Right(sqsClient.sendMessage(messageRequest))
+          val sendMessageCommand = new SendMessageRequest()
+            .withQueueUrl(transcribeConfig.transcriptionServiceQueueUrl)
+            .withMessageBody(Json.stringify(Json.toJson(job)))
+            .withMessageGroupId(UUID.randomUUID().toString)
+            .withMessageAttributes(
+              Map("BlobId" -> new MessageAttributeValue().withDataType("String").withStringValue(blob.uri.value)).asJava
+            )
+          Right(amazonSQSClient.sendMessage(sendMessageCommand))
         } catch {
           case e: Failure => Left(e)
         }

--- a/backend/app/services/ingestion/RemoteIngestWorker.scala
+++ b/backend/app/services/ingestion/RemoteIngestWorker.scala
@@ -1,7 +1,7 @@
 package services.ingestion
 
-import software.amazon.awssdk.services.sqs.SqsClient
-import software.amazon.awssdk.services.sqs.model.{SendMessageRequest, ReceiveMessageRequest, DeleteMessageRequest}
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import commands.IngestFile
 import controllers.api.Collections
 import ingestion.phase2.IngestStorePolling
@@ -24,7 +24,7 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 class RemoteIngestWorker(
-                          sqsClient: SqsClient,
+                          amazonSQSClient: AmazonSQS,
                           config: RemoteIngestConfig,
                           s3Config: S3Config,
                           annotations: Annotations,
@@ -109,15 +109,12 @@ class RemoteIngestWorker(
 
   private def processFinishedJobs(): Unit = {
     try {
-      sqsClient.receiveMessage(
-        ReceiveMessageRequest.builder()
-          .queueUrl(config.outputQueueUrl)
-          .maxNumberOfMessages(10)
-          .build()
-      ).messages().asScala.foreach { sqsMessage =>
-        logger.info(s"Processing finished job from SQS with id ${sqsMessage.messageId()}")
+      amazonSQSClient.receiveMessage(
+        new ReceiveMessageRequest(config.outputQueueUrl).withMaxNumberOfMessages(10)
+      ).getMessages.asScala.foreach { sqsMessage =>
+        logger.info(s"Processing finished job from SQS with id ${sqsMessage.getMessageId}")
 
-        val messageParseResult = Json.fromJson[RemoteIngestOutput](Json.parse(sqsMessage.body()))
+        val messageParseResult = Json.fromJson[RemoteIngestOutput](Json.parse(sqsMessage.getBody))
 
         (for {
           remoteIngestOutput <- Attempt.fromEither(messageParseResult.asEither.left.map(JsonParseFailure))
@@ -157,11 +154,11 @@ class RemoteIngestWorker(
             failureDetail => {
               val maybeParsedJob =  messageParseResult.asOpt
               logger.error(
-                s"Failed to ingest remote file for job with id ${maybeParsedJob.map(_.id).getOrElse(s"unknown (but had sqs id ${sqsMessage.messageId()}")}",
+                s"Failed to ingest remote file for job with id ${maybeParsedJob.map(_.id).getOrElse(s"unknown (but had sqs id ${sqsMessage.getMessageId}")}",
                 failureDetail.toThrowable
               )
               // TODO: Do we care if this sending to dead letter queue fails?
-              sqsClient.sendMessage(SendMessageRequest.builder().queueUrl(config.outputDeadLetterQueueUrl).messageBody(sqsMessage.body()).build())
+              amazonSQSClient.sendMessage(config.outputDeadLetterQueueUrl, sqsMessage.getBody)
               maybeParsedJob.map { parsedJob =>
                 // INVALID_URL is returned by the media download service when there are no videos on the page -this is not
                 // a failure we need to expose to the user
@@ -177,10 +174,7 @@ class RemoteIngestWorker(
               remoteIngestStorage.delete(jobAndOutput._1.taskKey(jobAndOutput._2.taskId))
             }
         ).onComplete { _ =>
-          sqsClient.deleteMessage(DeleteMessageRequest.builder()
-            .queueUrl(config.outputQueueUrl)
-            .receiptHandle(sqsMessage.receiptHandle())
-            .build())
+          amazonSQSClient.deleteMessage(config.outputQueueUrl, sqsMessage.getReceiptHandle)
         }
       }
     } catch  {

--- a/backend/test/test/integration/Helpers.scala
+++ b/backend/test/test/integration/Helpers.scala
@@ -1,6 +1,7 @@
 package test.integration
 
 import software.amazon.awssdk.services.sns.SnsClient
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import org.apache.pekko.util.Timeout
 import commands.IngestFileResult
 import controllers.api._

--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ lazy val backend = (project in file("backend"))
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatchmetrics" % awsVersion,
-      "software.amazon.awssdk" % "sqs" % awsSdkVersion2,
+      "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
       "software.amazon.awssdk" % "sns" % awsSdkVersion2,
       "com.beachape" %% "enumeratum-play" % "1.8.0",
       "com.iheart" %% "ficus" % "1.5.2",


### PR DESCRIPTION
Reverts guardian/giant#446

This has caused transcription to break in Giant - reverting until we can fix. 

Related to message attributes now needing `dataType` set.