### PR TITLE
Add "Search this workspace" button

### DIFF
--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -26,6 +26,7 @@ import { takeOwnershipOfWorkspace } from "../../actions/workspaces/takeOwnership
 import { CaptureFromUrl } from "../Uploads/CaptureFromUrl";
 import { EuiText } from "@elastic/eui";
 import { FileAndFolderCounts } from "../UtilComponents/TreeBrowser/FileAndFolderCounts";
+import buildLink from "../../util/buildLink";
 import history from "../../util/history";
 
 type Props = {
@@ -122,10 +123,15 @@ export default function WorkspaceSummary({
       <button
         className="btn"
         onClick={() => {
-          const searchUrl = `/search?filters.workspace[]=${encodeURIComponent(workspace.id)}`;
-          window.open(searchUrl, "_blank");
+          const searchUrl = buildLink(
+            "/search",
+            {},
+            { filters: { workspace: [workspace.id] } },
+          );
+          window.open(searchUrl, "_blank", "noopener");
         }}
         title="Search workspace"
+        aria-label={`Search workspace ${workspace.name}`}
       >
         <SearchIcon style={{ marginRight: "3px", marginBottom: "1px" }} />
         Search workspace


### PR DESCRIPTION
Fixes #307 as a temporary convenience (before we do this properly with https://github.com/guardian/giant/issues/372), adds a button to prefill the active workspace in a Giant search page (in a new tab so the current context is not altogether lost)  

Tested in local dev env and playground; looks ok