### PR TITLE
Use AMI encrypted with investigations stack key for elasticsearch

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -34,7 +34,7 @@ deployments:
       amiTags:
         Recipe: investigations-elasticsearch-8-arm64
         AmigoStage: PROD
-        Encrypted: pfi-playground
+        Encrypted: investigations
 
   pfi:
     type: autoscaling


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/giant/pull/522 this moves elasticsearch onto using AMIs encrypted with the shared 'investigations' KMS key, rather than having different keys for playground/giant.

## How has this change been tested?
I've tested this on playground and verified that a cluster with 2 nodes using different KMS keys still works (as expected since the encryption/decryption happens transparently)