### PR TITLE
Only sync workspace location from url on first load

### DIFF
--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -429,9 +429,9 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
 
     this.poller = setInterval(this.performPollingIfRequired, 5000);
 
-    const workspaceLocationParam = this.props.match.params.workspaceLocation
+    const workspaceLocationParam = this.props.match.params.workspaceLocation;
     if (!workspaceLocationParam || workspaceLocationParam.length === 0) {
-      this.setState({ haveAppliedWorkspaceLocationParam: true })
+      this.setState({ haveAppliedWorkspaceLocationParam: true });
     }
   }
 


### PR DESCRIPTION
## What does this change?
Replaces https://github.com/guardian/giant/pull/484 - this change ensures that we only 'load from url' once in the workspaces view. Currently there is a bug where if you expand a folder as your first action on the workspace then it won't expand, due to a race condition between expanding it adding the folder location to the url.

The bug looks like this:

![2026-01-05 11 31 03](https://github.com/user-attachments/assets/ac87c380-43cb-461f-befc-450bf7c5d6bc)


## How to test
Tested on playground