### PR TITLE
Use AMI encrypted with investigations stack key for neo4j

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -24,7 +24,7 @@ deployments:
       amiTags:
         Recipe: investigations-neo4j-jammy
         AmigoStage: PROD
-        Encrypted: pfi-playground
+        Encrypted: investigations
 
   pfi-elasticsearch-ami-update:
     type: ami-cloudformation-parameter


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/giant/pull/598 this does the same thing for neo4j

## How has this change been tested?
I've tested this on playground - playground's neo4j instance is now using an AMI encrypted with the investigations key