### PR TITLE
Make nature of extractor failures clearer in workspace ui

### DIFF
--- a/backend/app/model/annotations/Workspace.scala
+++ b/backend/app/model/annotations/Workspace.scala
@@ -108,7 +108,8 @@ object WorkspaceEntry {
     hasFailures: Boolean
   ): TreeEntry[WorkspaceEntry] = {
     val processingStage = if (hasFailures) {
-      ProcessingStage.Failed
+      if (numberOfTodos > 0) ProcessingStage.Processing(numberOfTodos, Some("some failures"))
+      else ProcessingStage.Failed
     } else if (numberOfTodos > 0) {
       ProcessingStage.Processing(numberOfTodos, note)
     } else {

--- a/frontend/src/js/util/workspaceUtils.ts
+++ b/frontend/src/js/util/workspaceUtils.ts
@@ -79,7 +79,7 @@ export function processingStageToString(processingStage: ProcessingStage): strin
             return 'processed';
 
         case 'failed':
-            return 'failed';
+            return 'processed (with errors)';
     }
 }
 


### PR DESCRIPTION
## What does this change?
This is a small tweak to how errors are rendered in the workspace view - only mark stuff has having failed once all the extractors have finished, and change the error next to add some suggestion that the file might still be worth looking at.

I think this makes sense, though it does increase the number of spinners as opposed to error icons in giant. I'm going to see how that looks on playground - might be it's just too many spinners

## How to test
todo...