### PR TITLE
Only poll every minute for workspace updates instead of every 5 seconds

### DIFF
--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -427,7 +427,8 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
     this.props.getCollections();
     this.props.getWorkspace(this.props.match.params.id);
 
-    this.poller = setInterval(this.performPollingIfRequired, 5000);
+    // poll every minute
+    this.poller = setInterval(this.performPollingIfRequired, 60 * 1000);
 
     const workspaceLocationParam = this.props.match.params.workspaceLocation;
     if (!workspaceLocationParam || workspaceLocationParam.length === 0) {


### PR DESCRIPTION
## What does this change?
We currently have a lot of people working on some very large workspaces that are effectively read only for all except one or two users. To reduce the impact of this, this drops giant's polling frequency to once a minute rather than every 5 seconds. 



## How to test
Let's just put it straight to PROD!