### PR TITLE
Remove unnecessary (and no longer available) isTranslation property

### DIFF
--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -50,7 +50,6 @@ sealed trait TranscriptionOutput {
   def id: String
   def originalFilename: String
   def userEmail: String
-  def isTranslation: Boolean
   def status: String
 }
 
@@ -58,7 +57,6 @@ case class TranscriptionOutputSuccess(
                                           id: String,
                                           originalFilename: String,
                                           userEmail: String,
-                                          isTranslation: Boolean,
                                           status: String = "SUCCESS",
                                           languageCode: String,
                                           combinedOutputKey: String,
@@ -68,7 +66,6 @@ case class TranscriptionOutputFailure(
                                       id: String,
                                       originalFilename: String,
                                       userEmail: String,
-                                      isTranslation: Boolean,
                                       status: String = "FAILURE"
                                     ) extends TranscriptionOutput
 


### PR DESCRIPTION
## What does this change?
The release of https://github.com/guardian/transcription-service/pull/235 broke transcription in giant as it was expecting an `isTranslation` field

## How to test
Check that you get something back when you upload a media file with speech in it to giant