### PR TITLE
Click on title to return to base workspace url

### DIFF
--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -20,6 +20,7 @@ import {takeOwnershipOfWorkspace} from "../../actions/workspaces/takeOwnershipOf
 import {CaptureFromUrl} from "../Uploads/CaptureFromUrl";
 import {EuiText} from "@elastic/eui";
 import {FileAndFolderCounts} from "../UtilComponents/TreeBrowser/FileAndFolderCounts";
+import history from '../../util/history';
 
 type Props = {
     workspace: Workspace,
@@ -36,6 +37,7 @@ type Props = {
     workspaces: WorkspaceMetadata[],
     expandedNodes: TreeNode<WorkspaceEntry>[],
     isAdmin: boolean,
+    clearFocus: () => void
 }
 
 export default function WorkspaceSummary({
@@ -52,7 +54,8 @@ export default function WorkspaceSummary({
     focusedEntry,
     workspaces,
     expandedNodes,
-    isAdmin
+    isAdmin,
+    clearFocus
 }: Props) {
 
     const [isShowingMoreOptions, setIsShowingMoreOptions] = useState(false);
@@ -64,8 +67,13 @@ export default function WorkspaceSummary({
 
     const maybeRootNodeData = isWorkspaceNode(workspace.rootNode.data) && workspace.rootNode.data;
 
+    const handleTitleClick = () => {
+        clearFocus();
+        history.push(`/workspaces/${workspace.id}`);
+    };
+
     return <div className='page-title workspace__header shrinkable-buttons'>
-        <h1 className='workspace__title'>
+        <h1 className='workspace__title' onClick={handleTitleClick} style={{ cursor: "pointer" }}>
             {workspace.name}{maybeRootNodeData && <>
               <br/>
               <EuiText size="s"><FileAndFolderCounts

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -926,6 +926,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                     workspaces={this.props.workspacesMetadata}
                     expandedNodes={this.props.expandedNodes}
                     isAdmin={this.props.myPermissions.includes('CanPerformAdminOperations')}
+                    clearFocus={this.clearFocus}
                 />
                 <div className='workspace'>
                     {this.renderFolderTree(this.props.currentWorkspace)}


### PR DESCRIPTION
_Very small thing that if it's hard to review you should just reject._ 

Clears selection and updates url to just show the workspace rather than a particular view thereof.

An unanticipated consequence of https://github.com/guardian/giant/pull/418 is that once people start navigating a workspace, they can't get back to the initial URL state (i.e. just the workspace, not some sublocation therein). Deselecting everything in the workspace does not clear the URL, nor does restoring all subfolders to their initial state. 

Although this extra URL detail is unproblematic for that user, it does cause a problem if that user shares that URL with someone else, because it directs the recipient to the initial user's last subfolder selection, even when the initial user doesn't want to direct the recipient there. 

So we need a way to "clear" the current selection state and just show the base URL of the workspace. 

I, well, Claude, have attempted to do that by making thr workspace title clickable. Such a click will clear the current selection and its sublocation from the URL, and just show the clean workspace URL. I think.

## To review

I suggest deploying it locally and seeing if it does any good before carefully examining each changed line. Because if it doesn't help you shouldn't waste any time on it. This PR claims it's 1,354 lines but it's actually much fewer plus a bunch of code reformatting that I couldn't work out how to undo. Sorry. 

If it doesn't immediately make sense, or if it creates some new problems, don't both fix it it. We'll live without.