### PR TITLE
Always send failed transcription tasks to dead letter queue

### DIFF
--- a/backend/app/extraction/ExternalTranscriptionWorker.scala
+++ b/backend/app/extraction/ExternalTranscriptionWorker.scala
@@ -78,7 +78,7 @@ class ExternalTranscriptionWorker(manifest: WorkerManifest, sqsClient: SqsClient
         handleExternalTranscriptionOutputFailure(message, messageAttributes.messageGroupId, failure.msg)
         completed + 1
       case Left(failure) =>
-        logger.error(s"failed to process sqs message", failure.toThrowable)
+        logger.error(s"failed to process sqs message. Receive count: ${messageAttributes.receiveCount}", failure.toThrowable)
         if (messageAttributes.receiveCount.exists(_ >= MAX_RECEIVE_COUNT)) {
           handleExternalTranscriptionOutputFailure(message, messageAttributes.messageGroupId, failure.msg)
         }


### PR DESCRIPTION
## What does this change?
At the moment there is an issue in giant where transcription jobs fail because it can't read the file from S3. This is (I think) due to this thing https://github.com/guardian/giant/pull/64

At the moment for some reason we don't move messages to the dead letter queue where something goes wrong during giant's processing of the message - only if the message itself is a 'transcription failure'

In theory, messages should end up in the dead letter queue anyway in this situation - why aren't they? Leaving this as a draft for further discussion tomorrow

## How to test
todo...