### PR TITLE
Log out elasticsearch search query 

### DIFF
--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -410,14 +410,18 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
           )
         )
 
+    val requestWithSorting = parameters.sortBy match {
+      case Relevance => req
+      case SizeAsc => req.sortBy(fieldSort(IndexFields.metadataField + "." + IndexFields.metadata.fileSize).asc())
+      case SizeDesc => req.sortBy(fieldSort(IndexFields.metadataField + "." + IndexFields.metadata.fileSize).desc())
+      case CreatedAtAsc => req.sortBy(fieldSort(IndexFields.createdAt).asc())
+      case CreatedAtDesc => req.sortBy(fieldSort(IndexFields.createdAt).desc())
+    }
+
+    logger.info(s"Elasticsearch query: ${requestWithSorting.show}")
+
     execute {
-      parameters.sortBy match {
-        case Relevance => req
-        case SizeAsc => req.sortBy(fieldSort(IndexFields.metadataField + "." + IndexFields.metadata.fileSize).asc())
-        case SizeDesc => req.sortBy(fieldSort(IndexFields.metadataField + "." + IndexFields.metadata.fileSize).desc())
-        case CreatedAtAsc => req.sortBy(fieldSort(IndexFields.createdAt).asc())
-        case CreatedAtDesc => req.sortBy(fieldSort(IndexFields.createdAt).desc())
-      }
+      requestWithSorting
     }.map { resp =>
       val hits = resp.totalHits
       val took = resp.took


### PR DESCRIPTION
## What does this change?

In an effort to understand the weirdness raised in https://github.com/guardian/giant/issues/565 this gets giant to log out the full elasticsearch query it is using. 

Note - the query is _enormous_ and we should remove this logging once we've understood the problem better

## How has this change been tested?
Tested locally