### PR TITLE
Improve move ingestion elasticsearch query performance

### DIFF
--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -684,7 +684,7 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     executeUpdateByQuery {
       updateByQuerySync(indexName,
         termQuery(IndexFields.ingestionRaw, oldIngestionPath)
-      ).script(
+      ).scrollSize(250).requestsPerSecond(100).script(
         Script(
           s"""
              |if(ctx._source.${IndexFields.ingestion} != null) {


### PR DESCRIPTION
## What does this change?
Adds [scroll size and requests per second](https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-update-by-query) params to the elasticsearch query to move ingestions to a collection.
Before this change, the elasticsearch cluster was running out of memory while moving larger ingestions. After deploying this change and increasing each node's memory, the memory issues were mostly solved. 

## How has this change been tested?
Tested in prod 

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
