### PR TITLE
Ensure we always close PDDocument

### DIFF
--- a/backend/app/commands/GetPages.scala
+++ b/backend/app/commands/GetPages.scala
@@ -50,14 +50,19 @@ class GetPages(uri: Uri, top: Double, bottom: Double, query: Option[String], use
   }
 
   private def addSearchHighlightsToPageResponse(pageNumber: Int, pageData: InputStream, pageText: String): Attempt[List[PageHighlight]] = Attempt.catchNonFatalBlasé {
+
     try {
       val pagePDF = PDDocument.load(pageData)
-      val highlightableText = HighlightableText.fromString(pageText, Some(pageNumber), isFind = false)
-
-      PDFUtil.getSearchResultHighlights(highlightableText, pagePDF, pageNumber)
+      try {
+        val highlightableText = HighlightableText.fromString(pageText, Some(pageNumber), isFind = false)
+        PDFUtil.getSearchResultHighlights(highlightableText, pagePDF, pageNumber)
+      } finally {
+        pagePDF.close()
+      }
     } finally {
       pageData.close()
     }
+
   }
 }
 

--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -19,7 +19,7 @@ import java.io.File
 import java.nio.file.{Files, Path}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.Try
+import scala.util.{Try, Using}
 
 class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages, previewStorage: ObjectStorage,
   ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
@@ -47,7 +47,7 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
 
     try {
       pdDocuments = params.languages.map { lang =>
-        val pages = Try(PDDocument.load(file).getNumberOfPages).toOption
+        val pages = Using(PDDocument.load(file))(_.getNumberOfPages).toOption
         val biggerThanA1 = Ocr.isBiggerThanA1(file.toPath, stdErrLogger)
         val preProcessPdf = Ocr.preProcessPdf(file.toPath, tmpDir, stdErrLogger, biggerThanA1)
         val pdfPath = Ocr.invokeOcrMyPdf(lang.ocr, preProcessPdf.getOrElse(file.toPath), None, stdErrLogger, tmpDir, pages)

--- a/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.sys.process.{Process, ProcessLogger}
-import scala.util.Try
+import scala.util.{Try, Using}
 
 class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, previewStorage: ObjectStorage,
   ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
@@ -76,7 +76,7 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
   }
 
   private def invokeOcrMyPdf(blobUri: Uri, lang: Language, file: File, config: OcrConfig, stderr: OcrStderrLogger, tmpDir: Path): String = {
-    val unprocessedFilePages = Try(PDDocument.load(file).getNumberOfPages).toOption
+    val unprocessedFilePages = Using(PDDocument.load(file))(_.getNumberOfPages).toOption
     val pdfFile = Ocr.invokeOcrMyPdf(lang.ocr, file.toPath, Some(config.dpi), stderr, tmpDir, unprocessedFilePages)
     var document: PDDocument = null
 


### PR DESCRIPTION
## What does this change?
I noticed in the logs thousands of instances of `Warning: You did not close the PDF Document` (50k in last 24 hours). This is documented here https://pdfbox.apache.org/2.0/faq.html#why-do-i-get-a-%22warning%3A-you-did-not-close-the-pdf-document%22%3F - we're supposed to wrap the `PDDocument.load` in a try/finally.

I don't expect this to have a huge impact on giant performance but it will clean up the logs a bit. 

It might be nice to switch all of our try/finally uses to [Using](https://www.scala-lang.org/api/2.13.6/scala/util/Using$.html)  at some point but here I've used using where it's a lot less verbose and try/finally in GetPages where there was already a try/finally.

## How has this change been tested?
I've tested this on playground by deploying it and uploading a single file. 
