### PR TITLE
add a new 'fast lane' option when uploading

### DIFF
--- a/backend/app/controllers/api/Collections.scala
+++ b/backend/app/controllers/api/Collections.scala
@@ -245,7 +245,10 @@ class Collections(override val controllerComponents: AuthControllerComponents, m
       temporaryFilePath = req.body.path,
       originalPath = Paths.get(originalPath),
       lastModifiedTime,
-      manifest, esEvents, ingestionServices, annotations, fingerprint
+      manifest, esEvents, ingestionServices, annotations, fingerprint,
+      // TODO consider isAdmin check too for fast lane (isAdmin <- users.hasPermission(req.user.username, CanPerformAdminOperations)
+      isFastLane = req.headers.get("X-PFI-Fast-Lane").contains("true")
+
     ).process().map { result =>
       Created(Json.toJson(result))
     }

--- a/backend/app/services/manifest/Manifest.scala
+++ b/backend/app/services/manifest/Manifest.scala
@@ -16,8 +16,17 @@ import java.nio.file.Path
 object Manifest {
   sealed trait Insertion
   case class InsertDirectory(parentUri: Uri, uri: Uri) extends Insertion
-  case class InsertBlob(file: IngestionFile, blobUri: Uri, parentBlobs: List[Uri], mimeType: MimeType, ingestion: String,
-                        languages: List[String], extractors: Iterable[Extractor], workspace: Option[WorkspaceItemContext]) extends Insertion
+  case class InsertBlob(
+    file: IngestionFile,
+    blobUri: Uri,
+    parentBlobs: List[Uri],
+    mimeType: MimeType,
+    ingestion: String,
+    languages: List[String],
+    extractors: Iterable[Extractor],
+    workspace: Option[WorkspaceItemContext],
+    isFastLane: Boolean
+  ) extends Insertion
   case class InsertEmail(email: Email, parent: Uri) extends Insertion
 
   case class WorkCounts(inProgress: Int, outstanding: Int)

--- a/backend/test/services/manifest/Neo4JManifestITest.scala
+++ b/backend/test/services/manifest/Neo4JManifestITest.scala
@@ -183,7 +183,8 @@ class Neo4JManifestITest extends AnyFreeSpec
           extractors,
           workspace = workspace.map { id =>
             WorkspaceItemContext(id, id, uri.value)
-          }
+          },
+          isFastLane = true
         )
       }
 

--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -125,6 +125,7 @@ export default function WorkspaceSummary({
         getResource={getWorkspaceContents}
         focusedWorkspaceEntry={focusedEntry}
         expandedNodes={expandedNodes}
+        isAdmin={isAdmin}
       />
       <CaptureFromUrl maybePreSelectedWorkspace={workspace} withButton />
       <div>

--- a/frontend/src/js/services/CollectionsApi.ts
+++ b/frontend/src/js/services/CollectionsApi.ts
@@ -33,6 +33,7 @@ export function uploadFileWithNewIngestion(
   uploadId: string,
   file: File,
   path: string,
+  isFastLane: boolean,
   workspace?: WorkspaceUploadMetadata,
   onProgress?: ProgressHandler,
 ) {
@@ -41,6 +42,7 @@ export function uploadFileWithNewIngestion(
     uploadId,
     file,
     path,
+    isFastLane,
     workspace,
     onProgress,
     ingestionName,

--- a/frontend/src/js/util/auth/authUploadWithProgress.ts
+++ b/frontend/src/js/util/auth/authUploadWithProgress.ts
@@ -10,6 +10,7 @@ export default function authUploadWithProgress(
   uploadId: string,
   file: File,
   path: string,
+  isFastLane: boolean,
   workspace?: WorkspaceUploadMetadata,
   onProgress?: ProgressHandler,
   ingestionName?: string,
@@ -35,6 +36,7 @@ export default function authUploadWithProgress(
       retryInitialCount,
       resolve,
       reject,
+      isFastLane,
       workspace,
       ingestionName,
     );
@@ -50,6 +52,7 @@ const processRequest = (
   retryCount: number,
   resolve: (value: unknown) => void,
   reject: (reason?: any) => void,
+  isFastLane: boolean,
   workspace?: WorkspaceUploadMetadata,
   ingestionName?: string,
 ) => {
@@ -71,6 +74,7 @@ const processRequest = (
           uploadId,
           resolve,
           reject,
+          isFastLane,
           workspace,
           ingestionName,
         );
@@ -90,6 +94,7 @@ const processRequest = (
     path,
     uploadId,
     retryCount,
+    isFastLane,
     workspace,
     ingestionName,
   );
@@ -104,6 +109,7 @@ const retryRequest = (
   uploadId: string,
   resolve: (value: unknown) => void,
   reject: (reason?: any) => void,
+  isFastLane: boolean,
   workspace?: WorkspaceUploadMetadata,
   ingestionName?: string,
 ) => {
@@ -120,6 +126,7 @@ const retryRequest = (
       retryCount,
       resolve,
       reject,
+      isFastLane,
       workspace,
       ingestionName,
     );
@@ -133,6 +140,7 @@ const sendRequest = (
   path: string,
   uploadId: string,
   retryCount: number,
+  isFastLane: boolean,
   workspace?: WorkspaceUploadMetadata,
   ingestionName?: string,
 ) => {
@@ -155,6 +163,9 @@ const sendRequest = (
       workspace.parentNodeId,
     );
     xhr.setRequestHeader("X-PFI-Workspace-Name", workspace.workspaceName);
+  }
+  if (isFastLane) {
+    xhr.setRequestHeader("X-PFI-Fast-Lane", "true");
   }
 
   if (ingestionName) {


### PR DESCRIPTION
## What does this change?
Adds a new 'fast lane' option when uploading (via new header `X-PFI-Fast-Lane`) which x10 the priority of the `TODO` relations in Neo4J which determine the order the workers pickup work - see existing priority logic https://github.com/guardian/giant/blob/2061212cdcfabec9e4e42a2f7a8184ee85e3502f/backend/app/services/manifest/Neo4jManifest.scala#L457

Here is the UI change (new checkbox near the Upload button, visible only to admins)...
<img width="612" height="329" alt="image" src="https://github.com/user-attachments/assets/23ee35f5-1c1e-434c-9205-d280ed18826b" />

## How has this change been tested?
Tested on playground, by uploading a couple of PDFs, one with fast lane ticked one without and we can see the priority on the respective TODO relations (by connecting to Neo4J and running a simple query in bolt on the respective blob URIs)...
| Normal | Fast Lane |
|--------|--------|
| PRIORITY: 200 <img width="288" height="353" alt="image" src="https://github.com/user-attachments/assets/1361a4f8-c14b-48d1-9657-29caf29e9d9c" />  | PRIORITY: 2000 <img width="298" height="354" alt="image" src="https://github.com/user-attachments/assets/bec26a95-7067-4f10-bc8e-60ffba43839a" /> | 


## How can we measure success?
We now have a way to skip the queue for very urgent uploads.