### PR TITLE
Disable diarization for giant

### DIFF
--- a/backend/app/extraction/ExternalTranscriptionExtractor.scala
+++ b/backend/app/extraction/ExternalTranscriptionExtractor.scala
@@ -142,7 +142,7 @@ class ExternalTranscriptionExtractor(index: Index, transcribeConfig: TranscribeC
         combinedOutputUrl = CombinedOutputUrl(url = combinedOutputUrl,key = combinedOutputKey),
         languageCode = "auto",
         translate = true,
-        diarize = true,
+        diarize = false,
         engine = "whisperx",
         ingestion = params.ingestion)
     }


### PR DESCRIPTION
## What does this change?
I've noticed some problems with downloading the diarization models in the transcription service, resulting in transcription slowness. Needs further digging but whilst we deal with the current tranche of videos let's disable this

