### PR TITLE
Optimise rendering of Pageviewer pages for HiDPI screens 

### DIFF
--- a/frontend/src/js/components/PageViewer/PdfHelpers.ts
+++ b/frontend/src/js/components/PageViewer/PdfHelpers.ts
@@ -84,8 +84,17 @@ const renderPagePreview = async (
 
   const viewport = pdfPage.getViewport({ scale });
 
-  canvas.width = viewport.width;
-  canvas.height = viewport.height;
+  // Render at higher resolution on HiDPI displays for sharper text.
+  // The canvas backing store is multiplied by DPR, but CSS dimensions
+  // are set to the logical size so the layout footprint is unchanged.
+  // Critically, `scale` (returned in CachedPreview) stays as the logical
+  // scale — text overlays and highlight geometry depend on this.
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = Math.floor(viewport.width * dpr);
+  canvas.height = Math.floor(viewport.height * dpr);
+  canvas.style.width = `${viewport.width}px`;
+  canvas.style.height = `${viewport.height}px`;
+  canvasContext.scale(dpr, dpr);
 
   // Render
   await pdfPage.render({


### PR DESCRIPTION
Fixes https://github.com/guardian/giant/issues/609

All screens are 'Retina'/HiDPI these days, so optimising for 72px/inch is no longer appropriate.

This multiplies the canvas backing store dimensions by window.devicePixelRatio and sets explicit CSS width/height to maintain the same footprint. Applies canvasContext.scale(dpr, dpr) so PDF.js renders at the higher resolution.

The logical scale returned in CachedPreview is unchanged, so text overlays (for selection and copy-paste), search highlights, find-in-document highlights, and comment selection geometry are all unaffected.

Before:
<img width="300" alt="Picture 58" src="https://github.com/user-attachments/assets/7e535d33-52e4-4630-af7f-724fdd442fb6" />

After:
<img width="300" alt="Picture 57" src="https://github.com/user-attachments/assets/8ad454ca-384d-49b0-99c4-ac0363c606ac" />


Tested:

- [x]  Local dev
- [x]  Playground - including e.g. scrolling quickly through a document by loads of pages
