### PR TITLE
Add drag-and-drop file upload to workspace tree

### DIFF
--- a/frontend/src/js/components/Uploads/FileApiHelpers.ts
+++ b/frontend/src/js/components/Uploads/FileApiHelpers.ts
@@ -84,8 +84,22 @@ export async function readDirectoryEntry(
   }
 
   return new Promise((resolve, reject) => {
-    entry
-      .createReader()
-      .readEntries((entries) => entriesToMap(entries).then(resolve), reject);
+    const reader = entry.createReader();
+    const allEntries: FileSystemEntry[] = [];
+
+    // readEntries() may return results in batches (e.g. Chrome/Safari cap at ~100).
+    // Must call repeatedly until an empty array is returned.
+    function readBatch() {
+      reader.readEntries((entries) => {
+        if (entries.length === 0) {
+          entriesToMap(allEntries).then(resolve, reject);
+        } else {
+          allEntries.push(...entries);
+          readBatch();
+        }
+      }, reject);
+    }
+
+    readBatch();
   });
 }

--- a/frontend/src/js/components/Uploads/FilePicker.tsx
+++ b/frontend/src/js/components/Uploads/FilePicker.tsx
@@ -1,43 +1,6 @@
 import React from "react";
 import { Button } from "semantic-ui-react";
-import {
-  readFileEntry,
-  readDirectoryEntry,
-  FileSystemEntry,
-  FileSystemFileEntry,
-  FileSystemDirectoryEntry,
-} from "./FileApiHelpers";
-
-async function readDragEvent(e: React.DragEvent): Promise<Map<string, File>> {
-  const files = new Map<string, File>();
-
-  for (const item of e.dataTransfer.items) {
-    if (item.webkitGetAsEntry()) {
-      const entry: FileSystemEntry | null = item.webkitGetAsEntry();
-
-      if (entry && entry.isFile) {
-        const file = await readFileEntry(entry as FileSystemFileEntry);
-        files.set(file.name, file as File);
-      } else if (entry && entry.isDirectory) {
-        const directoryFiles = await readDirectoryEntry(
-          entry as FileSystemDirectoryEntry,
-        );
-
-        for (const [path, file] of directoryFiles) {
-          files.set(path, file as File);
-        }
-      }
-    } else {
-      const file = item.getAsFile();
-
-      if (file) {
-        files.set(file.name, file);
-      }
-    }
-  }
-
-  return files;
-}
+import { readFilesFromDragEvent } from "./dropZoneUtils";
 
 type Props = {
   disabled: boolean;
@@ -129,14 +92,21 @@ export default class FilePicker extends React.Component<Props, State> {
   onDrop = (e: React.DragEvent) => {
     e.preventDefault();
 
-    // Prevents React re-uses the event since readDragEvent is asynchronous
+    // Prevents React re-uses the event since readFilesFromDragEvent is asynchronous
     e.persist();
 
     this.setState({ readingFiles: true });
-    readDragEvent(e).then((files) => {
-      this.props.onAddFiles(files);
-      this.setState({ readingFiles: false });
-    });
+    readFilesFromDragEvent(e)
+      .then((files) => {
+        this.props.onAddFiles(files);
+      })
+      .catch((error) => {
+        console.error("Failed to read dropped files:", error);
+        window.alert(error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => {
+        this.setState({ readingFiles: false });
+      });
   };
 
   render() {

--- a/frontend/src/js/components/Uploads/FilePicker.tsx
+++ b/frontend/src/js/components/Uploads/FilePicker.tsx
@@ -5,6 +5,7 @@ import { readFilesFromDragEvent } from "./dropZoneUtils";
 type Props = {
   disabled: boolean;
   onAddFiles: (files: Map<string, File>) => void;
+  onError?: (message: string) => void;
 };
 
 type State = {
@@ -102,7 +103,11 @@ export default class FilePicker extends React.Component<Props, State> {
       })
       .catch((error) => {
         console.error("Failed to read dropped files:", error);
-        window.alert(error instanceof Error ? error.message : String(error));
+        if (this.props.onError) {
+          this.props.onError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
       })
       .finally(() => {
         this.setState({ readingFiles: false });

--- a/frontend/src/js/components/Uploads/UploadFiles.tsx
+++ b/frontend/src/js/components/Uploads/UploadFiles.tsx
@@ -74,6 +74,8 @@ type Props = {
   droppedFiles?: DroppedFilesInfo;
   /** Callback to clear the dropped files after they've been consumed */
   onClearDroppedFiles?: () => void;
+  /** Callback to report errors to the user */
+  onError?: (message: string) => void;
 };
 
 type State = {
@@ -469,6 +471,7 @@ export default function UploadFiles(props: Props) {
               onAddFiles={(files) => {
                 dispatch({ type: "Add_Files", files });
               }}
+              onError={props.onError}
             />
           </Form.Field>
           <Form.Field>

--- a/frontend/src/js/components/Uploads/UploadFiles.tsx
+++ b/frontend/src/js/components/Uploads/UploadFiles.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useState } from "react";
+import React, { useReducer, useState, useEffect } from "react";
 import uuid from "uuid/v4";
 import MdFileUpload from "react-icons/lib/md/file-upload";
 import Modal from "../UtilComponents/Modal";
@@ -55,6 +55,13 @@ export type WorkspaceUploadMetadata = {
 
 export type UploadFile = { file: File; state: FileUploadState };
 
+/** Files dropped from the file system to be uploaded */
+export type DroppedFilesInfo = {
+  files: Map<string, File>;
+  /** The target folder node where files should be uploaded, or null for root */
+  targetFolder: TreeNode<WorkspaceEntry> | null;
+};
+
 type Props = {
   username: string;
   workspace: Workspace;
@@ -63,6 +70,10 @@ type Props = {
   focusedWorkspaceEntry: TreeEntry<WorkspaceEntry> | null;
   expandedNodes?: TreeNode<WorkspaceEntry>[];
   isAdmin: boolean;
+  /** Files dropped from the file system (via drag-and-drop) */
+  droppedFiles?: DroppedFilesInfo;
+  /** Callback to clear the dropped files after they've been consumed */
+  onClearDroppedFiles?: () => void;
 };
 
 type State = {
@@ -329,6 +340,28 @@ export default function UploadFiles(props: Props) {
   const [open, setOpen] = useState(false);
   const [focusedWorkspaceFolder, setFocusedWorkspaceFolder] =
     useState<TreeNode<WorkspaceEntry> | null>(null);
+
+  // Destructure for useEffect dependencies
+  const { droppedFiles, onClearDroppedFiles } = props;
+
+  // Handle files dropped from the file system via drag-and-drop
+  useEffect(() => {
+    if (droppedFiles && droppedFiles.files.size > 0) {
+      // Set the target folder (null means root)
+      setFocusedWorkspaceFolder(droppedFiles.targetFolder);
+
+      // Add the files
+      dispatch({ type: "Add_Files", files: droppedFiles.files });
+
+      // Open the modal
+      setOpen(true);
+
+      // Clear the dropped files prop
+      if (onClearDroppedFiles) {
+        onClearDroppedFiles();
+      }
+    }
+  }, [droppedFiles, onClearDroppedFiles]);
 
   async function onSubmit() {
     const { username, workspace, collections, getResource } = props;

--- a/frontend/src/js/components/Uploads/dropZoneUtils.spec.ts
+++ b/frontend/src/js/components/Uploads/dropZoneUtils.spec.ts
@@ -1,0 +1,251 @@
+import {
+  readFilesFromDragEvent,
+  dragEventContainsFiles,
+} from "./dropZoneUtils";
+import * as FileApiHelpers from "./FileApiHelpers";
+
+// Mock the FileApiHelpers module
+jest.mock("./FileApiHelpers");
+const mockedReadFileEntry = FileApiHelpers.readFileEntry as jest.MockedFunction<
+  typeof FileApiHelpers.readFileEntry
+>;
+const mockedReadDirectoryEntry =
+  FileApiHelpers.readDirectoryEntry as jest.MockedFunction<
+    typeof FileApiHelpers.readDirectoryEntry
+  >;
+
+function makeFile(name: string): File {
+  return new File(["content"], name);
+}
+
+type MockItem = {
+  webkitGetAsEntry: () => FileApiHelpers.FileSystemEntry | null;
+  getAsFile: () => File | null;
+};
+
+function makeFileEntry(name: string): FileApiHelpers.FileSystemFileEntry {
+  const file = makeFile(name);
+  return {
+    isFile: true,
+    isDirectory: false,
+    fullPath: `/${name}`,
+    file: (cb: (f: File) => void) => {
+      cb(file);
+      return undefined as undefined;
+    },
+  };
+}
+
+function makeDirectoryEntry(): FileApiHelpers.FileSystemDirectoryEntry {
+  return {
+    isFile: false,
+    isDirectory: true,
+    createReader: () =>
+      ({
+        isFile: false,
+        isDirectory: false,
+        readEntries: (
+          cb: (entries: FileApiHelpers.FileSystemEntry[]) => void,
+        ) => {
+          cb([]);
+          return undefined as undefined;
+        },
+      }) as FileApiHelpers.FileSystemDirectoryReader,
+  };
+}
+
+function makeDragEvent(
+  items: MockItem[],
+  types: string[] = ["Files"],
+): React.DragEvent {
+  return {
+    dataTransfer: {
+      items: items as unknown as DataTransferItemList,
+      types,
+    },
+  } as unknown as React.DragEvent;
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe("readFilesFromDragEvent", () => {
+  test("reads a single file via webkitGetAsEntry", async () => {
+    const entry = makeFileEntry("test.txt");
+    const file = makeFile("test.txt");
+
+    mockedReadFileEntry.mockResolvedValue(file);
+
+    const event = makeDragEvent([
+      { webkitGetAsEntry: () => entry, getAsFile: () => null },
+    ]);
+
+    const result = await readFilesFromDragEvent(event);
+
+    expect(result.size).toBe(1);
+    expect(result.get("test.txt")).toBe(file);
+  });
+
+  test("reads multiple files", async () => {
+    const entry1 = makeFileEntry("a.txt");
+    const entry2 = makeFileEntry("b.txt");
+    const file1 = makeFile("a.txt");
+    const file2 = makeFile("b.txt");
+
+    mockedReadFileEntry
+      .mockResolvedValueOnce(file1)
+      .mockResolvedValueOnce(file2);
+
+    const event = makeDragEvent([
+      { webkitGetAsEntry: () => entry1, getAsFile: () => null },
+      { webkitGetAsEntry: () => entry2, getAsFile: () => null },
+    ]);
+
+    const result = await readFilesFromDragEvent(event);
+
+    expect(result.size).toBe(2);
+    expect(result.get("a.txt")).toBe(file1);
+    expect(result.get("b.txt")).toBe(file2);
+  });
+
+  test("reads a single directory", async () => {
+    const dirEntry = makeDirectoryEntry();
+    const dirFiles = new Map<string, File>([
+      ["dir/a.txt", makeFile("a.txt")],
+      ["dir/b.txt", makeFile("b.txt")],
+    ]);
+
+    mockedReadDirectoryEntry.mockResolvedValue(dirFiles);
+
+    const event = makeDragEvent([
+      { webkitGetAsEntry: () => dirEntry, getAsFile: () => null },
+    ]);
+
+    const result = await readFilesFromDragEvent(event);
+
+    expect(result.size).toBe(2);
+    expect(result.has("dir/a.txt")).toBe(true);
+    expect(result.has("dir/b.txt")).toBe(true);
+  });
+
+  test("rejects multiple directories", async () => {
+    const dir1 = makeDirectoryEntry();
+    const dir2 = makeDirectoryEntry();
+
+    const event = makeDragEvent([
+      { webkitGetAsEntry: () => dir1, getAsFile: () => null },
+      { webkitGetAsEntry: () => dir2, getAsFile: () => null },
+    ]);
+
+    await expect(readFilesFromDragEvent(event)).rejects.toThrow(
+      "Dragging multiple folders at once is not supported",
+    );
+  });
+
+  test("rejects mixed files and directory", async () => {
+    const dirEntry = makeDirectoryEntry();
+    const fileEntry = makeFileEntry("test.txt");
+
+    const event = makeDragEvent([
+      { webkitGetAsEntry: () => dirEntry, getAsFile: () => null },
+      { webkitGetAsEntry: () => fileEntry, getAsFile: () => null },
+    ]);
+
+    await expect(readFilesFromDragEvent(event)).rejects.toThrow(
+      "not both at the same time",
+    );
+  });
+
+  test("rejects directory mixed with fallback files", async () => {
+    const dirEntry = makeDirectoryEntry();
+    const fallbackFile = makeFile("fallback.txt");
+
+    const event = makeDragEvent([
+      { webkitGetAsEntry: () => dirEntry, getAsFile: () => null },
+      { webkitGetAsEntry: () => null, getAsFile: () => fallbackFile },
+    ]);
+
+    await expect(readFilesFromDragEvent(event)).rejects.toThrow(
+      "not both at the same time",
+    );
+  });
+
+  test("falls back to getAsFile when webkitGetAsEntry returns null", async () => {
+    const file = makeFile("fallback.txt");
+
+    const event = makeDragEvent([
+      { webkitGetAsEntry: () => null, getAsFile: () => file },
+    ]);
+
+    const result = await readFilesFromDragEvent(event);
+
+    expect(result.size).toBe(1);
+    expect(result.get("fallback.txt")).toBe(file);
+    expect(mockedReadFileEntry).not.toHaveBeenCalled();
+  });
+
+  test("skips items where both webkitGetAsEntry and getAsFile return null", async () => {
+    const file = makeFile("real.txt");
+
+    mockedReadFileEntry.mockResolvedValue(file);
+
+    const event = makeDragEvent([
+      { webkitGetAsEntry: () => null, getAsFile: () => null },
+      {
+        webkitGetAsEntry: () => makeFileEntry("real.txt"),
+        getAsFile: () => null,
+      },
+    ]);
+
+    const result = await readFilesFromDragEvent(event);
+
+    expect(result.size).toBe(1);
+    expect(result.get("real.txt")).toBe(file);
+  });
+});
+
+describe("dragEventContainsFiles", () => {
+  test("returns false when application/json is present (internal drag)", () => {
+    const event = makeDragEvent([], ["application/json", "Files"]);
+    expect(dragEventContainsFiles(event)).toBe(false);
+  });
+
+  test("returns true when Files type is present", () => {
+    const event = makeDragEvent([], ["Files"]);
+    expect(dragEventContainsFiles(event)).toBe(true);
+  });
+
+  test("returns true when items contain a file kind", () => {
+    const event = {
+      dataTransfer: {
+        types: ["text/plain"],
+        items: [{ kind: "file" }] as unknown as DataTransferItemList,
+      },
+    } as unknown as React.DragEvent;
+
+    expect(dragEventContainsFiles(event)).toBe(true);
+  });
+
+  test("returns false when no files and no file items", () => {
+    const event = {
+      dataTransfer: {
+        types: ["text/plain"],
+        items: [{ kind: "string" }] as unknown as DataTransferItemList,
+      },
+    } as unknown as React.DragEvent;
+
+    expect(dragEventContainsFiles(event)).toBe(false);
+  });
+
+  test("returns false for empty dataTransfer", () => {
+    const event = {
+      dataTransfer: {
+        types: [],
+        items: [] as unknown as DataTransferItemList,
+      },
+    } as unknown as React.DragEvent;
+
+    expect(dragEventContainsFiles(event)).toBe(false);
+  });
+});

--- a/frontend/src/js/components/Uploads/dropZoneUtils.spec.ts
+++ b/frontend/src/js/components/Uploads/dropZoneUtils.spec.ts
@@ -1,6 +1,7 @@
 import {
   readFilesFromDragEvent,
   dragEventContainsFiles,
+  INTERNAL_DRAG_MIME,
 } from "./dropZoneUtils";
 import * as FileApiHelpers from "./FileApiHelpers";
 
@@ -203,12 +204,54 @@ describe("readFilesFromDragEvent", () => {
     expect(result.size).toBe(1);
     expect(result.get("real.txt")).toBe(file);
   });
+
+  test("deduplicates files with the same name", async () => {
+    const file1 = makeFile("doc.txt");
+    const file2 = makeFile("doc.txt");
+
+    mockedReadFileEntry
+      .mockResolvedValueOnce(file1)
+      .mockResolvedValueOnce(file2);
+
+    const event = makeDragEvent([
+      {
+        webkitGetAsEntry: () => makeFileEntry("doc.txt"),
+        getAsFile: () => null,
+      },
+      {
+        webkitGetAsEntry: () => makeFileEntry("doc.txt"),
+        getAsFile: () => null,
+      },
+    ]);
+
+    const result = await readFilesFromDragEvent(event);
+
+    expect(result.size).toBe(2);
+    expect(result.has("doc.txt")).toBe(true);
+    expect(result.has("doc (1).txt")).toBe(true);
+  });
+
+  test("rejects an empty directory", async () => {
+    const dirEntry = makeDirectoryEntry();
+    mockedReadDirectoryEntry.mockResolvedValue(new Map());
+
+    const event = makeDragEvent([
+      { webkitGetAsEntry: () => dirEntry, getAsFile: () => null },
+    ]);
+
+    await expect(readFilesFromDragEvent(event)).rejects.toThrow("empty");
+  });
 });
 
 describe("dragEventContainsFiles", () => {
-  test("returns false when application/json is present (internal drag)", () => {
-    const event = makeDragEvent([], ["application/json", "Files"]);
+  test("returns false when internal drag MIME is present", () => {
+    const event = makeDragEvent([], [INTERNAL_DRAG_MIME, "Files"]);
     expect(dragEventContainsFiles(event)).toBe(false);
+  });
+
+  test("returns true when application/json is from an external source alongside Files", () => {
+    const event = makeDragEvent([], ["application/json", "Files"]);
+    expect(dragEventContainsFiles(event)).toBe(true);
   });
 
   test("returns true when Files type is present", () => {

--- a/frontend/src/js/components/Uploads/dropZoneUtils.spec.ts
+++ b/frontend/src/js/components/Uploads/dropZoneUtils.spec.ts
@@ -1,7 +1,7 @@
 import {
   readFilesFromDragEvent,
-  dragEventContainsFiles,
-  INTERNAL_DRAG_MIME,
+  isFilesystemDragEvent,
+  INTERNAL_DRAG_MIME_TYPE,
 } from "./dropZoneUtils";
 import * as FileApiHelpers from "./FileApiHelpers";
 
@@ -205,7 +205,7 @@ describe("readFilesFromDragEvent", () => {
     expect(result.get("real.txt")).toBe(file);
   });
 
-  test("deduplicates files with the same name", async () => {
+  test("last file wins when names collide", async () => {
     const file1 = makeFile("doc.txt");
     const file2 = makeFile("doc.txt");
 
@@ -226,9 +226,8 @@ describe("readFilesFromDragEvent", () => {
 
     const result = await readFilesFromDragEvent(event);
 
-    expect(result.size).toBe(2);
-    expect(result.has("doc.txt")).toBe(true);
-    expect(result.has("doc (1).txt")).toBe(true);
+    expect(result.size).toBe(1);
+    expect(result.get("doc.txt")).toBe(file2);
   });
 
   test("rejects an empty directory", async () => {
@@ -243,34 +242,23 @@ describe("readFilesFromDragEvent", () => {
   });
 });
 
-describe("dragEventContainsFiles", () => {
+describe("isFilesystemDragEvent", () => {
   test("returns false when internal drag MIME is present", () => {
-    const event = makeDragEvent([], [INTERNAL_DRAG_MIME, "Files"]);
-    expect(dragEventContainsFiles(event)).toBe(false);
+    const event = makeDragEvent([], [INTERNAL_DRAG_MIME_TYPE, "Files"]);
+    expect(isFilesystemDragEvent(event)).toBe(false);
   });
 
   test("returns true when application/json is from an external source alongside Files", () => {
     const event = makeDragEvent([], ["application/json", "Files"]);
-    expect(dragEventContainsFiles(event)).toBe(true);
+    expect(isFilesystemDragEvent(event)).toBe(true);
   });
 
   test("returns true when Files type is present", () => {
     const event = makeDragEvent([], ["Files"]);
-    expect(dragEventContainsFiles(event)).toBe(true);
+    expect(isFilesystemDragEvent(event)).toBe(true);
   });
 
-  test("returns true when items contain a file kind", () => {
-    const event = {
-      dataTransfer: {
-        types: ["text/plain"],
-        items: [{ kind: "file" }] as unknown as DataTransferItemList,
-      },
-    } as unknown as React.DragEvent;
-
-    expect(dragEventContainsFiles(event)).toBe(true);
-  });
-
-  test("returns false when no files and no file items", () => {
+  test("returns false when no Files type is present", () => {
     const event = {
       dataTransfer: {
         types: ["text/plain"],
@@ -278,7 +266,7 @@ describe("dragEventContainsFiles", () => {
       },
     } as unknown as React.DragEvent;
 
-    expect(dragEventContainsFiles(event)).toBe(false);
+    expect(isFilesystemDragEvent(event)).toBe(false);
   });
 
   test("returns false for empty dataTransfer", () => {
@@ -289,6 +277,6 @@ describe("dragEventContainsFiles", () => {
       },
     } as unknown as React.DragEvent;
 
-    expect(dragEventContainsFiles(event)).toBe(false);
+    expect(isFilesystemDragEvent(event)).toBe(false);
   });
 });

--- a/frontend/src/js/components/Uploads/dropZoneUtils.ts
+++ b/frontend/src/js/components/Uploads/dropZoneUtils.ts
@@ -1,0 +1,124 @@
+import React from "react";
+import {
+  readFileEntry,
+  readDirectoryEntry,
+  FileSystemEntry,
+  FileSystemFileEntry,
+  FileSystemDirectoryEntry,
+} from "./FileApiHelpers";
+
+/**
+ * Reads files from a drag event - handles both direct file drops and directories.
+ * Works across all major browsers on all platforms using the File System Access API.
+ *
+ * Only two kinds of selection are accepted:
+ *  1. A single directory (its full hierarchy is preserved); or
+ *  2. One or more files with no directories.
+ *
+ * Any other combination (e.g. mixed files and folders, or multiple folders) is
+ * rejected to avoid the ambiguous duplicate-entry problem that arises when the
+ * OS includes both a folder and its visible children as separate DataTransfer
+ * items.
+ *
+ * @param e - The React drag event
+ * @returns A Map of file paths to File objects
+ * @throws {Error} if the selection doesn't match one of the two accepted shapes
+ */
+export async function readFilesFromDragEvent(
+  e: React.DragEvent,
+): Promise<Map<string, File>> {
+  // Collect all entries and fallback files synchronously before any async work.
+  // The browser clears the DataTransfer after the event handler returns,
+  // so awaiting inside the loop would lose items beyond the first.
+  const entries: FileSystemEntry[] = [];
+  const fallbackFiles: File[] = [];
+
+  for (const item of e.dataTransfer.items) {
+    const entry = item.webkitGetAsEntry();
+
+    if (entry) {
+      entries.push(entry);
+    } else {
+      // Fallback for browsers that don't support webkitGetAsEntry
+      const file = item.getAsFile();
+
+      if (file) {
+        fallbackFiles.push(file);
+      }
+    }
+  }
+
+  const directoryEntries = entries.filter((e) => e.isDirectory);
+  const fileEntries = entries.filter((e) => e.isFile);
+
+  // Validate the selection shape
+  if (directoryEntries.length > 1) {
+    throw new Error(
+      "Please drag a single folder, or one or more individual files. " +
+        "Dragging multiple folders at once is not supported.",
+    );
+  }
+
+  if (
+    directoryEntries.length === 1 &&
+    (fileEntries.length > 0 || fallbackFiles.length > 0)
+  ) {
+    throw new Error(
+      "Please drag either a single folder or individual files, but not both at the same time.",
+    );
+  }
+
+  // Now process collected entries asynchronously
+  const files = new Map<string, File>();
+
+  if (directoryEntries.length === 1) {
+    // Single directory: read its full hierarchy
+    const directoryFiles = await readDirectoryEntry(
+      directoryEntries[0] as FileSystemDirectoryEntry,
+    );
+
+    for (const [path, file] of directoryFiles) {
+      files.set(path, file as File);
+    }
+  } else {
+    // Files only (no directories)
+    for (const entry of fileEntries) {
+      const file = await readFileEntry(entry as FileSystemFileEntry);
+      files.set(file.name, file as File);
+    }
+
+    for (const file of fallbackFiles) {
+      files.set(file.name, file);
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Checks if a drag event contains files from the file system (as opposed to
+ * internal application data like dragging items within the workspace).
+ *
+ * @param e - The React drag event
+ * @returns true if the drag event contains files from the file system and not internal app data
+ */
+export function dragEventContainsFiles(e: React.DragEvent): boolean {
+  // Internal tree drags set application/json — exclude those even if Files is also present
+  if (e.dataTransfer.types.includes("application/json")) {
+    return false;
+  }
+
+  // Check if there are any files in the dataTransfer
+  if (e.dataTransfer.types.includes("Files")) {
+    return true;
+  }
+
+  // Also check items for file entries
+  for (const item of e.dataTransfer.items) {
+    if (item.kind === "file") {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/frontend/src/js/components/Uploads/dropZoneUtils.ts
+++ b/frontend/src/js/components/Uploads/dropZoneUtils.ts
@@ -8,6 +8,28 @@ import {
 } from "./FileApiHelpers";
 
 /**
+ * Custom MIME type used by internal tree drags to distinguish them from
+ * file-system drops. Using a custom type avoids false positives when an
+ * external application happens to set application/json on its drag data.
+ */
+export const INTERNAL_DRAG_MIME = "application/x-giant-tree-entry";
+
+/** If `key` already exists in `map`, append a numeric suffix to make it unique. */
+function deduplicateKey(map: Map<string, unknown>, key: string): string {
+  if (!map.has(key)) return key;
+
+  const dotIndex = key.lastIndexOf(".");
+  const base = dotIndex > 0 ? key.slice(0, dotIndex) : key;
+  const ext = dotIndex > 0 ? key.slice(dotIndex) : "";
+
+  let counter = 1;
+  while (map.has(`${base} (${counter})${ext}`)) {
+    counter++;
+  }
+  return `${base} (${counter})${ext}`;
+}
+
+/**
  * Reads files from a drag event - handles both direct file drops and directories.
  * Works across all major browsers on all platforms using the File System Access API.
  *
@@ -84,12 +106,18 @@ export async function readFilesFromDragEvent(
     // Files only (no directories)
     for (const entry of fileEntries) {
       const file = await readFileEntry(entry as FileSystemFileEntry);
-      files.set(file.name, file as File);
+      const name = deduplicateKey(files, file.name);
+      files.set(name, file as File);
     }
 
     for (const file of fallbackFiles) {
-      files.set(file.name, file);
+      const name = deduplicateKey(files, file.name);
+      files.set(name, file);
     }
+  }
+
+  if (files.size === 0) {
+    throw new Error("The dropped folder was empty.");
   }
 
   return files;
@@ -103,8 +131,8 @@ export async function readFilesFromDragEvent(
  * @returns true if the drag event contains files from the file system and not internal app data
  */
 export function dragEventContainsFiles(e: React.DragEvent): boolean {
-  // Internal tree drags set application/json — exclude those even if Files is also present
-  if (e.dataTransfer.types.includes("application/json")) {
+  // Internal tree drags use a custom MIME type — exclude them even if Files is also present
+  if (e.dataTransfer.types.includes(INTERNAL_DRAG_MIME)) {
     return false;
   }
 

--- a/frontend/src/js/components/Uploads/dropZoneUtils.ts
+++ b/frontend/src/js/components/Uploads/dropZoneUtils.ts
@@ -12,26 +12,11 @@ import {
  * file-system drops. Using a custom type avoids false positives when an
  * external application happens to set application/json on its drag data.
  */
-export const INTERNAL_DRAG_MIME = "application/x-giant-tree-entry";
-
-/** If `key` already exists in `map`, append a numeric suffix to make it unique. */
-function deduplicateKey(map: Map<string, unknown>, key: string): string {
-  if (!map.has(key)) return key;
-
-  const dotIndex = key.lastIndexOf(".");
-  const base = dotIndex > 0 ? key.slice(0, dotIndex) : key;
-  const ext = dotIndex > 0 ? key.slice(dotIndex) : "";
-
-  let counter = 1;
-  while (map.has(`${base} (${counter})${ext}`)) {
-    counter++;
-  }
-  return `${base} (${counter})${ext}`;
-}
+export const INTERNAL_DRAG_MIME_TYPE = "application/x-giant-tree-entry";
 
 /**
  * Reads files from a drag event - handles both direct file drops and directories.
- * Works across all major browsers on all platforms using the File System Access API.
+ * using the File System Access API.
  *
  * Only two kinds of selection are accepted:
  *  1. A single directory (its full hierarchy is preserved); or
@@ -106,13 +91,11 @@ export async function readFilesFromDragEvent(
     // Files only (no directories)
     for (const entry of fileEntries) {
       const file = await readFileEntry(entry as FileSystemFileEntry);
-      const name = deduplicateKey(files, file.name);
-      files.set(name, file as File);
+      files.set(file.name, file as File);
     }
 
     for (const file of fallbackFiles) {
-      const name = deduplicateKey(files, file.name);
-      files.set(name, file);
+      files.set(file.name, file);
     }
   }
 
@@ -130,23 +113,11 @@ export async function readFilesFromDragEvent(
  * @param e - The React drag event
  * @returns true if the drag event contains files from the file system and not internal app data
  */
-export function dragEventContainsFiles(e: React.DragEvent): boolean {
+export function isFilesystemDragEvent(e: React.DragEvent): boolean {
   // Internal tree drags use a custom MIME type — exclude them even if Files is also present
-  if (e.dataTransfer.types.includes(INTERNAL_DRAG_MIME)) {
+  if (e.dataTransfer.types.includes(INTERNAL_DRAG_MIME_TYPE)) {
     return false;
   }
 
-  // Check if there are any files in the dataTransfer
-  if (e.dataTransfer.types.includes("Files")) {
-    return true;
-  }
-
-  // Also check items for file entries
-  for (const item of e.dataTransfer.items) {
-    if (item.kind === "file") {
-      return true;
-    }
-  }
-
-  return false;
+  return e.dataTransfer.types.includes("Files");
 }

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/Leaf.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/Leaf.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { MenuChevron } from "../MenuChevron";
 import { ColumnsConfig, TreeEntry, TreeLeaf } from "../../../types/Tree";
+import { INTERNAL_DRAG_MIME } from "../../Uploads/dropZoneUtils";
 
 type Props<T> = {
   entry: TreeLeaf<T>;
@@ -81,7 +82,7 @@ export default class Leaf<T> extends React.Component<Props<T>, {}> {
 
   onDragStart = (e: React.DragEvent<HTMLTableRowElement>) => {
     e.dataTransfer.setData(
-      "application/json",
+      INTERNAL_DRAG_MIME,
       JSON.stringify({ id: this.props.entry.id }),
     );
   };

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/Leaf.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/Leaf.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { MenuChevron } from "../MenuChevron";
 import { ColumnsConfig, TreeEntry, TreeLeaf } from "../../../types/Tree";
-import { INTERNAL_DRAG_MIME } from "../../Uploads/dropZoneUtils";
+import { INTERNAL_DRAG_MIME_TYPE } from "../../Uploads/dropZoneUtils";
 
 type Props<T> = {
   entry: TreeLeaf<T>;
@@ -82,7 +82,7 @@ export default class Leaf<T> extends React.Component<Props<T>, {}> {
 
   onDragStart = (e: React.DragEvent<HTMLTableRowElement>) => {
     e.dataTransfer.setData(
-      INTERNAL_DRAG_MIME,
+      INTERNAL_DRAG_MIME_TYPE,
       JSON.stringify({ id: this.props.entry.id }),
     );
   };

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
@@ -13,6 +13,7 @@ import {
 import { SearchLink } from "../SearchLink";
 import { MAX_NUMBER_OF_CHILDREN } from "../../../util/resourceUtils";
 import { sortEntries } from "../../../util/treeUtils";
+import { INTERNAL_DRAG_MIME } from "../../Uploads/dropZoneUtils";
 
 type Props<T> = {
   entry: TreeNode<T>;
@@ -142,7 +143,7 @@ export default class Node<T> extends React.Component<Props<T>, State> {
   onDragStart = (e: DragEvent<HTMLTableRowElement>) => {
     if (e.dataTransfer) {
       e.dataTransfer.setData(
-        "application/json",
+        INTERNAL_DRAG_MIME,
         JSON.stringify({ id: this.props.entry.id }),
       );
     }

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
@@ -13,7 +13,7 @@ import {
 import { SearchLink } from "../SearchLink";
 import { MAX_NUMBER_OF_CHILDREN } from "../../../util/resourceUtils";
 import { sortEntries } from "../../../util/treeUtils";
-import { INTERNAL_DRAG_MIME } from "../../Uploads/dropZoneUtils";
+import { INTERNAL_DRAG_MIME_TYPE } from "../../Uploads/dropZoneUtils";
 
 type Props<T> = {
   entry: TreeNode<T>;
@@ -143,7 +143,7 @@ export default class Node<T> extends React.Component<Props<T>, State> {
   onDragStart = (e: DragEvent<HTMLTableRowElement>) => {
     if (e.dataTransfer) {
       e.dataTransfer.setData(
-        INTERNAL_DRAG_MIME,
+        INTERNAL_DRAG_MIME_TYPE,
         JSON.stringify({ id: this.props.entry.id }),
       );
     }

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
@@ -17,6 +17,10 @@ import {
 import { MAX_NUMBER_OF_CHILDREN } from "../../../util/resourceUtils";
 import { SearchLink } from "../SearchLink";
 import { getIdsOfEntriesToMove, sortEntries } from "../../../util/treeUtils";
+import {
+  dragEventContainsFiles,
+  readFilesFromDragEvent,
+} from "../../Uploads/dropZoneUtils";
 
 type Props<T> = {
   onSelectLeaf: (leaf: TreeLeaf<T>) => void;
@@ -42,6 +46,8 @@ type Props<T> = {
   onExpandNode: (entry: TreeNode<T>) => void;
   onCollapseNode: (entry: TreeNode<T>) => void;
   onContextMenu: (e: React.MouseEvent, entry: TreeEntry<T>) => void;
+  /** Optional callback for handling file drops from the file system */
+  onDropFiles?: (files: Map<string, File>, targetFolderId: string) => void;
 };
 
 type State = {
@@ -174,13 +180,36 @@ export default class TreeBrowser<T> extends React.Component<Props<T>, State> {
   onDrop = (e: React.DragEvent, idOfLocationToMoveTo: string) => {
     e.preventDefault();
 
+    // Check if this is a file drop from the file system
+    if (dragEventContainsFiles(e) && this.props.onDropFiles) {
+      // Prevent React from reusing the event since readFilesFromDragEvent is asynchronous
+      e.persist();
+
+      this.setState({ hoveredOver: false });
+
+      readFilesFromDragEvent(e)
+        .then((files) => {
+          if (files.size > 0 && this.props.onDropFiles) {
+            this.props.onDropFiles(files, idOfLocationToMoveTo);
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to read dropped files:", error);
+          window.alert(error instanceof Error ? error.message : String(error));
+        });
+      return;
+    }
+
+    // Handle internal item move
     const json = e.dataTransfer.getData("application/json");
-    const { id: idOfDraggedEntry } = JSON.parse(json);
-    const idsOfEntriesToMove = getIdsOfEntriesToMove(
-      this.props.selectedEntries,
-      idOfDraggedEntry,
-    );
-    this.props.onMoveItems(idsOfEntriesToMove, idOfLocationToMoveTo);
+    if (json) {
+      const { id: idOfDraggedEntry } = JSON.parse(json);
+      const idsOfEntriesToMove = getIdsOfEntriesToMove(
+        this.props.selectedEntries,
+        idOfDraggedEntry,
+      );
+      this.props.onMoveItems(idsOfEntriesToMove, idOfLocationToMoveTo);
+    }
 
     this.setState({
       hoveredOver: false,

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
@@ -19,6 +19,7 @@ import { SearchLink } from "../SearchLink";
 import { getIdsOfEntriesToMove, sortEntries } from "../../../util/treeUtils";
 import {
   dragEventContainsFiles,
+  INTERNAL_DRAG_MIME,
   readFilesFromDragEvent,
 } from "../../Uploads/dropZoneUtils";
 
@@ -207,7 +208,7 @@ export default class TreeBrowser<T> extends React.Component<Props<T>, State> {
     }
 
     // Handle internal item move
-    const json = e.dataTransfer.getData("application/json");
+    const json = e.dataTransfer.getData(INTERNAL_DRAG_MIME);
     if (json) {
       const { id: idOfDraggedEntry } = JSON.parse(json);
       const idsOfEntriesToMove = getIdsOfEntriesToMove(

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
@@ -48,6 +48,8 @@ type Props<T> = {
   onContextMenu: (e: React.MouseEvent, entry: TreeEntry<T>) => void;
   /** Optional callback for handling file drops from the file system */
   onDropFiles?: (files: Map<string, File>, targetFolderId: string) => void;
+  /** Optional callback for reporting file drop errors to the user */
+  onDropError?: (message: string) => void;
 };
 
 type State = {
@@ -195,7 +197,11 @@ export default class TreeBrowser<T> extends React.Component<Props<T>, State> {
         })
         .catch((error) => {
           console.error("Failed to read dropped files:", error);
-          window.alert(error instanceof Error ? error.message : String(error));
+          if (this.props.onDropError) {
+            this.props.onDropError(
+              error instanceof Error ? error.message : String(error),
+            );
+          }
         });
       return;
     }

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
@@ -18,8 +18,8 @@ import { MAX_NUMBER_OF_CHILDREN } from "../../../util/resourceUtils";
 import { SearchLink } from "../SearchLink";
 import { getIdsOfEntriesToMove, sortEntries } from "../../../util/treeUtils";
 import {
-  dragEventContainsFiles,
-  INTERNAL_DRAG_MIME,
+  isFilesystemDragEvent,
+  INTERNAL_DRAG_MIME_TYPE,
   readFilesFromDragEvent,
 } from "../../Uploads/dropZoneUtils";
 
@@ -184,7 +184,7 @@ export default class TreeBrowser<T> extends React.Component<Props<T>, State> {
     e.preventDefault();
 
     // Check if this is a file drop from the file system
-    if (dragEventContainsFiles(e) && this.props.onDropFiles) {
+    if (isFilesystemDragEvent(e) && this.props.onDropFiles) {
       // Prevent React from reusing the event since readFilesFromDragEvent is asynchronous
       e.persist();
 
@@ -208,7 +208,7 @@ export default class TreeBrowser<T> extends React.Component<Props<T>, State> {
     }
 
     // Handle internal item move
-    const json = e.dataTransfer.getData(INTERNAL_DRAG_MIME);
+    const json = e.dataTransfer.getData(INTERNAL_DRAG_MIME_TYPE);
     if (json) {
       const { id: idOfDraggedEntry } = JSON.parse(json);
       const idsOfEntriesToMove = getIdsOfEntriesToMove(

--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -12,7 +12,7 @@ import { setWorkspaceFollowers } from "../../actions/workspaces/setWorkspaceFoll
 import { setWorkspaceIsPublic } from "../../actions/workspaces/setWorkspaceIsPublic";
 import { renameWorkspace } from "../../actions/workspaces/renameWorkspace";
 import { deleteWorkspace } from "../../actions/workspaces/deleteWorkspace";
-import UploadFiles from "../Uploads/UploadFiles";
+import UploadFiles, { DroppedFilesInfo } from "../Uploads/UploadFiles";
 import { Collection } from "../../types/Collection";
 import { TreeEntry, TreeNode } from "../../types/Tree";
 import { getWorkspace } from "../../actions/workspaces/getWorkspace";
@@ -44,6 +44,10 @@ type Props = {
   expandedNodes: TreeNode<WorkspaceEntry>[];
   isAdmin: boolean;
   clearFocus: () => void;
+  /** Files dropped from the file system (via drag-and-drop) */
+  droppedFiles?: DroppedFilesInfo;
+  /** Callback to clear the dropped files after they've been consumed */
+  onClearDroppedFiles?: () => void;
 };
 
 export default function WorkspaceSummary({
@@ -62,6 +66,8 @@ export default function WorkspaceSummary({
   expandedNodes,
   isAdmin,
   clearFocus,
+  droppedFiles,
+  onClearDroppedFiles,
 }: Props) {
   const [downloadTextModalOpen, setDownloadTextModalOpen] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
@@ -150,6 +156,8 @@ export default function WorkspaceSummary({
         focusedWorkspaceEntry={focusedEntry}
         expandedNodes={expandedNodes}
         isAdmin={isAdmin}
+        droppedFiles={droppedFiles}
+        onClearDroppedFiles={onClearDroppedFiles}
       />
       <CaptureFromUrl maybePreSelectedWorkspace={workspace} withButton />
       <Dropdown

--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -48,6 +48,8 @@ type Props = {
   droppedFiles?: DroppedFilesInfo;
   /** Callback to clear the dropped files after they've been consumed */
   onClearDroppedFiles?: () => void;
+  /** Callback to report errors to the user */
+  onError?: (message: string) => void;
 };
 
 export default function WorkspaceSummary({
@@ -68,6 +70,7 @@ export default function WorkspaceSummary({
   clearFocus,
   droppedFiles,
   onClearDroppedFiles,
+  onError,
 }: Props) {
   const [downloadTextModalOpen, setDownloadTextModalOpen] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
@@ -158,6 +161,7 @@ export default function WorkspaceSummary({
         isAdmin={isAdmin}
         droppedFiles={droppedFiles}
         onClearDroppedFiles={onClearDroppedFiles}
+        onError={onError}
       />
       <CaptureFromUrl maybePreSelectedWorkspace={workspace} withButton />
       <Dropdown

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -85,6 +85,7 @@ import {
 import MdGlobeIcon from "react-icons/lib/md/public";
 import { FromNowDurationText } from "../UtilComponents/FromNowDurationText";
 import { DroppedFilesInfo } from "../Uploads/UploadFiles";
+import { createWarning } from "../../actions/problems";
 
 /** Recursively search a tree node for a child node by ID */
 function findNodeById(
@@ -819,6 +820,10 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
     });
   };
 
+  onDropError = (message: string) => {
+    this.props.createWarning(message);
+  };
+
   onContextMenu = (e: React.MouseEvent, entry: TreeEntry<WorkspaceEntry>) => {
     if (e.metaKey && e.shiftKey) {
       // override for devs to do "inspect element"
@@ -1224,6 +1229,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             focusedEntry={this.props.focusedEntry}
             onMoveItems={this.onMoveItems}
             onDropFiles={this.onDropFiles}
+            onDropError={this.onDropError}
             onSelectLeaf={onSelectLeaf}
             columnsConfig={this.state.columnsConfig}
             onClickColumn={this.onClickColumn}
@@ -1286,6 +1292,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
           clearFocus={this.clearFocus}
           droppedFiles={this.state.droppedFiles}
           onClearDroppedFiles={this.onClearDroppedFiles}
+          onError={this.onDropError}
         />
         <div className="workspace">
           {this.renderFolderTree(this.props.currentWorkspace)}
@@ -1376,6 +1383,7 @@ function mapDispatchToProps(dispatch: GiantDispatch) {
     setWorkspaceFollowers: bindActionCreators(setWorkspaceFollowers, dispatch),
     setWorkspaceIsPublic: bindActionCreators(setWorkspaceIsPublic, dispatch),
     listUsers: bindActionCreators(listUsers, dispatch),
+    createWarning: bindActionCreators(createWarning, dispatch),
     getCollections: bindActionCreators(getCollections, dispatch),
     getWorkspacesMetadata: bindActionCreators(getWorkspacesMetadata, dispatch),
     getWorkspace: bindActionCreators(getWorkspace, dispatch),

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -34,6 +34,7 @@ import {
   isTreeNode,
   TreeEntry,
   TreeLeaf,
+  TreeNode,
 } from "../../types/Tree";
 import {
   isWorkspaceLeaf,
@@ -83,6 +84,22 @@ import {
 } from "@elastic/eui";
 import MdGlobeIcon from "react-icons/lib/md/public";
 import { FromNowDurationText } from "../UtilComponents/FromNowDurationText";
+import { DroppedFilesInfo } from "../Uploads/UploadFiles";
+
+/** Recursively search a tree node for a child node by ID */
+function findNodeById(
+  node: TreeNode<WorkspaceEntry>,
+  id: string,
+): TreeNode<WorkspaceEntry> | undefined {
+  for (const child of node.children) {
+    if (isTreeNode(child)) {
+      if (child.id === id) return child;
+      const found = findNodeById(child, id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
 
 type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps> &
@@ -112,6 +129,8 @@ type State = {
   };
   itemsBeingMoved: number;
   itemsWithMoveSettled: number;
+  /** Files dropped from the file system via drag-and-drop */
+  droppedFiles: DroppedFilesInfo | undefined;
 };
 
 type ContextMenuEntry = {
@@ -420,6 +439,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
     },
     itemsBeingMoved: 0,
     itemsWithMoveSettled: 0,
+    droppedFiles: undefined,
   };
 
   poller: NodeJS.Timeout | null = null;
@@ -757,6 +777,45 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
           itemsBeingMoved: isAllSettled ? 0 : prev.itemsBeingMoved,
         };
       });
+    });
+  };
+
+  /**
+   * Handles files dropped from the file system via drag-and-drop onto a folder in the workspace tree.
+   * Sets the droppedFiles state which triggers the upload modal to open with the files pre-populated.
+   */
+  onDropFiles = (files: Map<string, File>, targetFolderId: string) => {
+    const workspace = this.props.currentWorkspace;
+    if (!workspace) return;
+
+    let targetFolder: TreeNode<WorkspaceEntry> | null = null;
+
+    if (targetFolderId !== workspace.rootNode.id) {
+      // Search expanded nodes first (cheapest), then the full tree
+      const foundNode =
+        this.props.expandedNodes.find((node) => node.id === targetFolderId) ??
+        findNodeById(workspace.rootNode, targetFolderId);
+
+      if (foundNode) {
+        targetFolder = foundNode;
+      }
+    }
+    // If targetFolderId is root or not found, targetFolder stays null (uploads to root)
+
+    this.setState({
+      droppedFiles: {
+        files,
+        targetFolder,
+      },
+    });
+  };
+
+  /**
+   * Clears the dropped files state after the upload modal has consumed them.
+   */
+  onClearDroppedFiles = () => {
+    this.setState({
+      droppedFiles: undefined,
     });
   };
 
@@ -1164,6 +1223,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             selectedEntries={this.props.selectedEntries}
             focusedEntry={this.props.focusedEntry}
             onMoveItems={this.onMoveItems}
+            onDropFiles={this.onDropFiles}
             onSelectLeaf={onSelectLeaf}
             columnsConfig={this.state.columnsConfig}
             onClickColumn={this.onClickColumn}
@@ -1224,6 +1284,8 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
             "CanPerformAdminOperations",
           )}
           clearFocus={this.clearFocus}
+          droppedFiles={this.state.droppedFiles}
+          onClearDroppedFiles={this.onClearDroppedFiles}
         />
         <div className="workspace">
           {this.renderFolderTree(this.props.currentWorkspace)}

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -54,6 +54,7 @@ import {
 } from "../../util/treeUtils";
 import { setFocusedEntry } from "../../actions/workspaces/setFocusedEntry";
 import {
+  findNodeById,
   getEntryLink,
   processingStageToString,
   workspaceEntryPath,
@@ -86,21 +87,6 @@ import MdGlobeIcon from "react-icons/lib/md/public";
 import { FromNowDurationText } from "../UtilComponents/FromNowDurationText";
 import { DroppedFilesInfo } from "../Uploads/UploadFiles";
 import { createWarning } from "../../actions/problems";
-
-/** Recursively search a tree node for a child node by ID */
-function findNodeById(
-  node: TreeNode<WorkspaceEntry>,
-  id: string,
-): TreeNode<WorkspaceEntry> | undefined {
-  for (const child of node.children) {
-    if (isTreeNode(child)) {
-      if (child.id === id) return child;
-      const found = findNodeById(child, id);
-      if (found) return found;
-    }
-  }
-  return undefined;
-}
 
 type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps> &

--- a/frontend/src/js/components/workspace/WorkspacesSidebarItem.tsx
+++ b/frontend/src/js/components/workspace/WorkspacesSidebarItem.tsx
@@ -6,6 +6,7 @@ import { bindActionCreators } from "redux";
 import { GiantDispatch } from "../../types/redux/GiantDispatch";
 import { connect } from "react-redux";
 import { getIdsOfEntriesToMove } from "../../util/treeUtils";
+import { INTERNAL_DRAG_MIME } from "../Uploads/dropZoneUtils";
 import { copyItems } from "../../actions/workspaces/copyItem";
 import Modal from "../UtilComponents/Modal";
 import { CopyOrMoveModal } from "./CopyOrMoveModal";
@@ -41,7 +42,7 @@ const WorkspacesSidebarItem: FC<PropTypes> = ({
             setInvalidDestinationModalOpen(true);
             return;
           }
-          const json = e.dataTransfer.getData("application/json");
+          const json = e.dataTransfer.getData(INTERNAL_DRAG_MIME);
           const { id: idOfDraggedEntry } = JSON.parse(json);
           const entryIds = getIdsOfEntriesToMove(
             selectedEntries,

--- a/frontend/src/js/components/workspace/WorkspacesSidebarItem.tsx
+++ b/frontend/src/js/components/workspace/WorkspacesSidebarItem.tsx
@@ -6,7 +6,7 @@ import { bindActionCreators } from "redux";
 import { GiantDispatch } from "../../types/redux/GiantDispatch";
 import { connect } from "react-redux";
 import { getIdsOfEntriesToMove } from "../../util/treeUtils";
-import { INTERNAL_DRAG_MIME } from "../Uploads/dropZoneUtils";
+import { INTERNAL_DRAG_MIME_TYPE } from "../Uploads/dropZoneUtils";
 import { copyItems } from "../../actions/workspaces/copyItem";
 import Modal from "../UtilComponents/Modal";
 import { CopyOrMoveModal } from "./CopyOrMoveModal";
@@ -42,7 +42,7 @@ const WorkspacesSidebarItem: FC<PropTypes> = ({
             setInvalidDestinationModalOpen(true);
             return;
           }
-          const json = e.dataTransfer.getData(INTERNAL_DRAG_MIME);
+          const json = e.dataTransfer.getData(INTERNAL_DRAG_MIME_TYPE);
           const { id: idOfDraggedEntry } = JSON.parse(json);
           const entryIds = getIdsOfEntriesToMove(
             selectedEntries,


### PR DESCRIPTION
Addresses #314.



Users can now drag files and folders from their file system directly onto any folder in the workspace tree (or the empty area below it) to trigger an upload to that location. The upload modal opens pre-populated with the dropped files and targeted at the correct workspace folder.

### Before:
![2026-04-14 15 37 20](https://github.com/user-attachments/assets/6fd32431-abb5-4b46-b0c3-c432d110b832)


### After:

![2026-04-14 15 38 12](https://github.com/user-attachments/assets/dc11363d-4cb4-421a-a7f6-e066266b08c0)

### What this does

- New shared utility `dropZoneUtils.ts`:
- - `readFilesFromDragEvent` reads files and recursively reads directories from the `DataTransfer`
- - `dragEventContainsFiles` distinguishes file-system drops from internal tree item drags.
- Detects file-system drops via a new `onDropFiles` prop, falling through to the existing internal-move logic otherwise.
- Resolves the target folder from the drop location and sets `droppedFiles` state, which flows through WorkspaceSummary to UploadFiles.
- *Consumes `droppedFiles` via a `useEffect` to prepopulate the existing upload dialog.

### Key implementation details

- `FileSystemEntry` references are captured synchronously before any async work. Browsers invalidate the `DataTransfer` after the synchronous event handler returns, so awaiting inside the `dataTransfer.items` loop would result in us silently losing all items beyond the first. 
- Chrome and Safari cap directory reads at ~100 entries per call. `readDirectoryEntry` now loops until an empty batch is returned to ensure that large directories are fully read.
- Browsers that don't support `webkitGetAsEntry()` fall back to `getAsFile()`.
- `findNodeByID` has been moved to a util since both this work and #658 use the same workspace position logic.

### Tested locally and on playground with

- Single folder (containing subfolders and files)
- Multiple files
- Multiple folders
- Mixed selection of files and folders
