### PR TITLE
Add back v1 cloudwatch libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,6 +149,9 @@ lazy val backend = (project in file("backend"))
       "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion2,
       "software.amazon.awssdk" % "sqs" % awsSdkVersion2,
       "software.amazon.awssdk" % "sns" % awsSdkVersion2,
+      // remove the below once s3 has been upgraded to v2
+      "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
+      "com.amazonaws" % "aws-java-sdk-cloudwatchmetrics" % awsVersion,
       "com.beachape" %% "enumeratum-play" % "1.8.0",
       "com.iheart" %% "ficus" % "1.5.2",
       "org.jsoup" % "jsoup" % "1.14.2",


### PR DESCRIPTION
## What does this change?
When we tested https://github.com/guardian/giant/pull/494 we only checked for issues with our custom cloudwatch metrics. Unfortunately there is also a dependency (added here https://github.com/guardian/giant/pull/64) between the s3 sdk and the v1 cloudwatch sdk so we need these back until we have removed the v1 s3 sdk.

## How to test
Deploy to playground and check the logs- should hopefully stop seeing `Failed to enable the default metrics` everywhere