### PR TITLE
ensure that no calls to `getWorkspace` (from anywhere) ever overlap

### DIFF
--- a/frontend/src/js/actions/workspaces/getWorkspace.ts
+++ b/frontend/src/js/actions/workspaces/getWorkspace.ts
@@ -22,10 +22,12 @@ export function getWorkspace(id: string, options:{shouldClearFirst?: boolean} = 
         idRequestedAgainWhilstInProgress = null;
         const operation: () => Promise<unknown> = () => getWorkspaceApi(id)
             .then(workspace => {
-                dispatch({
-                    type: WorkspacesActionType.WORKSPACE_GET_RECEIVE,
-                    workspace
-                });
+                if(idInProgress === id) { // only dispatch if still relevant
+                    dispatch({
+                        type: WorkspacesActionType.WORKSPACE_GET_RECEIVE,
+                        workspace
+                    });
+                }
             })
             .catch(error => dispatch({
                 type:        AppActionType.APP_SHOW_ERROR,


### PR DESCRIPTION
When working on https://github.com/guardian/giant/pull/460 (specifically the bit about throttling `getWorkspace` calls) I noticed that for big workspaces, the existing 5s polling (for when the workspace has in-flight ingests) can begin to overlap and slow everything down...
![5sPolling](https://github.com/user-attachments/assets/4a648181-8bb6-4674-99e0-234084670c1c)

## What does this change?
This changes the `getWorkspace` function to track/detect if an existing call to `getWorkspace` is still running and if so then return early, but ensure that the one in progress immediately starts again when it's finished. This takes account of the specific workspace id in progress, so one can still switch workspace whilst the workspace they are transitioning from still has an in progress `getWorkspace`.

## How to test
Using a large workspace, and with an ingest in progress (so it's polling) observe the network tab to see that there's only ever one `getWorkspace` in progress (unlike the above GIF), like so...
![5sPollingFixed](https://github.com/user-attachments/assets/b871aa32-a907-45e3-beb6-18483f8a9ff8)

## How can we measure success?
No waste! and things shouldn't choke up (less load on server/Neo4J etc.)

## Have we considered potential risks?
That there's a usage of `getWorkspace` that relies on the current chonky behaviour that I've not considered - however that is best addressed directly if/when it arises.