### PR TITLE
Tweak failure text in workspace ui

### DIFF
--- a/frontend/src/js/util/workspaceUtils.ts
+++ b/frontend/src/js/util/workspaceUtils.ts
@@ -79,7 +79,7 @@ export function processingStageToString(processingStage: ProcessingStage): strin
             return 'processed';
 
         case 'failed':
-            return 'failed';
+            return 'processed (with errors)';
     }
 }
 


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/giant/pull/469 put spinnners all over the place, I don't think it helped matters. This is a scaled back version suitable for a last-friday-before-xmas deploy
