### PR TITLE
Make sure input stream is closed after downloading a blob

### DIFF
--- a/backend/app/extraction/Worker.scala
+++ b/backend/app/extraction/Worker.scala
@@ -84,10 +84,14 @@ class Worker(
           status = EventStatus.Started,
           details = EventDetails.extractorDetails(extractor.name))
       )
-      val streamOrError = blobStorage.get(blob.uri.toStoragePath)
-      val result = streamOrError
-        .flatMap(safeInvokeExtractor(params, extractor, blob, _))
-      streamOrError.foreach(s => s.close())
+      val result = blobStorage.get(blob.uri.toStoragePath).flatMap { inputStream =>
+        try {
+          safeInvokeExtractor(params, extractor, blob, inputStream)
+        } finally {
+          if (inputStream != null) inputStream.close()
+        }
+      }
+
 
 
       result match {


### PR DESCRIPTION
## What does this change?
There is an ongoing bug in giant discussed here https://github.com/guardian/giant/pull/64 where s3 requests start timing out.

I think that this might help with that, as a key reason for this happening is because of the s3 connection pool being exhausted. At the moment, we are relying on each individual extractor to close the input stream. This is happening in FileExtractor.scala, but not in ExternalTranscriptionExtractor.scala

I think it makes sense to try and do this at the top level so that where we forget to close the input stream in the extractor there is a fallback, but I haven't tested how this works with extractors that have already closed the stream - but it should be a noop - it's fine to close a java inputstream more than once. 

## How to test
Deploy to playground and check that extraction/ingestion is still working - I haven't done this yet hence the draft status