### PR TITLE
Fix phantom transcript/OCR in highlighted resource responses

### DIFF
--- a/backend/app/services/index/HitReaders.scala
+++ b/backend/app/services/index/HitReaders.scala
@@ -306,10 +306,12 @@ object HitReaders {
       case Some(highlights) if highlights.nonEmpty =>
         val prefix = IndexFields.ocr + "."
 
-        Some(highlights.collect {
+        val result = highlights.collect {
           case (key, values) if key.startsWith(IndexFields.ocr) && values.nonEmpty =>
             key.substring(prefix.length) -> values.head
-        })
+        }
+
+        if (result.nonEmpty) Some(result) else None
 
       case _ =>
         None
@@ -333,7 +335,8 @@ object HitReaders {
           }
         }
 
-        Some(highlightedLanguages ++ nonHighlightedLanguages.getOrElse(Map()))
+        val result = highlightedLanguages ++ nonHighlightedLanguages.getOrElse(Map())
+        if (result.nonEmpty) Some(result) else None
 
       case _ =>
         None


### PR DESCRIPTION
Fixes #605 .

When fetching a resource with a search highlight query, highlightedOcr and highlightedTranscript could return Some(Map()) — an empty map wrapped in Some — when the highlight map was non-empty but contained no highlights for the OCR or transcript fields respectively.

This empty map serialised as {} in JSON, which is truthy in JavaScript, causing the frontend PreviewSwitcher to believe the document had a transcript and consequently suppress the Text and OCR view buttons.

Fix: Guard both functions to return None when the collected result map is empty.

