### PR TITLE
Log uris of blobs of work found

### DIFF
--- a/backend/app/extraction/Worker.scala
+++ b/backend/app/extraction/Worker.scala
@@ -67,7 +67,7 @@ class Worker(
 
   def executeBatch(work: Batch): Int = {
     if(work.nonEmpty) {
-      logger.info(s"Found work: ${work.size} assignments, uris: [${work.map(w => s"${w._2.uri}/${w._1.name}").mkString(", ")}]")
+      logger.info(s"Found work: ${work.size} assignments, uris: [${work.map(w => s"${w._2.uri.value}/${w._1.name}").mkString(", ")}]")
     } else {
       logger.info("No work found")
     }


### PR DESCRIPTION
## What does this change?
To help debug concurrency issues in giant, this gets it to log out the exact details of work found so we can track the point at which work gets picked up by multiple workers

## How has this change been tested?
Tested on playground