### PR TITLE
If workspace location ends with a folder, don't expand that folder

### DIFF
--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -382,14 +382,17 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
         if(workspaceLocation && !this.state.haveAppliedWorkspaceLocationParam && this.props.currentWorkspace) {
           const entryTreeEntries = this.getEntryTreeNodes(workspaceLocation, this.props.currentWorkspace.rootNode) || [];
           const entriesWithoutRoot = entryTreeEntries.filter((entry)=>this.props.currentWorkspace && entry.id !== this.props.currentWorkspace.rootNode.id)
+          const lastEntry = entriesWithoutRoot[entriesWithoutRoot.length - 1]
+          const lastEntryIsLeaf = lastEntry && isTreeLeaf(lastEntry);
           const entryTreeNodes= entriesWithoutRoot.filter(isTreeNode);
 
+          const nodesToExpand = lastEntryIsLeaf ? entryTreeNodes : entryTreeNodes.slice(0, entryTreeNodes.length -1)
+
           if (entryTreeNodes.length > 0) {
-            this.props.setNodesAsExpanded(entryTreeNodes);
+            this.props.setNodesAsExpanded(nodesToExpand);
           }
 
           if (entriesWithoutRoot.length > 0){
-            const lastEntry = entriesWithoutRoot[entriesWithoutRoot.length - 1]
             this.props.setFocusedEntry(lastEntry);
           }
           this.setState({haveAppliedWorkspaceLocationParam: true})


### PR DESCRIPTION
## What does this change?
Resolves https://github.com/guardian/giant/issues/482 

Note - it might be easier to understand the code than this PR description!

In the initial work to add workspace paths to the url https://github.com/guardian/giant/pull/418 we had the behaviour such that, when loading a workspace path, we would expand any folders included in that path.

This seemed to make sense, as typically if the user has selected a folder and then shared that url, presumably the contents of that folder is what's of interest.

However, this creates strange behaviour on first load where just selecting a folder (which triggers a history push to add that folder to the url) results in that folder being expanded (it doesn't happen more than once as the logic to expand folders based off the url only ever gets executed onced).

If the first action the user does is to expand the folder then we end up trying to expand the folder twice and bad things happen - it closes straight away:
![2026-01-05 11 31 03](https://github.com/user-attachments/assets/ac87c380-43cb-461f-befc-450bf7c5d6bc)

The new behaviour with this PR is that, when loading from a url, the selected item (the last bit of the path) is not expanded, even if it is a folder. 


## How to test
I've tested this locally. You can observe the current problem by loading a workspace in giant and then clicking to expand a folder - it won't expand