### PR TITLE
Add giant specific PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,8 @@
  - [ ] Tested on playground
 
 ## Things to think about
- - [ ] Does this change impact the external transcription service integration? If so, how has this been tested?
+ - Does this change impact the external transcription service integration? If so, how has this been tested?
+ - For UI changes: have you thought about accessibility? See https://github.com/guardian/accessibility/
 
 ## Images
 


### PR DESCRIPTION
## What does this change?
I think this is an improvement on the default guardian template, raising some giant specific stuff. 
