### PR TITLE
Flip workspaces and datasets in search sidebar

### DIFF
--- a/frontend/src/js/components/SearchSidebar/SearchSidebar.js
+++ b/frontend/src/js/components/SearchSidebar/SearchSidebar.js
@@ -44,7 +44,7 @@ export class SearchSidebarUnconnected extends React.Component {
     sortFilters = (filters) => {
         // Hard-coded to pull up workspace and dataset (collection  and ingestion) filters
         // as we expect these to be immediately useful as the number of workspaces grow
-        const hardcodedTopLevelFilters = ['ingestion', 'workspace'];
+        const hardcodedTopLevelFilters = ['workspace', 'ingestion'];
 
         // Map the hardcoded filters to be the actual filter structure to preserve ordering
         const topLevelFilters = hardcodedTopLevelFilters.map(key => filters.find(f => f.key === key)).filter(f => f !== undefined);


### PR DESCRIPTION
Since people use workspaces far more than datasets, I want to make workspaces more visible in the search UI so people can more intuitively filter searches directly from that page. 

Changes like this should become redundant with the long-proposed UI overhaul but we might as well make this tiny change in the meantime.  