### PR TITLE
Fix rollovers for user guide and settings

### DIFF
--- a/frontend/src/js/components/Header.js
+++ b/frontend/src/js/components/Header.js
@@ -82,6 +82,7 @@ export default class Header extends React.Component {
       <HeaderSearchLink
         to="/settings/dataset-permissions"
         activePaths={["/settings"]}
+        title="Settings"
       >
         <Settings className="main-header__item__icon" />
       </HeaderSearchLink>

--- a/frontend/src/js/components/UtilComponents/SearchLink.js
+++ b/frontend/src/js/components/UtilComponents/SearchLink.js
@@ -26,7 +26,7 @@ SearchLinkUnconnected.propTypes = {
 
 function NavSearchLinkUnconnected(props) {
   const { to, urlParams, children, onDrop, onDragOver, onDragLeave } = props;
-  const { className, activeClassName, isActive } = props;
+  const { className, activeClassName, isActive, title } = props;
   const link = buildLink(to, urlParams, {});
 
   return (
@@ -38,6 +38,7 @@ function NavSearchLinkUnconnected(props) {
       onDrop={onDrop}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
+      title={title}
     >
       {children}
     </NavLink>


### PR DESCRIPTION
Tooltips for the "User guide" and "Settings" icons at the top right of the screen weren't displaying.

Now they are. 

Checked on a local deploy; looks ok