### PR TITLE
[LOW PRIORITY] Search box: expand downwards not sideways; truncate long workspace folder chips

### DIFF
--- a/frontend/src/js/components/UtilComponents/InputSupper/Chip.js
+++ b/frontend/src/js/components/UtilComponents/InputSupper/Chip.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import ReactTooltip from "react-tooltip";
 
 import AutosizeInput from "react-input-autosize";
 
@@ -99,7 +100,19 @@ export default class Chip extends React.Component {
     this.currentControl = element;
   };
 
+  getDisplayValue = () => {
+    if (
+      this.props.type === "workspace_folder" &&
+      this.props.value.length > 75
+    ) {
+      return `${this.props.value.substring(0, 72)}...`;
+    }
+
+    return this.props.value;
+  };
+
   renderControl = () => {
+    const displayValue = this.getDisplayValue();
     switch (this.props.type) {
       case "text":
         return (
@@ -115,7 +128,7 @@ export default class Chip extends React.Component {
         return (
           <WorkspaceFolderChip
             ref={this.refHandler}
-            value={this.props.value}
+            value={displayValue}
             onChange={this.onChange}
             onKeyDown={this.onKeyDownDropdown}
             onFocus={this.onFocus}
@@ -163,6 +176,17 @@ export default class Chip extends React.Component {
   };
 
   render() {
+    const isWorkspaceFolder = this.props.type === "workspace_folder";
+
+    let displayName = this.props.name;
+    if (isWorkspaceFolder && this.props.value.length > 50) {
+      displayName = "Folder";
+    }
+
+    const tooltipText = isWorkspaceFolder
+      ? `Workspace Folder: ${this.props.value}`
+      : undefined;
+
     return (
       <span
         className={`input-supper__chip ${this.props.stagedForDeletion ? "input-supper__chip--delete-glow" : ""}`}
@@ -176,8 +200,12 @@ export default class Chip extends React.Component {
           </div>
         </button>
 
-        <span className="input-supper__chip-body">
-          <span className="input-supper__chip-name">{this.props.name}</span>
+        <span
+          className="input-supper__chip-body"
+          data-tip={tooltipText}
+          data-effect={tooltipText ? "solid" : undefined}
+        >
+          <span className="input-supper__chip-name">{displayName}</span>
           {this.renderControl()}
         </span>
 
@@ -187,6 +215,7 @@ export default class Chip extends React.Component {
         >
           <div className="input-supper__button-icon">&times;</div>
         </button>
+        {tooltipText ? <ReactTooltip insecure={false} /> : null}
       </span>
     );
   }

--- a/frontend/src/js/components/UtilComponents/InputSupper/InlineInput.js
+++ b/frontend/src/js/components/UtilComponents/InputSupper/InlineInput.js
@@ -149,7 +149,11 @@ export default class InlineInput extends React.Component {
           type="text"
           onChange={this.onUpdate}
           value={this.props.value}
-          inputStyle={{ fontSize: 18, fontFamily: "Avenir Next" }}
+          inputStyle={{
+            fontSize: 18,
+            fontFamily: "Avenir Next",
+            maxWidth: "100%",
+          }}
           onKeyDown={this.onKeyPress}
           onClick={this.onClickInput}
           onFocus={this.onFocus}

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -982,7 +982,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                       workspaceId: workspace.id,
                       folderId: entry.id,
                     },
-                    "*",
+                    "",
                   ]),
                   page: 1,
                 }),

--- a/frontend/src/stylesheets/components/_input-supper.scss
+++ b/frontend/src/stylesheets/components/_input-supper.scss
@@ -42,6 +42,10 @@
   display: inline-block;
   border: none;
   font-size: 18px;
+  max-width: 100%;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 
   &--chip {
     color: white;
@@ -58,11 +62,13 @@
   display: inline-block;
   height: 100%;
   margin: 0 calc($baseSpacing / 2) 0 0;
+  max-width: 100%;
 
   &:last-child {
     flex-grow: 1;
     cursor: text;
     margin: 0;
+    min-width: 100px; // Ensure there's always some space for typing
   }
 }
 


### PR DESCRIPTION
A new attempt at #474 (+1,189 −886 changes) that comes after the introduction of prettier.  This one is less galling (+44, -5).

Attempt to fix the problem where long search terms cause the search box to extend offscreen.


## What does this change?

Changes the behaviour of the Giant search box by increasing its depth for long queries rather than width. Secondly, very long workspace folder chip names - a common occurence - are truncated within the search box. A tooltip provides the full name. 

- Lets the free-text portion of the search box wrap _within the available width_ (plus SCSS tweaks so chips/input flow vertically with a 100 px typing minimum), preventing long queries from stretching the layout off the right of the screen.
- If a workspace folder chip name is very long, truncates the chip display, swaps the label to “Folder”, and shows the full name via a tooltip.
- Removes the auto-inserted * when triggering “Search in folder”, so the search field is empty and ready for the user’s own terms.

## How to test

1. Put some very long search terms into Giant's search box.
2. Make a folder with a very long name in a workspace. Execute "search in folder". Check that the chip is properly truncated, and shows a tooltip to reveal the full name of the folder. 
 
## How can we measure success?

If our searches don't lead to a search box that stretches off the right of the screen and renders it impossible to execute and see the results on the same screen. 

## Have we considered potential risks?

Well, it's LukeCode™ I'm afraid

