### PR TITLE
Enable gzip compression

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -2,6 +2,7 @@ import org.apache.pekko.actor.{ActorSystem, CoordinatedShutdown}
 import org.apache.pekko.actor.CoordinatedShutdown.Reason
 import cats.syntax.either._
 import com.amazonaws.client.builder.AwsClientBuilder
+
 import java.net.URI
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sqs.SqsClient
@@ -34,6 +35,7 @@ import services.annotations.Neo4jAnnotations
 import services.events.ElasticsearchEvents
 import services.index.{ElasticsearchPages, ElasticsearchResources, Pages2}
 import ingestion.{IngestionServices, Neo4jRemoteIngestStore, RemoteIngestWorker}
+import play.filters.gzip.{GzipFilter, GzipFilterConfig}
 import services.manifest.Neo4jManifest
 import services.observability.{PostgresClientDoNothing, PostgresClientImpl}
 import services.previewing.PreviewService
@@ -67,7 +69,8 @@ class AppComponents(context: Context, config: Config)
     super.httpFilters.filterNot(disabledFilters.contains) ++ Seq(
       new AllowFrameFilter,
       new RequestLoggingFilter(materializer),
-      new ReadOnlyFilter(config.app, materializer)
+      new ReadOnlyFilter(config.app, materializer),
+      new GzipFilter(new GzipFilterConfig())
     )
   }
 

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -14,13 +14,6 @@ play {
       Authorization: "*"
     }
 
-    enabled += "play.filters.gzip.GzipFilter"
-
-    gzip {
-      # -1 is the default
-      compressionLevel = -1
-    }
-
     headers.allowActionSpecificHeaders = true
   }
 


### PR DESCRIPTION
## What does this change?
On @twrichards suggestion [here](https://github.com/guardian/giant/pull/502), I did some basic performance testing of nothing vs gzip vs brotli compression in giant.

For a worskspace with a json blob that's 11.63MB, I got the following timings before the server started serving content (after several refreshes to reduce any first load perfomance impact):

Nothing: 3.8s
Brotli: 4.5s
Gzip: 4s

Compression wise, the results were:
Brotli: 76% (2.83MB)
Gzip: 75% (2.96MB)

With the above in mind, I think gzip compression is the sweet spot. From some basic research, brotli is also generally recommended for dynamically generated files - brotli is more for stuff that is getting cached so you don't pay the higher compression cost on every request.

## How to test
Tested on playground!