### PR TITLE
[hold] Document view #5: Improve text overlay alignment for PageViewer selection accuracy

### DIFF
--- a/frontend/src/js/components/PageViewer/PageHighlight.tsx
+++ b/frontend/src/js/components/PageViewer/PageHighlight.tsx
@@ -18,7 +18,7 @@ export const PageHighlight: FC<PageHighlightProps> = ({
   const isFind = type === "FindHighlight";
   return (
     <>
-      {highlight.data.map((span) => {
+      {highlight.data.map((span, i) => {
         const style: CSSProperties = {
           position: "absolute",
           left: span.x * scale,
@@ -37,7 +37,12 @@ export const PageHighlight: FC<PageHighlightProps> = ({
         ];
 
         return (
-          <span id={id} key={id} className={classes.join(" ")} style={style} />
+          <span
+            id={`${id}-${i}`}
+            key={`${id}-${i}`}
+            className={classes.join(" ")}
+            style={style}
+          />
         );
       })}
     </>

--- a/frontend/src/js/components/PageViewer/PdfHelpers.ts
+++ b/frontend/src/js/components/PageViewer/PdfHelpers.ts
@@ -58,7 +58,7 @@ export const renderTextOverlays = async (
   }).promise;
 
   return textDivs.map((textDiv) => ({
-    value: textDiv.innerHTML,
+    value: textDiv.textContent ?? "",
     left: textDiv.style.left,
     top: textDiv.style.top,
     fontSize: textDiv.style.fontSize,

--- a/frontend/src/stylesheets/components/_page.scss
+++ b/frontend/src/stylesheets/components/_page.scss
@@ -26,10 +26,7 @@
 
 .pfi-page__pdf-text::selection {
   color: transparent;
-  // Can't use opacity with ::selection so this is CSS lightpink
-  // (to match comment selection)
   background-color: rgba(255, 182, 193, 0.4);
-  opacity: 0.5;
 }
 
 .pfi-page-highlight {

--- a/frontend/src/stylesheets/components/_page.scss
+++ b/frontend/src/stylesheets/components/_page.scss
@@ -20,6 +20,8 @@
   color: transparent;
   position: absolute;
   transform-origin: 0% 0%;
+  line-height: 1;
+  white-space: pre;
 }
 
 .pfi-page__pdf-text::selection {


### PR DESCRIPTION
This is an attempt to address the way text selection in the PageViewer is often misaligned vertically. A little robot tells me that the browser was adding default padding vertically, affecting selection. This removes that. 

This doesn't fix the much more serious problem of text selection and highlighting being misaligned in terms of character counts down the page. But it does at least get the user onto the right line. 

Add `line-height: 1` and `white-space: pre` to **.pfi-page__pdf-text** to prevent browser defaults from distorting the invisible text overlay geometry. 
- The default `line-height` (~1.2) added extra vertical space above/below each text div, causing the selectable area to be taller than the actual glyph; and on pages with lots of lines eventually shifts the selection and highlight to below the text.
- `white-space: pre` prevents the browser from collapsing whitespace or wrapping text, keeping positions aligned with where PDF.js placed them. Allegedly.

### Before:
<img width="500" alt="Picture 65" src="https://github.com/user-attachments/assets/b4d5d570-3279-435d-be40-a5d6e07cc61c" />

To select "workspaces section" the user actually has to drag the cursor across what appears to be the line below to get the selection right. The highlight itself is also too tall, although this actually helps since it overlaps the text, unlike the required cursor action. 

### After:
<img width="500" alt="Picture 66" src="https://github.com/user-attachments/assets/9891c420-425a-469f-b5a9-6b687951c48e" />

Cursor drag (and the highlight itself) aligns more accurately to the displayed text.

### Testing:      
- [x] Looks good on local dev but..
- [ ] Probably needs some quite thorough testing with different documents on playground