### PR TITLE
Align workspace column headers with their content

### DIFF
--- a/frontend/src/stylesheets/components/_file-browser.scss
+++ b/frontend/src/stylesheets/components/_file-browser.scss
@@ -77,6 +77,9 @@
   user-select: none;
   position: relative;
   min-width: fit-content;
+  padding-left: $baseSpacing;
+  padding-right: $baseSpacing;
+  text-align: left;
 
   &-resizer {
     &-grabber {


### PR DESCRIPTION
Alignment and padding for the headers in the Workspace file tree adjusted to match the content

- Because headers should use the same alignment as the content of the columns below them in my book, and
- Because hitherto at a typical viewport the last column can show content without any visible header:

Before:
 
<img width="800" alt="Picture 258" src="https://github.com/user-attachments/assets/51f7b9e5-412b-48a3-81e4-1cde5a11f992" />

After:

<img width="800" alt="Picture 261" src="https://github.com/user-attachments/assets/493d59fc-01cb-44ab-ae49-3ef256609859" />


