### PR TITLE
Export workspace inventory as json, with ingestion ID

### DIFF
--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -254,7 +254,7 @@ class Workspaces(
       case TreeLeaf(_, name, data, _) =>
         // a TreeLeaf won't have any children, so just insert the item at the destination location, and return it's new ID
         data match {
-          case WorkspaceLeaf(_, _, _, _, _, uri, mimeType, size) =>
+          case WorkspaceLeaf(_, _, _, _, _, uri, mimeType, size, _) =>
             val addItemData = AddItemData(name, destinationParentId, "file", Some("document"), AddItemParameters(Some(uri), size, Some(mimeType)))
             insertItem(user, workspaceId, newId, addItemData).map(i => List(i))
           case _ => Attempt.Left(WorkspaceCopyFailure("Unexpected data type of TreeLeaf"))
@@ -461,6 +461,7 @@ object Workspaces {
               "size" -> wl.size,
               "addedBy" -> wl.addedBy.displayName,
               "addedOn" -> wl.addedOn,
+              "ingestionUri" -> wl.ingestionUri,
               "processingStage" -> Json.toJson(wl.processingStage)
             )
           case _ => Json.obj(
@@ -530,18 +531,19 @@ object Workspaces {
               wl.size.map(_.toString).getOrElse(""),
               wl.addedBy.displayName,
               wl.addedOn.map(_.toString).getOrElse(""),
+              wl.ingestionUri.getOrElse(""),
               processingStatus
             ))
           case _ =>
-            List(List(leaf.id, leaf.name, "unknown", s"$path/${leaf.name}", "", "", "", "", "", ""))
+            List(List(leaf.id, leaf.name, "unknown", s"$path/${leaf.name}", "", "", "", "", "", "", ""))
         }
       case node: TreeNode[WorkspaceEntry] =>
         val currentPath = s"$path/${node.name}"
         val folderRow = node.data match {
           case wn: WorkspaceNode =>
-            List(node.id, node.name, "folder", currentPath, "", "", "", wn.addedBy.displayName, wn.addedOn.map(_.toString).getOrElse(""), "")
+            List(node.id, node.name, "folder", currentPath, "", "", "", wn.addedBy.displayName, wn.addedOn.map(_.toString).getOrElse(""), "", "")
           case _ =>
-            List(node.id, node.name, "folder", currentPath, "", "", "", "", "", "")
+            List(node.id, node.name, "folder", currentPath, "", "", "", "", "", "", "")
         }
         folderRow :: node.children.flatMap(child => flattenTreeToCsvRows(child, currentPath))
     }
@@ -556,7 +558,7 @@ object Workspaces {
   }
 
   def workspaceToCsv(workspace: Workspace): String = {
-    val header = List("Node ID", "Name", "Type", "Path", "URI", "MIME Type", "Size (bytes)", "Added By", "Added On (epoch ms)", "Processing Status")
+    val header = List("Node ID", "Name", "Type", "Path", "URI", "MIME Type", "Size (bytes)", "Added By", "Added On (epoch ms)", "Ingestion URI", "Processing Status")
     val rows = flattenTreeToCsvRows(workspace.rootNode, "")
     (header :: rows).map(_.map(escapeCsvField).mkString(",")).mkString("\n")
   }

--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -10,6 +10,7 @@ import model.ingestion.{ RemoteIngest, RemoteIngestStatus}
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.append
 import org.joda.time.DateTime
+import java.time.LocalDate
 import play.api.libs.json._
 import play.api.mvc.Action
 import services.{IngestStorage, RemoteIngestConfig, ObjectStorage}
@@ -422,18 +423,21 @@ class Workspaces(
         val workspace = Workspace.fromMetadataAndRootNode(metadata, contents)
         logAction(req.user, workspaceId, s"Exporting workspace inventory. Format: ${format.getOrElse("json")}")
 
+        val safeName = workspace.name.replaceAll("[^a-zA-Z0-9_\\-]", "_")
+        val date = LocalDate.now().toString
+
         format.getOrElse("json").toLowerCase match {
           case "csv" =>
             val csvContent = Workspaces.workspaceToCsv(workspace)
             Ok(csvContent)
               .as("text/csv")
-              .withHeaders("Content-Disposition" -> s"""attachment; filename="${workspace.name}-inventory.csv"""")
+              .withHeaders("Content-Disposition" -> s"""attachment; filename="${safeName}_${date}.csv"""")
 
           case _ =>
             val jsonContent = Workspaces.workspaceToInventoryJson(workspace)
             Ok(jsonContent)
               .as("application/json")
-              .withHeaders("Content-Disposition" -> s"""attachment; filename="${workspace.name}-inventory.json"""")
+              .withHeaders("Content-Disposition" -> s"""attachment; filename="${safeName}_${date}.json"""")
         }
       }
     }

--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -3,8 +3,9 @@ package controllers.api
 import software.amazon.awssdk.services.sns.SnsClient
 import commands.DeleteResource
 import model.Uri
-import model.annotations.{ProcessingStage, Workspace, WorkspaceEntry, WorkspaceLeaf}
+import model.annotations.{ProcessingStage, Workspace, WorkspaceEntry, WorkspaceLeaf, WorkspaceNode}
 import model.frontend.{TreeEntry, TreeLeaf, TreeNode}
+import model.user.UserPermission.CanPerformAdminOperations
 import model.ingestion.{ RemoteIngest, RemoteIngestStatus}
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.append
@@ -412,8 +413,151 @@ class Workspaces(
     } map (_ => NoContent)
   }
 
+  def exportInventory(workspaceId: String, format: Option[String]) = ApiAction.attempt { req: UserIdentityRequest[_] =>
+    checkPermission(CanPerformAdminOperations, req) {
+      for {
+        metadata <- annotation.getWorkspaceMetadata(req.user.username, workspaceId)
+        contents <- annotation.getWorkspaceContents(req.user.username, workspaceId)
+      } yield {
+        val workspace = Workspace.fromMetadataAndRootNode(metadata, contents)
+        logAction(req.user, workspaceId, s"Exporting workspace inventory. Format: ${format.getOrElse("json")}")
+
+        format.getOrElse("json").toLowerCase match {
+          case "csv" =>
+            val csvContent = Workspaces.workspaceToCsv(workspace)
+            Ok(csvContent)
+              .as("text/csv")
+              .withHeaders("Content-Disposition" -> s"""attachment; filename="${workspace.name}-inventory.csv"""")
+
+          case _ =>
+            val jsonContent = Workspaces.workspaceToInventoryJson(workspace)
+            Ok(jsonContent)
+              .as("application/json")
+              .withHeaders("Content-Disposition" -> s"""attachment; filename="${workspace.name}-inventory.json"""")
+        }
+      }
+    }
+  }
+
   private def logAction(user: User, workspaceId: String, message: String) = {
     val markers: LogstashMarker = user.asLogMarker.and(append("workspaceId", workspaceId))
     logger.info(markers, message)
+  }
+}
+
+object Workspaces {
+  private def treeEntryToInventoryJson(entry: TreeEntry[WorkspaceEntry], path: String): JsValue = {
+    entry match {
+      case leaf: TreeLeaf[WorkspaceEntry] =>
+        leaf.data match {
+          case wl: WorkspaceLeaf =>
+            Json.obj(
+              "nodeId" -> leaf.id,
+              "name" -> leaf.name,
+              "type" -> "file",
+              "path" -> s"$path/${leaf.name}",
+              "uri" -> wl.uri,
+              "mimeType" -> wl.mimeType,
+              "size" -> wl.size,
+              "addedBy" -> wl.addedBy.displayName,
+              "addedOn" -> wl.addedOn,
+              "processingStage" -> Json.toJson(wl.processingStage)
+            )
+          case _ => Json.obj(
+              "nodeId" -> leaf.id,
+              "name" -> leaf.name,
+              "type" -> "unknown",
+              "path" -> s"$path/${leaf.name}"
+            )
+        }
+      case node: TreeNode[WorkspaceEntry] =>
+        val currentPath = s"$path/${node.name}"
+        val childrenJson = node.children.map(child => treeEntryToInventoryJson(child, currentPath))
+        node.data match {
+          case wn: WorkspaceNode =>
+            Json.obj(
+              "nodeId" -> node.id,
+              "name" -> node.name,
+              "type" -> "folder",
+              "path" -> currentPath,
+              "addedBy" -> wn.addedBy.displayName,
+              "addedOn" -> wn.addedOn,
+              "descendantsFileCount" -> wn.descendantsLeafCount,
+              "descendantsFolderCount" -> wn.descendantsNodeCount,
+              "children" -> JsArray(childrenJson)
+            )
+          case _ =>
+            Json.obj(
+              "nodeId" -> node.id,
+              "name" -> node.name,
+              "type" -> "folder",
+              "path" -> currentPath,
+              "children" -> JsArray(childrenJson)
+            )
+        }
+    }
+  }
+
+  def workspaceToInventoryJson(workspace: Workspace): JsValue = {
+    Json.obj(
+      "workspaceId" -> workspace.id,
+      "workspaceName" -> workspace.name,
+      "isPublic" -> workspace.isPublic,
+      "owner" -> workspace.owner.displayName,
+      "creator" -> workspace.creator.displayName,
+      "exportedAt" -> System.currentTimeMillis(),
+      "contents" -> treeEntryToInventoryJson(workspace.rootNode, "")
+    )
+  }
+
+  private def flattenTreeToCsvRows(entry: TreeEntry[WorkspaceEntry], path: String): List[List[String]] = {
+    entry match {
+      case leaf: TreeLeaf[WorkspaceEntry] =>
+        leaf.data match {
+          case wl: WorkspaceLeaf =>
+            val processingStatus = wl.processingStage match {
+              case ProcessingStage.Processing(n, _) => s"processing ($n remaining)"
+              case ProcessingStage.Processed => "processed"
+              case ProcessingStage.Failed => "failed"
+            }
+            List(List(
+              leaf.id,
+              leaf.name,
+              "file",
+              s"$path/${leaf.name}",
+              wl.uri,
+              wl.mimeType,
+              wl.size.map(_.toString).getOrElse(""),
+              wl.addedBy.displayName,
+              wl.addedOn.map(_.toString).getOrElse(""),
+              processingStatus
+            ))
+          case _ =>
+            List(List(leaf.id, leaf.name, "unknown", s"$path/${leaf.name}", "", "", "", "", "", ""))
+        }
+      case node: TreeNode[WorkspaceEntry] =>
+        val currentPath = s"$path/${node.name}"
+        val folderRow = node.data match {
+          case wn: WorkspaceNode =>
+            List(node.id, node.name, "folder", currentPath, "", "", "", wn.addedBy.displayName, wn.addedOn.map(_.toString).getOrElse(""), "")
+          case _ =>
+            List(node.id, node.name, "folder", currentPath, "", "", "", "", "", "")
+        }
+        folderRow :: node.children.flatMap(child => flattenTreeToCsvRows(child, currentPath))
+    }
+  }
+
+  private def escapeCsvField(field: String): String = {
+    if (field.contains(",") || field.contains("\"") || field.contains("\n")) {
+      "\"" + field.replace("\"", "\"\"") + "\""
+    } else {
+      field
+    }
+  }
+
+  def workspaceToCsv(workspace: Workspace): String = {
+    val header = List("Node ID", "Name", "Type", "Path", "URI", "MIME Type", "Size (bytes)", "Added By", "Added On (epoch ms)", "Processing Status")
+    val rows = flattenTreeToCsvRows(workspace.rootNode, "")
+    (header :: rows).map(_.map(escapeCsvField).mkString(",")).mkString("\n")
   }
 }

--- a/backend/app/model/annotations/Workspace.scala
+++ b/backend/app/model/annotations/Workspace.scala
@@ -79,6 +79,7 @@ case class WorkspaceLeaf(
   // there are nodes in Playground where this is null, which breaks things
   // if I don't make it optional
   size: Option[Long],
+  ingestionUri: Option[String] = None,
 ) extends WorkspaceEntry
 
 
@@ -105,7 +106,8 @@ object WorkspaceEntry {
     maybeCapturedFromURL: Option[String],
     numberOfTodos: Int,
     note: Option[String],
-    hasFailures: Boolean
+    hasFailures: Boolean,
+    ingestionUri: Option[String] = None
   ): TreeEntry[WorkspaceEntry] = {
     val processingStage = if (hasFailures) {
       ProcessingStage.Failed
@@ -148,6 +150,7 @@ object WorkspaceEntry {
           // there are nodes in Playground where this is null, which breaks things
           // if I don't make it optional
           size = v.get("size").optionally(_.asLong()),
+          ingestionUri = ingestionUri,
         )
       )
     }

--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -113,6 +113,7 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         |RETURN node, nodeCreator, parentNode.id, remoteIngest.url,
         |	count(todo) AS numberOfTodos,
         |	collect(todo)[0].note as note,
+        |	collect(todo)[0].ingestion as ingestionUri,
         |	exists((:Resource {uri: node.uri})<-[:EXTRACTION_FAILURE]-(:Extractor)) AS hasFailures
       """.stripMargin,
       parameters(
@@ -129,9 +130,10 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         val maybeCapturedFromURL = r.get("remoteIngest.url").optionally(_.asString())
         val numberOfTodos = r.get("numberOfTodos").asInt()
         val note = r.get("note").optionally(_.asString())
+        val ingestionUri = r.get("ingestionUri").optionally(_.asString())
         val hasFailures = r.get("hasFailures").asBoolean()
 
-        WorkspaceEntry.fromNeo4jValue(node, nodeCreator, maybeParentNodeId, maybeCapturedFromURL, numberOfTodos, note, hasFailures)
+        WorkspaceEntry.fromNeo4jValue(node, nodeCreator, maybeParentNodeId, maybeCapturedFromURL, numberOfTodos, note, hasFailures, ingestionUri)
       }.toList
 
       val synthesisedEntries = remoteIngestsToMixin.flatMap(_.asSyntheticEntries(

--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -110,10 +110,11 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         |OPTIONAL MATCH (node)-[:FROM]->(remoteIngest: RemoteIngest)
         |
         |OPTIONAL MATCH (:Resource {uri: node.uri})<-[todo:TODO|:PROCESSING_EXTERNALLY]-(:Extractor)
+        |OPTIONAL MATCH (:Resource {uri: node.uri})<-[extraction:TODO|:PROCESSING_EXTERNALLY|:PROCESSED]-(:Extractor)
         |RETURN node, nodeCreator, parentNode.id, remoteIngest.url,
         |	count(todo) AS numberOfTodos,
         |	collect(todo)[0].note as note,
-        |	collect(todo)[0].ingestion as ingestionUri,
+        |	collect(extraction)[0].ingestion as ingestionUri,
         |	exists((:Resource {uri: node.uri})<-[:EXTRACTION_FAILURE]-(:Extractor)) AS hasFailures
       """.stripMargin,
       parameters(

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -74,6 +74,7 @@ POST          /api/workspaces/:workspaceId/nodes/:itemId/copy               cont
 DELETE        /api/workspaces/:workspaceId/nodes/:itemId                    controllers.api.Workspaces.removeItem(workspaceId: String, itemId: String)
 POST          /api/workspaces/:workspaceId/nodes/delete/:blobUri            controllers.api.Workspaces.deleteBlob(workspaceId: String, blobUri: String)
 POST          /api/workspaces/:workspaceId/nodes/delete/RemoteIngestTask/:taskId     controllers.api.Workspaces.archiveRemoteIngestTask(workspaceId: String, taskId: String)
+GET           /api/workspaces/:workspaceId/export                            controllers.api.Workspaces.exportInventory(workspaceId: String, format: Option[String])
 DELETE        /api/workspaces/:workspaceId                                  controllers.api.Workspaces.deleteWorkspace(workspaceId: String)
 
 HEAD          /api/preview/download/:uri                                    controllers.api.Previews.getPreviewMetadata(uri: model.Uri)

--- a/backend/test/controllers/api/WorkspacesExportTest.scala
+++ b/backend/test/controllers/api/WorkspacesExportTest.scala
@@ -1,0 +1,183 @@
+package controllers.api
+
+import model.annotations._
+import model.frontend._
+import model.frontend.user.PartialUser
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.libs.json._
+
+class WorkspacesExportTest extends AnyFreeSpec with Matchers {
+
+  val testUser = PartialUser("testuser", "Test User")
+  val otherUser = PartialUser("otheruser", "Other User")
+
+  def makeLeaf(id: String, name: String, uri: String, mimeType: String = "application/pdf",
+               size: Option[Long] = Some(1024L), processingStage: ProcessingStage = ProcessingStage.Processed,
+               ingestionUri: Option[String] = None): TreeLeaf[WorkspaceEntry] =
+    TreeLeaf(id, name, isExpandable = false, data = WorkspaceLeaf(
+      addedBy = testUser, addedOn = Some(1000L), maybeParentId = Some("root"),
+      processingStage = processingStage, uri = uri, mimeType = mimeType, size = size,
+      ingestionUri = ingestionUri
+    ))
+
+  def makeFolder(id: String, name: String, children: List[TreeEntry[WorkspaceEntry]],
+                 leafCount: Long = 0, nodeCount: Long = 0): TreeNode[WorkspaceEntry] =
+    TreeNode(id, name, data = WorkspaceNode(
+      addedBy = testUser, addedOn = Some(2000L), maybeParentId = if (id == "root") None else Some("root"),
+      descendantsLeafCount = leafCount, descendantsNodeCount = nodeCount,
+      descendantsProcessingTaskCount = 0, descendantsFailedCount = 0
+    ), children = children)
+
+  def makeWorkspace(rootNode: TreeEntry[WorkspaceEntry]): Workspace =
+    Workspace(
+      id = "ws-1", name = "Test Workspace", isPublic = false, tagColor = "blue",
+      creator = testUser, owner = otherUser, followers = List.empty, rootNode = rootNode
+    )
+
+  val leaf1 = makeLeaf("leaf-1", "report.pdf", "file:///report.pdf", ingestionUri = Some("ingestion://batch-1"))
+  val leaf2 = makeLeaf("leaf-2", "notes.txt", "file:///notes.txt", mimeType = "text/plain", size = Some(256L))
+  val leaf3 = makeLeaf("leaf-3", "image.png", "file:///image.png", mimeType = "image/png",
+    processingStage = ProcessingStage.Processing(3, Some("OCR in progress")),
+    ingestionUri = Some("ingestion://batch-2"))
+  val failedLeaf = makeLeaf("leaf-4", "broken.doc", "file:///broken.doc", mimeType = "application/msword",
+    processingStage = ProcessingStage.Failed)
+
+  val subfolder = makeFolder("folder-1", "Documents", List(leaf1, leaf3), leafCount = 2)
+  val rootWithFiles = makeFolder("root", "root", List(subfolder, leaf2, failedLeaf), leafCount = 4, nodeCount = 1)
+
+  val workspace = makeWorkspace(rootWithFiles)
+
+  "workspaceToInventoryJson" - {
+    val json = Workspaces.workspaceToInventoryJson(workspace)
+
+    "includes workspace metadata" in {
+      (json \ "workspaceId").as[String] must be("ws-1")
+      (json \ "workspaceName").as[String] must be("Test Workspace")
+      (json \ "isPublic").as[Boolean] must be(false)
+      (json \ "owner").as[String] must be("Other User")
+      (json \ "creator").as[String] must be("Test User")
+      (json \ "exportedAt").asOpt[Long] must be(defined)
+    }
+
+    "includes root node as contents" in {
+      (json \ "contents" \ "type").as[String] must be("folder")
+      (json \ "contents" \ "name").as[String] must be("root")
+    }
+
+    "includes nested folder with correct path" in {
+      val folder = (json \ "contents" \ "children")(0)
+      (folder \ "type").as[String] must be("folder")
+      (folder \ "name").as[String] must be("Documents")
+      (folder \ "path").as[String] must be("/root/Documents")
+      (folder \ "descendantsFileCount").as[Long] must be(2)
+    }
+
+    "includes file leaves with all fields" in {
+      val folder = (json \ "contents" \ "children")(0)
+      val file = (folder \ "children")(0)
+      (file \ "type").as[String] must be("file")
+      (file \ "name").as[String] must be("report.pdf")
+      (file \ "path").as[String] must be("/root/Documents/report.pdf")
+      (file \ "uri").as[String] must be("file:///report.pdf")
+      (file \ "mimeType").as[String] must be("application/pdf")
+      (file \ "size").as[Long] must be(1024L)
+      (file \ "addedBy").as[String] must be("Test User")
+      (file \ "addedOn").as[Long] must be(1000L)
+    }
+
+    "includes ingestionUri when present" in {
+      val folder = (json \ "contents" \ "children")(0)
+      val file = (folder \ "children")(0)
+      (file \ "ingestionUri").as[String] must be("ingestion://batch-1")
+    }
+
+    "includes null ingestionUri when absent" in {
+      val file = (json \ "contents" \ "children")(1)
+      (file \ "ingestionUri").asOpt[String] must be(None)
+    }
+
+    "includes processing stage" in {
+      val folder = (json \ "contents" \ "children")(0)
+      val processingFile = (folder \ "children")(1)
+      (processingFile \ "processingStage" \ "type").as[String] must be("processing")
+      (processingFile \ "processingStage" \ "tasksRemaining").as[Int] must be(3)
+
+      val failedFile = (json \ "contents" \ "children")(2)
+      (failedFile \ "processingStage" \ "type").as[String] must be("failed")
+    }
+  }
+
+  "workspaceToCsv" - {
+    val csv = Workspaces.workspaceToCsv(workspace)
+    val lines = csv.split("\n").toList
+
+    "includes header row" in {
+      lines.head must be("Node ID,Name,Type,Path,URI,MIME Type,Size (bytes),Added By,Added On (epoch ms),Ingestion URI,Processing Status")
+    }
+
+    "includes a row for every node" in {
+      // 1 root folder + 1 subfolder + 4 leaves = 6 rows + 1 header
+      lines.length must be(7)
+    }
+
+    "includes folder rows with empty file-specific fields" in {
+      val rootRow = lines(1).split(",", -1).toList
+      rootRow(0) must be("root")
+      rootRow(2) must be("folder")
+      rootRow(4) must be("") // URI
+      rootRow(5) must be("") // MIME Type
+      rootRow(10) must be("") // Processing Status
+    }
+
+    "includes file rows with all fields" in {
+      // leaf1 is inside Documents folder — should be row 3 (after header, root, Documents)
+      val reportRow = lines(3).split(",", -1).toList
+      reportRow(0) must be("leaf-1")
+      reportRow(1) must be("report.pdf")
+      reportRow(2) must be("file")
+      reportRow(3) must be("/root/Documents/report.pdf")
+      reportRow(4) must be("file:///report.pdf")
+      reportRow(5) must be("application/pdf")
+      reportRow(6) must be("1024")
+      reportRow(7) must be("Test User")
+      reportRow(8) must be("1000")
+      reportRow(9) must be("ingestion://batch-1")
+      reportRow(10) must be("processed")
+    }
+
+    "includes ingestion URI in CSV when present" in {
+      val imageRow = lines(4).split(",", -1).toList
+      imageRow(9) must be("ingestion://batch-2")
+    }
+
+    "leaves ingestion URI empty when absent" in {
+      val notesRow = lines(5).split(",", -1).toList
+      notesRow(9) must be("")
+    }
+
+    "shows processing status correctly" in {
+      val imageRow = lines(4).split(",", -1).toList
+      imageRow(10) must be("processing (3 remaining)")
+
+      val brokenRow = lines(6).split(",", -1).toList
+      brokenRow(10) must be("failed")
+    }
+
+    "escapes CSV fields containing commas" in {
+      val leafWithComma = makeLeaf("c-1", "report, final.pdf", "file:///report.pdf")
+      val root = makeFolder("root", "root", List(leafWithComma), leafCount = 1)
+      val ws = makeWorkspace(root)
+      val csvOutput = Workspaces.workspaceToCsv(ws)
+      csvOutput must include("\"report, final.pdf\"")
+    }
+
+    "escapes CSV fields containing double quotes" in {
+      val leafWithQuote = makeLeaf("q-1", """file "draft".pdf""", "file:///draft.pdf")
+      val root = makeFolder("root", "root", List(leafWithQuote), leafCount = 1)
+      val ws = makeWorkspace(root)
+      val csvOutput = Workspaces.workspaceToCsv(ws)
+      csvOutput must include("\"file \"\"draft\"\".pdf\"")
+    }
+  }
+}

--- a/frontend/src/js/components/UtilComponents/ModalAction.tsx
+++ b/frontend/src/js/components/UtilComponents/ModalAction.tsx
@@ -6,10 +6,12 @@ import _ from "lodash";
 type BaseProps = {
   actionType: string;
   actionDescription: string;
-  className: string;
+  className?: string;
   title: string;
   text?: string;
   disabled?: boolean;
+  isOpen?: boolean;
+  onClose?: () => void;
 };
 
 type ConfirmProps = BaseProps & {
@@ -35,8 +37,11 @@ export default function ModalAction(
     ConfirmProps | EditProps | SelectMultipleProps
   >,
 ) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
   const [value, setValue] = useState<string | string[] | undefined>(undefined);
+
+  const isExternallyControlled = props.isOpen !== undefined;
+  const open = isExternallyControlled ? props.isOpen! : internalOpen;
 
   function onSubmit(e?: React.FormEvent) {
     if (e) {
@@ -67,7 +72,11 @@ export default function ModalAction(
   }
 
   function onDismiss() {
-    setOpen(false);
+    if (isExternallyControlled) {
+      props.onClose?.();
+    } else {
+      setInternalOpen(false);
+    }
     setValue(undefined);
   }
 
@@ -76,15 +85,16 @@ export default function ModalAction(
 
   return (
     <React.Fragment>
-      {/* The component that triggers the modal (pass-through rendering of children) */}
-      <button
-        className={props.className}
-        disabled={props.disabled}
-        onClick={() => setOpen(true)}
-        title={props.title}
-      >
-        {props.children}
-      </button>
+      {!isExternallyControlled && (
+        <button
+          className={props.className}
+          disabled={props.disabled}
+          onClick={() => setInternalOpen(true)}
+          title={props.title}
+        >
+          {props.children}
+        </button>
+      )}
 
       <Modal
         isOpen={open}

--- a/frontend/src/js/components/workspace/ShareWorkspaceModal.tsx
+++ b/frontend/src/js/components/workspace/ShareWorkspaceModal.tsx
@@ -10,7 +10,6 @@ import { Checkbox } from "../UtilComponents/Checkbox";
 import { setWorkspaceIsPublic } from "../../actions/workspaces/setWorkspaceIsPublic";
 import { WorkspacePublicInfoIcon } from "./WorkspacePublicInfoIcon";
 import { WorkspacePublicMessage } from "./WorkspacePublicMessage";
-import MdShare from "react-icons/lib/md/share";
 
 type Props = {
   workspace: Workspace;
@@ -19,6 +18,8 @@ type Props = {
   currentUser: PartialUser;
   setWorkspaceFollowers: typeof setWorkspaceFollowers;
   setWorkspaceIsPublic: typeof setWorkspaceIsPublic;
+  isOpen: boolean;
+  onClose: () => void;
 };
 
 export default function ShareWorkspaceModal(props: Props) {
@@ -26,7 +27,7 @@ export default function ShareWorkspaceModal(props: Props) {
     (u) => u.username,
   );
   const currentIsPublic = props.workspace.isPublic;
-  const [open, setOpen] = useState(false);
+  const open = props.isOpen;
 
   // These should be undefined when the modal is closed.
   // This stops us preserving state across different openings of the modal,
@@ -60,7 +61,7 @@ export default function ShareWorkspaceModal(props: Props) {
   }
 
   function onDismiss() {
-    setOpen(false);
+    props.onClose();
     setFollowers(undefined);
     setIsPublic(undefined);
   }
@@ -73,17 +74,6 @@ export default function ShareWorkspaceModal(props: Props) {
 
   return (
     <React.Fragment>
-      {/* The component that triggers the modal (pass-through rendering of children) */}
-      <button
-        className="item workspace-menu__item"
-        disabled={props.currentUser.username !== props.workspace.owner.username}
-        onClick={() => setOpen(true)}
-        title="Share Workspace"
-      >
-        <MdShare />
-        Share Workspace
-      </button>
-
       <Modal
         isOpen={open}
         dismiss={onDismiss}

--- a/frontend/src/js/components/workspace/ShareWorkspaceModal.tsx
+++ b/frontend/src/js/components/workspace/ShareWorkspaceModal.tsx
@@ -75,7 +75,7 @@ export default function ShareWorkspaceModal(props: Props) {
     <React.Fragment>
       {/* The component that triggers the modal (pass-through rendering of children) */}
       <button
-        className="btn workspace__button"
+        className="item workspace-menu__item"
         disabled={props.currentUser.username !== props.workspace.owner.username}
         onClick={() => setOpen(true)}
         title="Share Workspace"

--- a/frontend/src/js/components/workspace/TakeOwnershipOfWorkspaceModal.tsx
+++ b/frontend/src/js/components/workspace/TakeOwnershipOfWorkspaceModal.tsx
@@ -41,7 +41,7 @@ export default function TakeOwnershipOfWorkspaceModal(props: Props) {
     <React.Fragment>
       {/* The component that triggers the modal (pass-through rendering of children) */}
       <button
-        className="btn workspace__button"
+        className="item workspace-menu__item"
         onClick={() => setOpen(true)}
         title="Take ownership"
       >

--- a/frontend/src/js/components/workspace/TakeOwnershipOfWorkspaceModal.tsx
+++ b/frontend/src/js/components/workspace/TakeOwnershipOfWorkspaceModal.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
+import React from "react";
 import Modal from "../UtilComponents/Modal";
-import MdSupervisorAccount from "react-icons/lib/md/supervisor-account";
 import { Workspace } from "../../types/Workspaces";
 import { PartialUser } from "../../types/User";
 import { takeOwnershipOfWorkspace } from "../../actions/workspaces/takeOwnershipOfWorkspace";
@@ -10,10 +9,12 @@ type Props = {
   isAdmin: Boolean;
   currentUser: PartialUser;
   takeOwnershipOfWorkspace: typeof takeOwnershipOfWorkspace;
+  isOpen: boolean;
+  onClose: () => void;
 };
 
 export default function TakeOwnershipOfWorkspaceModal(props: Props) {
-  const [open, setOpen] = useState(false);
+  const open = props.isOpen;
 
   function onSubmit(e?: React.FormEvent) {
     if (e) {
@@ -30,7 +31,7 @@ export default function TakeOwnershipOfWorkspaceModal(props: Props) {
   }
 
   function onDismiss() {
-    setOpen(false);
+    props.onClose();
   }
 
   if (props.currentUser.username === props.workspace.owner.username)
@@ -39,15 +40,6 @@ export default function TakeOwnershipOfWorkspaceModal(props: Props) {
 
   return (
     <React.Fragment>
-      {/* The component that triggers the modal (pass-through rendering of children) */}
-      <button
-        className="item workspace-menu__item"
-        onClick={() => setOpen(true)}
-        title="Take ownership"
-      >
-        <MdSupervisorAccount /> Take Ownership
-      </button>
-
       <Modal
         isOpen={open}
         dismiss={onDismiss}

--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -20,6 +20,8 @@ import ShareWorkspaceModal from "./ShareWorkspaceModal";
 import MdEdit from "react-icons/lib/md/edit";
 import MdDelete from "react-icons/lib/md/delete";
 import MdFileDownload from "react-icons/lib/md/file-download";
+import MdShare from "react-icons/lib/md/share";
+import MdSupervisorAccount from "react-icons/lib/md/supervisor-account";
 import TakeOwnershipOfWorkspaceModal from "./TakeOwnershipOfWorkspaceModal";
 import { takeOwnershipOfWorkspace } from "../../actions/workspaces/takeOwnershipOfWorkspace";
 import { CaptureFromUrl } from "../Uploads/CaptureFromUrl";
@@ -64,6 +66,11 @@ export default function WorkspaceSummary({
   clearFocus,
 }: Props) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+  const [isTakeOwnershipModalOpen, setIsTakeOwnershipModalOpen] =
+    useState(false);
+  const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const workspaceUsers = workspace.followers.filter(
     (follower) =>
@@ -85,9 +92,12 @@ export default function WorkspaceSummary({
   const canDelete = isOwner || (isAdmin && workspace.isPublic);
 
   const menuButton = (
-    <button className="btn workspace__button" aria-label="Workspace actions">
-      <Icon name="bars" />
-    </button>
+    <Icon
+      name="bars"
+      size="large"
+      style={{ cursor: "pointer" }}
+      aria-label="Workspace actions"
+    />
   );
 
   return (
@@ -152,47 +162,58 @@ export default function WorkspaceSummary({
       >
         <Menu vertical compact style={{ minWidth: 200 }}>
           {/* Sharing & ownership */}
-          <ShareWorkspaceModal
-            workspace={workspace}
-            workspaceUsers={workspaceUsers}
-            allUsers={users}
-            currentUser={currentUser}
-            setWorkspaceFollowers={setWorkspaceFollowers}
-            setWorkspaceIsPublic={setWorkspaceIsPublic}
-          />
-          <TakeOwnershipOfWorkspaceModal
-            workspace={workspace}
-            isAdmin={isAdmin}
-            currentUser={currentUser}
-            takeOwnershipOfWorkspace={takeOwnershipOfWorkspace}
-          />
+          <button
+            className="item workspace-menu__item"
+            disabled={!isOwner}
+            onClick={() => {
+              closeMenu();
+              setIsShareModalOpen(true);
+            }}
+            title="Share Workspace"
+          >
+            <MdShare />
+            Share Workspace
+          </button>
+          {isAdmin && currentUser.username !== workspace.owner.username && (
+            <button
+              className="item workspace-menu__item"
+              onClick={() => {
+                closeMenu();
+                setIsTakeOwnershipModalOpen(true);
+              }}
+              title="Take ownership"
+            >
+              <MdSupervisorAccount /> Take Ownership
+            </button>
+          )}
 
           <Divider fitted style={{ margin: 0 }} />
 
           {/* Edit actions */}
-          <ModalAction
-            actionType="edit"
+          <button
             className="item workspace-menu__item"
-            actionDescription="Rename"
-            title={`Rename workspace '${workspace.name}'`}
-            value={workspace.name}
-            onConfirm={(newName) => renameWorkspace(workspace.id, newName)}
             disabled={!isOwner}
+            onClick={() => {
+              closeMenu();
+              setIsRenameModalOpen(true);
+            }}
+            title={`Rename workspace '${workspace.name}'`}
           >
             <MdEdit />
             Rename Workspace
-          </ModalAction>
-          <ModalAction
-            actionType="confirm"
+          </button>
+          <button
             className="item workspace-menu__item workspace-menu__item--danger"
-            actionDescription="Delete"
-            title={`Delete workspace '${workspace.name}'?`}
-            onConfirm={() => deleteWorkspace(workspace.id)}
             disabled={!canDelete}
+            onClick={() => {
+              closeMenu();
+              setIsDeleteModalOpen(true);
+            }}
+            title={`Delete workspace '${workspace.name}'?`}
           >
             <MdDelete />
             Delete Workspace
-          </ModalAction>
+          </button>
 
           {isAdmin && (
             <>
@@ -223,6 +244,41 @@ export default function WorkspaceSummary({
           )}
         </Menu>
       </Popup>
+      <ShareWorkspaceModal
+        workspace={workspace}
+        workspaceUsers={workspaceUsers}
+        allUsers={users}
+        currentUser={currentUser}
+        setWorkspaceFollowers={setWorkspaceFollowers}
+        setWorkspaceIsPublic={setWorkspaceIsPublic}
+        isOpen={isShareModalOpen}
+        onClose={() => setIsShareModalOpen(false)}
+      />
+      <TakeOwnershipOfWorkspaceModal
+        workspace={workspace}
+        isAdmin={isAdmin}
+        currentUser={currentUser}
+        takeOwnershipOfWorkspace={takeOwnershipOfWorkspace}
+        isOpen={isTakeOwnershipModalOpen}
+        onClose={() => setIsTakeOwnershipModalOpen(false)}
+      />
+      <ModalAction
+        actionType="edit"
+        actionDescription="Rename"
+        title={`Rename workspace '${workspace.name}'`}
+        value={workspace.name}
+        onConfirm={(newName) => renameWorkspace(workspace.id, newName)}
+        isOpen={isRenameModalOpen}
+        onClose={() => setIsRenameModalOpen(false)}
+      />
+      <ModalAction
+        actionType="confirm"
+        actionDescription="Delete"
+        title={`Delete workspace '${workspace.name}'?`}
+        onConfirm={() => deleteWorkspace(workspace.id)}
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -19,11 +19,13 @@ import { getWorkspace } from "../../actions/workspaces/getWorkspace";
 import ShareWorkspaceModal from "./ShareWorkspaceModal";
 import MdEdit from "react-icons/lib/md/edit";
 import MdDelete from "react-icons/lib/md/delete";
+import MdFileDownload from "react-icons/lib/md/file-download";
 import MdMore from "react-icons/lib/md/expand-more";
 import TakeOwnershipOfWorkspaceModal from "./TakeOwnershipOfWorkspaceModal";
 import { takeOwnershipOfWorkspace } from "../../actions/workspaces/takeOwnershipOfWorkspace";
 import { CaptureFromUrl } from "../Uploads/CaptureFromUrl";
 import { EuiText } from "@elastic/eui";
+import { exportWorkspaceInventory } from "../../services/WorkspaceApi";
 import { FileAndFolderCounts } from "../UtilComponents/TreeBrowser/FileAndFolderCounts";
 import history from "../../util/history";
 
@@ -200,6 +202,24 @@ export default function WorkspaceSummary({
             <MdDelete />
             Delete Workspace
           </ModalAction>
+          {isAdmin && (
+            <>
+              <button
+                className="btn workspace__button"
+                onClick={() => exportWorkspaceInventory(workspace.id, "json")}
+              >
+                <MdFileDownload />
+                Export as JSON
+              </button>
+              <button
+                className="btn workspace__button"
+                onClick={() => exportWorkspaceInventory(workspace.id, "csv")}
+              >
+                <MdFileDownload />
+                Export as CSV
+              </button>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -6,7 +6,7 @@ import {
   isWorkspaceNode,
 } from "../../types/Workspaces";
 import ModalAction from "../UtilComponents/ModalAction";
-import { Label, Popup } from "semantic-ui-react";
+import { Divider, Icon, Label, Menu, Popup } from "semantic-ui-react";
 import { PartialUser } from "../../types/User";
 import { setWorkspaceFollowers } from "../../actions/workspaces/setWorkspaceFollowers";
 import { setWorkspaceIsPublic } from "../../actions/workspaces/setWorkspaceIsPublic";
@@ -20,7 +20,6 @@ import ShareWorkspaceModal from "./ShareWorkspaceModal";
 import MdEdit from "react-icons/lib/md/edit";
 import MdDelete from "react-icons/lib/md/delete";
 import MdFileDownload from "react-icons/lib/md/file-download";
-import MdMore from "react-icons/lib/md/expand-more";
 import TakeOwnershipOfWorkspaceModal from "./TakeOwnershipOfWorkspaceModal";
 import { takeOwnershipOfWorkspace } from "../../actions/workspaces/takeOwnershipOfWorkspace";
 import { CaptureFromUrl } from "../Uploads/CaptureFromUrl";
@@ -64,7 +63,7 @@ export default function WorkspaceSummary({
   isAdmin,
   clearFocus,
 }: Props) {
-  const [isShowingMoreOptions, setIsShowingMoreOptions] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const workspaceUsers = workspace.followers.filter(
     (follower) =>
@@ -79,6 +78,17 @@ export default function WorkspaceSummary({
     clearFocus();
     history.push(`/workspaces/${workspace.id}`);
   };
+
+  const closeMenu = () => setIsMenuOpen(false);
+
+  const isOwner = currentUser.username === workspace.owner.username;
+  const canDelete = isOwner || (isAdmin && workspace.isPublic);
+
+  const menuButton = (
+    <button className="btn workspace__button" aria-label="Workspace actions">
+      <Icon name="bars" />
+    </button>
+  );
 
   return (
     <div className="page-title workspace__header shrinkable-buttons">
@@ -130,44 +140,18 @@ export default function WorkspaceSummary({
         isAdmin={isAdmin}
       />
       <CaptureFromUrl maybePreSelectedWorkspace={workspace} withButton />
-      <div>
-        <button
-          className="btn workspace__button"
-          onClick={() =>
-            setIsShowingMoreOptions((prev) => {
-              if (!prev) {
-                document.addEventListener(
-                  "click",
-                  () => {
-                    setIsShowingMoreOptions(false);
-                  },
-                  { once: true },
-                );
-              }
-              return !prev;
-            })
-          }
-        >
-          <MdMore />
-        </button>
-        <div
-          className={`workspace__header ${isShowingMoreOptions ? "" : "hide-direct-child-buttons"}`}
-          style={{
-            position: "absolute",
-            alignItems: "flex-end",
-            flexDirection: "column",
-            gap: "5px",
-            padding: "12px",
-            right: 0,
-            zIndex: 9999,
-          }}
-        >
-          <TakeOwnershipOfWorkspaceModal
-            workspace={workspace}
-            isAdmin={isAdmin}
-            currentUser={currentUser}
-            takeOwnershipOfWorkspace={takeOwnershipOfWorkspace}
-          />
+      <Popup
+        trigger={menuButton}
+        open={isMenuOpen}
+        onOpen={() => setIsMenuOpen(true)}
+        onClose={closeMenu}
+        on="click"
+        position="bottom right"
+        basic
+        style={{ padding: 0 }}
+      >
+        <Menu vertical compact style={{ minWidth: 200 }}>
+          {/* Sharing & ownership */}
           <ShareWorkspaceModal
             workspace={workspace}
             workspaceUsers={workspaceUsers}
@@ -176,52 +160,69 @@ export default function WorkspaceSummary({
             setWorkspaceFollowers={setWorkspaceFollowers}
             setWorkspaceIsPublic={setWorkspaceIsPublic}
           />
+          <TakeOwnershipOfWorkspaceModal
+            workspace={workspace}
+            isAdmin={isAdmin}
+            currentUser={currentUser}
+            takeOwnershipOfWorkspace={takeOwnershipOfWorkspace}
+          />
+
+          <Divider fitted style={{ margin: 0 }} />
+
+          {/* Edit actions */}
           <ModalAction
             actionType="edit"
-            className="btn workspace__button"
+            className="item workspace-menu__item"
             actionDescription="Rename"
             title={`Rename workspace '${workspace.name}'`}
             value={workspace.name}
             onConfirm={(newName) => renameWorkspace(workspace.id, newName)}
-            disabled={currentUser.username !== workspace.owner.username}
+            disabled={!isOwner}
           >
             <MdEdit />
             Rename Workspace
           </ModalAction>
           <ModalAction
             actionType="confirm"
-            className="btn workspace__button"
+            className="item workspace-menu__item workspace-menu__item--danger"
             actionDescription="Delete"
             title={`Delete workspace '${workspace.name}'?`}
             onConfirm={() => deleteWorkspace(workspace.id)}
-            disabled={
-              currentUser.username !== workspace.owner.username &&
-              !(isAdmin && workspace.isPublic)
-            }
+            disabled={!canDelete}
           >
             <MdDelete />
             Delete Workspace
           </ModalAction>
+
           {isAdmin && (
             <>
-              <button
-                className="btn workspace__button"
-                onClick={() => exportWorkspaceInventory(workspace.id, "json")}
+              <Divider fitted style={{ margin: 0 }} />
+
+              {/* Admin export actions */}
+              <Menu.Item
+                className="workspace-menu__item"
+                onClick={() => {
+                  exportWorkspaceInventory(workspace.id, "json");
+                  closeMenu();
+                }}
               >
                 <MdFileDownload />
-                Export as JSON
-              </button>
-              <button
-                className="btn workspace__button"
-                onClick={() => exportWorkspaceInventory(workspace.id, "csv")}
+                Export Inventory as JSON
+              </Menu.Item>
+              <Menu.Item
+                className="workspace-menu__item"
+                onClick={() => {
+                  exportWorkspaceInventory(workspace.id, "csv");
+                  closeMenu();
+                }}
               >
                 <MdFileDownload />
-                Export as CSV
-              </button>
+                Export Inventory as CSV
+              </Menu.Item>
             </>
           )}
-        </div>
-      </div>
+        </Menu>
+      </Popup>
     </div>
   );
 }

--- a/frontend/src/js/services/WorkspaceApi.ts
+++ b/frontend/src/js/services/WorkspaceApi.ts
@@ -55,6 +55,31 @@ export function getWorkspacesMetadata(): Promise<WorkspaceMetadata[]> {
   return authFetch("/api/workspaces").then((res) => res.json());
 }
 
+export function exportWorkspaceInventory(
+  workspaceId: string,
+  format: "json" | "csv",
+) {
+  return authFetch(
+    `/api/workspaces/${workspaceId}/export?format=${format}`,
+  ).then(async (res) => {
+    const blob = await res.blob();
+    const disposition = res.headers.get("Content-Disposition");
+    const filenameMatch = disposition?.match(/filename="(.+)"/);
+    const filename = filenameMatch
+      ? filenameMatch[1]
+      : `workspace-inventory.${format}`;
+
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    window.URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+  });
+}
+
 export function getWorkspace(id: string) {
   return authFetch(`/api/workspaces/${id}`).then((res) => res.json());
 }

--- a/frontend/src/stylesheets/components/_workspace.scss
+++ b/frontend/src/stylesheets/components/_workspace.scss
@@ -53,10 +53,6 @@
   }
 }
 
-.hide-direct-child-buttons > button {
-  display: none;
-}
-
 .workspace__documents {
   height: 100%;
   width: 100%;

--- a/frontend/src/stylesheets/components/_workspace.scss
+++ b/frontend/src/stylesheets/components/_workspace.scss
@@ -131,6 +131,38 @@
   align-items: center;
 }
 
+// Custom menu item styles for the workspace actions menu
+// Uses higher specificity to override Semantic UI's .ui.vertical.menu .item
+.ui.vertical.menu .workspace-menu__item,
+.ui.vertical.menu > .workspace-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.workspace-menu__item {
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  svg {
+    flex-shrink: 0;
+    font-size: 16px;
+  }
+
+  &--danger:hover:not(:disabled) {
+    background-color: rgba(189, 39, 30, 0.08) !important;
+    color: #bd271e !important;
+  }
+}
+
 .workspace__tree {
   position: relative;
   height: 100%;

--- a/frontend/src/stylesheets/components/_workspace.scss
+++ b/frontend/src/stylesheets/components/_workspace.scss
@@ -140,6 +140,10 @@
   font-size: 14px;
   text-align: left;
   white-space: nowrap;
+
+  &:before {
+    display: none !important;
+  }
 }
 
 .workspace-menu__item {


### PR DESCRIPTION
Allows admins to export a JSON (or CSV) file of the current contents of the active workspace, showing workspace ID and

- when item added
- who added it
- URI of the dateset and ingestion it was uploaded to
- file type (if applicable)
- filename
- nodeID
- URI
- path in workspace
- size
- processing status


![2026-03-05 14 10 00](https://github.com/user-attachments/assets/e5e60086-5323-4f5d-900b-727a12c3d33c)
