### PR TITLE
Workspaces: when processing involves errors, describe them as errors rather than failures

### DIFF
--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -207,7 +207,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             name: 'Name',
             align: 'left' as const,
             style: {
-                width: '500px'
+                width: '560px'
             },
             render: (entry: TreeEntry<WorkspaceEntry>) => {
                 const workspaceId = this.props.match.params.id;


### PR DESCRIPTION
Attempt to fix https://github.com/guardian/investigations-internal-issues/issues/67

- Changes the word "failed" to "errors" for processing stage summary at the folder level of workspaces, to match https://github.com/guardian/giant/commit/5a164dda3cb27530e8de52ddeff05a4af8e4b53e at the document level. 
- Changes the document icon for documents with errors to black from red to make it less overbearing, since in most cases these files are still viewable, just not as richly viewable. 
- Adds 60 more pixels to width of Name column because now that it has content summaries, important info is more frequently lost than hitherto. The price (columns to the right are less likely to be displayed in small browser windows) is worth paying since Name is so much more important than any other column