### PR TITLE
Use Map in getWorkspaceContents query to improve performance

### DIFF
--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -144,12 +144,14 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
       ))
 
       val entries = realEntries ++ synthesisedEntries
+      val childrenByParent: Map[String, List[TreeEntry[WorkspaceEntry]]] =
+        entries.groupBy(_.data.maybeParentId.getOrElse("noParent"))
 
       def buildNode(currentEntry: TreeEntry[WorkspaceEntry]): TreeEntry[WorkspaceEntry] = {
         currentEntry match {
           case leaf: TreeLeaf[WorkspaceEntry] => leaf
           case node: TreeNode[WorkspaceEntry] => {
-            val children = entries.filter(n => n.data.maybeParentId.contains(currentEntry.id)).map(buildNode)
+            val children = childrenByParent.getOrElse(node.id, List.empty).map(buildNode)
             node.copy(
               children = children,
               data = node.data match {


### PR DESCRIPTION
## What does this change?
This implements suggestion 1 from @hoyla 's investigation here https://github.com/guardian/giant/issues/369#issuecomment-3996093262, which seems very sensible! Currently we are iterating over every item in the workspace for every folder in the workspace, which could be slow if we have lots of folders. Building the map should mean we only do it once when first building the map

## How has this change been tested?
 - [x] Tested locally
 - [x] Tested on playground
