### PR TITLE
Show results from workspaces OR ingestions when both selected

### DIFF
--- a/backend/app/services/index/SearchContext.scala
+++ b/backend/app/services/index/SearchContext.scala
@@ -97,8 +97,8 @@ object SearchContext {
         )
       )
     } else {
-      // Show the user just what they asked for. Example again (NB the 'AND' is performed by the `must` in the calling code)
-      //   (collection == 'Panama' OR collection == 'Paradise') AND (workspace == 'Shared With Barry')
+      // Show the user results from any of the selected collections/workspaces. Example:
+      //   (collection == 'Panama' OR collection == 'Paradise') OR (workspace == 'Shared With Barry')
       List(
         should(
           parameters.ingestionFilters.map(prefixQuery(IndexFields.ingestionRaw, _)) ++


### PR DESCRIPTION
## What does this change?
Resolves https://github.com/guardian/giant/issues/565

Currently, if a user tries to search across both workspace folders and datasets (ingestions) then they will only get results that are both in one of the workspaces they searched for AND in one of the ingestions they searched for. This is because we were doing a `must` match in our step that filters the results. The query looks like this:

```
      "filter": [
              {
                  "bool": {
                      "must": [
                          {
                              "bool": {
                                  "should": [
                                      {
                                          "prefix": {
                                              "ingestion.keyword": {
                                                  "value": "epstein_files/"
                                              }
                                          }
                                      },
                                      ...otherDatasetFilters
                                  ]
                              }
                          },
                          {
                              "bool": {
                                  "should": [
                                      {
                                          "nested": {
                                              "path": "workspaces",
                                              "query": {
                                                  "term": {
                                                      "workspaces.workspaceId": {
                                                          "value": "id123"
                                                      }
                                                  }
                                              }
                                          }
                                      },
                                      ...otherWorkspaceFilters
                                  ]
                              }
                          },
                          ...otherFilters
                      ]
                  }
              }
          ]
```

This PR changes it to look like this - bote that the workspace/dataset queries are now wrapped in an inner 'should' instead:

```
      "filter": [
              {
                  "bool": {
                      "should": [
                          {
                              "bool": {
                                  "should": [
                                      {
                                          "prefix": {
                                              "ingestion.keyword": {
                                                  "value": "epstein_files/"
                                              }
                                          }
                                      },
                                      ...otherDatasetFilters,
                                      {
                                          "nested": {
                                              "path": "workspaces",
                                              "query": {
                                                  "term": {
                                                      "workspaces.workspaceId": {
                                                          "value": "id123"
                                                      }
                                                  }
                                              }
                                          }
                                      },
                                      ...otherWorkspaceFilters
                                  ]
                              }
                          },
                          ...otherFilters
                      ]
                  }
              }
          ]
```


## How has this change been tested?
I tested on playground, pre-deploy this query returns 0 results:

https://playground.pfi.gutools.co.uk/search?page=1&q=%5B%22guardian%22%5D&filters.workspace[]=3d33bcc4-a69d-4a02-996a-3231b2de3de0&filters.ingestion[]=skiptext_test

Post deploy it returns more than 0 results!

