### PR TITLE
Fix move items progress bar stuck on '1 remaining'

### DIFF
--- a/frontend/src/js/actions/workspaces/moveItem.spec.ts
+++ b/frontend/src/js/actions/workspaces/moveItem.spec.ts
@@ -1,0 +1,67 @@
+jest.mock("../../services/WorkspaceApi");
+jest.mock("./getWorkspace");
+
+import { moveItems } from "./moveItem";
+import { moveItem as moveItemApi } from "../../services/WorkspaceApi";
+
+const mockedMoveItemApi = moveItemApi as jest.MockedFunction<
+  typeof moveItemApi
+>;
+
+function runThunk(thunk: ReturnType<typeof moveItems>) {
+  const dispatch = jest.fn((action) => {
+    if (typeof action === "function") {
+      return action();
+    }
+  });
+  return thunk(dispatch, jest.fn() as any, null);
+}
+
+beforeEach(() => {
+  mockedMoveItemApi.mockResolvedValue(undefined as any);
+});
+
+describe("moveItems", () => {
+  test("calls onEachSettled for every item", async () => {
+    const onEachSettled = jest.fn();
+    const thunk = moveItems(
+      "ws1",
+      ["a", "b", "c"],
+      "ws1",
+      "folder1",
+      onEachSettled,
+    );
+
+    await runThunk(thunk);
+
+    expect(mockedMoveItemApi).toHaveBeenCalledTimes(3);
+    expect(onEachSettled).toHaveBeenCalledTimes(3);
+  });
+
+  test("calls onEachSettled even when an item matches newParentId", async () => {
+    const onEachSettled = jest.fn();
+    // "folder1" is both in itemIds and is the newParentId
+    const thunk = moveItems(
+      "ws1",
+      ["a", "folder1", "b"],
+      "ws1",
+      "folder1",
+      onEachSettled,
+    );
+
+    await runThunk(thunk);
+
+    // "folder1" should be skipped for the API call
+    expect(mockedMoveItemApi).toHaveBeenCalledTimes(2);
+    // but onEachSettled should still fire for all 3 items
+    expect(onEachSettled).toHaveBeenCalledTimes(3);
+  });
+
+  test("does not call moveItemApi for items matching newParentId", async () => {
+    const thunk = moveItems("ws1", ["folder1"], "ws1", "folder1");
+
+    await runThunk(thunk);
+
+    expect(mockedMoveItemApi).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/js/actions/workspaces/moveItem.ts
+++ b/frontend/src/js/actions/workspaces/moveItem.ts
@@ -38,6 +38,8 @@ export function moveItems(
               .then(throttledCallback)
               .catch((error) => dispatch(() => errorMovingItem(error)))
               .finally(onEachSettled);
+          } else if (onEachSettled) {
+            onEachSettled();
           }
         }
       }),


### PR DESCRIPTION
Fixes #629 

When moving items within a workspace, the progress bar could get permanently stuck showing 1 remaining items, and the browser would warn users not to leave the page — even though nothing was being moved.

![2026-03-20 18 02 36](https://github.com/user-attachments/assets/e32ab006-6efd-4d7b-aaf3-f70835ae0894)

### Why (I think) this was happening:

In `moveItems()`, if a selected item's ID matched `newParentId` (the drop target), the API call was correctly skipped but the `onEachSettled` callback was never called. This caused `itemsWithMoveSettled` to never reach `itemsBeingMoved`, so the progress bar and `beforeunload` handler were never cleared.

### Changes:

- Call `onEachSettled` for skipped items as well, to keep the counters in sync. 
- Add tests covering the fix.

### Testing by humanz:

I tried some combinations of moves and copies within and across workspaces and I think I've addressed this. At least, I think what I've done seems entirely logical, even if it doesn't entirely eliminate the "stuck moving" issues.

- [x] Tests in local dev
- [ ] Tests in playground
