### PR TITLE
Search: chip truncation

### DIFF
--- a/frontend/src/js/components/UtilComponents/InputSupper/Chip.js
+++ b/frontend/src/js/components/UtilComponents/InputSupper/Chip.js
@@ -1,10 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
+import ReactTooltip from "react-tooltip";
 
 import AutosizeInput from "react-input-autosize";
 
 import _ from "lodash";
 import { parseDate } from "../../../util/parseDate";
+
+// Default truncation settings for chip values
+const DEFAULT_MAX_VALUE_LENGTH = 75;
+const DEFAULT_TRUNCATED_LENGTH = 72;
+const DEFAULT_MAX_NAME_LENGTH = 50;
 
 export default class Chip extends React.Component {
   static propTypes = {
@@ -23,6 +29,12 @@ export default class Chip extends React.Component {
     onNegateClicked: PropTypes.func.isRequired,
     onDeleteClicked: PropTypes.func.isRequired,
     onEnterPressed: PropTypes.func.isRequired,
+
+    // Optional truncation configuration
+    maxValueLength: PropTypes.number,
+    truncatedLength: PropTypes.number,
+    maxNameLength: PropTypes.number,
+    showTooltip: PropTypes.bool,
   };
 
   onChange = (value) => {
@@ -99,7 +111,19 @@ export default class Chip extends React.Component {
     this.currentControl = element;
   };
 
+  getDisplayValue = () => {
+    const maxLength = this.props.maxValueLength ?? DEFAULT_MAX_VALUE_LENGTH;
+    const truncateAt = this.props.truncatedLength ?? DEFAULT_TRUNCATED_LENGTH;
+
+    if (this.props.value.length > maxLength) {
+      return `${this.props.value.substring(0, truncateAt)}...`;
+    }
+
+    return this.props.value;
+  };
+
   renderControl = () => {
+    const displayValue = this.getDisplayValue();
     switch (this.props.type) {
       case "text":
         return (
@@ -115,7 +139,7 @@ export default class Chip extends React.Component {
         return (
           <WorkspaceFolderChip
             ref={this.refHandler}
-            value={this.props.value}
+            value={displayValue}
             onChange={this.onChange}
             onKeyDown={this.onKeyDownDropdown}
             onFocus={this.onFocus}
@@ -163,6 +187,20 @@ export default class Chip extends React.Component {
   };
 
   render() {
+    const maxNameLength = this.props.maxNameLength ?? DEFAULT_MAX_NAME_LENGTH;
+    const showTooltip = this.props.showTooltip ?? true;
+    const maxValueLength =
+      this.props.maxValueLength ?? DEFAULT_MAX_VALUE_LENGTH;
+
+    let displayName = this.props.name;
+    if (this.props.value.length > maxNameLength) {
+      displayName = this.props.name.split(" ")[0]; // Use first word of name
+    }
+
+    const shouldShowTooltip =
+      showTooltip && this.props.value.length > maxValueLength;
+    const tooltipText = shouldShowTooltip ? this.props.value : undefined;
+
     return (
       <span
         className={`input-supper__chip ${this.props.stagedForDeletion ? "input-supper__chip--delete-glow" : ""}`}
@@ -176,8 +214,12 @@ export default class Chip extends React.Component {
           </div>
         </button>
 
-        <span className="input-supper__chip-body">
-          <span className="input-supper__chip-name">{this.props.name}</span>
+        <span
+          className="input-supper__chip-body"
+          data-tip={tooltipText}
+          data-effect={tooltipText ? "solid" : undefined}
+        >
+          <span className="input-supper__chip-name">{displayName}</span>
           {this.renderControl()}
         </span>
 
@@ -187,6 +229,7 @@ export default class Chip extends React.Component {
         >
           <div className="input-supper__button-icon">&times;</div>
         </button>
+        {tooltipText ? <ReactTooltip insecure={false} /> : null}
       </span>
     );
   }

--- a/frontend/src/js/components/UtilComponents/InputSupper/Chip.js
+++ b/frontend/src/js/components/UtilComponents/InputSupper/Chip.js
@@ -1,16 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
-import ReactTooltip from "react-tooltip";
 
 import AutosizeInput from "react-input-autosize";
 
 import _ from "lodash";
 import { parseDate } from "../../../util/parseDate";
 
-// Default truncation settings for chip values
-const DEFAULT_MAX_VALUE_LENGTH = 75;
-const DEFAULT_TRUNCATED_LENGTH = 72;
-const DEFAULT_MAX_NAME_LENGTH = 50;
+// Truncation settings for chip display values
+const MAX_VALUE_LENGTH = 75;
+const TRUNCATED_LENGTH = 72;
 
 export default class Chip extends React.Component {
   static propTypes = {
@@ -29,12 +27,6 @@ export default class Chip extends React.Component {
     onNegateClicked: PropTypes.func.isRequired,
     onDeleteClicked: PropTypes.func.isRequired,
     onEnterPressed: PropTypes.func.isRequired,
-
-    // Optional truncation configuration
-    maxValueLength: PropTypes.number,
-    truncatedLength: PropTypes.number,
-    maxNameLength: PropTypes.number,
-    showTooltip: PropTypes.bool,
   };
 
   onChange = (value) => {
@@ -112,13 +104,9 @@ export default class Chip extends React.Component {
   };
 
   getDisplayValue = () => {
-    const maxLength = this.props.maxValueLength ?? DEFAULT_MAX_VALUE_LENGTH;
-    const truncateAt = this.props.truncatedLength ?? DEFAULT_TRUNCATED_LENGTH;
-
-    if (this.props.value.length > maxLength) {
-      return `${this.props.value.substring(0, truncateAt)}...`;
+    if (this.props.value.length > MAX_VALUE_LENGTH) {
+      return `${this.props.value.substring(0, TRUNCATED_LENGTH)}...`;
     }
-
     return this.props.value;
   };
 
@@ -149,7 +137,7 @@ export default class Chip extends React.Component {
         return (
           <DateChip
             ref={this.refHandler}
-            value={this.props.value}
+            value={displayValue}
             onChange={this.onChange}
             onKeyDown={this.onKeyDownText}
             dateMode="from_start"
@@ -159,7 +147,7 @@ export default class Chip extends React.Component {
         return (
           <DateChip
             ref={this.refHandler}
-            value={this.props.value}
+            value={displayValue}
             onChange={this.onChange}
             onKeyDown={this.onKeyDownText}
             dateMode="from_end"
@@ -169,7 +157,7 @@ export default class Chip extends React.Component {
         return (
           <DropDownChip
             ref={this.refHandler}
-            value={this.props.value}
+            value={displayValue}
             options={this.props.options}
             onKeyDown={this.onKeyDownDropdown}
             onChange={this.onChange}
@@ -187,19 +175,8 @@ export default class Chip extends React.Component {
   };
 
   render() {
-    const maxNameLength = this.props.maxNameLength ?? DEFAULT_MAX_NAME_LENGTH;
-    const showTooltip = this.props.showTooltip ?? true;
-    const maxValueLength =
-      this.props.maxValueLength ?? DEFAULT_MAX_VALUE_LENGTH;
-
-    let displayName = this.props.name;
-    if (this.props.value.length > maxNameLength) {
-      displayName = this.props.name.split(" ")[0]; // Use first word of name
-    }
-
-    const shouldShowTooltip =
-      showTooltip && this.props.value.length > maxValueLength;
-    const tooltipText = shouldShowTooltip ? this.props.value : undefined;
+    const isTruncated = this.props.value.length > MAX_VALUE_LENGTH;
+    const tooltipText = isTruncated ? this.props.value : undefined;
 
     return (
       <span
@@ -219,7 +196,7 @@ export default class Chip extends React.Component {
           data-tip={tooltipText}
           data-effect={tooltipText ? "solid" : undefined}
         >
-          <span className="input-supper__chip-name">{displayName}</span>
+          <span className="input-supper__chip-name">{this.props.name}</span>
           {this.renderControl()}
         </span>
 
@@ -229,7 +206,6 @@ export default class Chip extends React.Component {
         >
           <div className="input-supper__button-icon">&times;</div>
         </button>
-        {tooltipText ? <ReactTooltip insecure={false} /> : null}
       </span>
     );
   }

--- a/frontend/src/js/components/UtilComponents/InputSupper/InlineInput.js
+++ b/frontend/src/js/components/UtilComponents/InputSupper/InlineInput.js
@@ -149,7 +149,11 @@ export default class InlineInput extends React.Component {
           type="text"
           onChange={this.onUpdate}
           value={this.props.value}
-          inputStyle={{ fontSize: 18, fontFamily: "Avenir Next" }}
+          inputStyle={{
+            fontSize: 18,
+            fontFamily: "Avenir Next",
+            maxWidth: "100%",
+          }}
           onKeyDown={this.onKeyPress}
           onClick={this.onClickInput}
           onFocus={this.onFocus}

--- a/frontend/src/js/components/UtilComponents/InputSupper/index.js
+++ b/frontend/src/js/components/UtilComponents/InputSupper/index.js
@@ -7,6 +7,7 @@ import _isObject from "lodash/isObject";
 import Chip from "./Chip";
 import InlineInput from "./InlineInput";
 import SuggestionsPanel from "./SuggestionsPanel";
+import ReactTooltip from "react-tooltip";
 
 export default class InputSupper extends React.Component {
   static propTypes = {
@@ -451,6 +452,7 @@ export default class InputSupper extends React.Component {
         <div className="input-supper">
           {this.state.elements.map((e, index) => this.renderElement(e, index))}
         </div>
+        <ReactTooltip insecure={false} />
       </div>
     );
   }

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -983,7 +983,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                       workspaceId: workspace.id,
                       folderId: entry.id,
                     },
-                    "*",
+                    "",
                   ]),
                   page: 1,
                 }),

--- a/frontend/src/stylesheets/components/_input-supper.scss
+++ b/frontend/src/stylesheets/components/_input-supper.scss
@@ -42,6 +42,10 @@
   display: inline-block;
   border: none;
   font-size: 18px;
+  max-width: 100%;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 
   &--chip {
     color: white;
@@ -58,11 +62,13 @@
   display: inline-block;
   height: 100%;
   margin: 0 calc($baseSpacing / 2) 0 0;
+  max-width: 100%;
 
   &:last-child {
     flex-grow: 1;
     cursor: text;
     margin: 0;
+    min-width: 100px; // Ensure there's always some space for typing
   }
 }
 

--- a/frontend/src/stylesheets/components/_input-supper.scss
+++ b/frontend/src/stylesheets/components/_input-supper.scss
@@ -101,7 +101,8 @@
 }
 
 .input-supper__chip-body {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   height: 100%;
   margin-left: 2px;
   margin-right: 2px;
@@ -116,8 +117,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  display: inline-block;
-  vertical-align: middle;
 
   &:after {
     content: ":";

--- a/frontend/src/stylesheets/components/_input-supper.scss
+++ b/frontend/src/stylesheets/components/_input-supper.scss
@@ -39,13 +39,12 @@
 .input-supper__inline-input {
   display: inline-block;
   background-color: transparent;
-  display: inline-block;
   border: none;
   font-size: 18px;
   max-width: 100%;
-  word-wrap: break-word;
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &--chip {
     color: white;
@@ -113,6 +112,12 @@
 .input-supper__chip-name {
   margin-right: 2px;
   font-size: 16px;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  vertical-align: middle;
 
   &:after {
     content: ":";


### PR DESCRIPTION
Very long folder names were making some "Search in folder" searches unusable because the long chip pushes the search button offscreen. (This is because the search box expands horizontally rather than behaving like a text-area, which we should address separately.)

This configures some truncation of chip text to mitigate that risk. 

Also removes the wildcard asterisk which was confusing people

Tested locally; seems OK. But I'll wait until next week and see if I can try it on playground