### PR TITLE
Add warning if user chooses to download in original format

### DIFF
--- a/frontend/src/js/components/viewer/DownloadModal.js
+++ b/frontend/src/js/components/viewer/DownloadModal.js
@@ -271,6 +271,19 @@ Email Body:
             />
           </div>
         </div>
+        {this.state.downloadType === "original" && (
+          <div
+            className="error-bar__warning"
+            style={{
+              padding: "10px",
+              marginBottom: "10px",
+              borderRadius: "4px",
+            }}
+          >
+            <strong>Warning:</strong> files in their original format could
+            contain malware, macros, web beacons etc. Please exercise caution.
+          </div>
+        )}
         <div className="form__row">
           <span className="form__label required-field">Save As</span>
           <div className="download-modal__name">


### PR DESCRIPTION
Closes #555 

In the 'Download' dialog available from the document view, users can pick Original or one of the extracted text modes. If they pick Original, they're now shown a warning that the're not protected from malware if they view files directly on their computer. 

## What does this change?

`frontend/src/js/components/viewer/DownloadModal.js` adds a warning after 'Original' is picked. 

## Images

![2026-03-21 06 54 51](https://github.com/user-attachments/assets/989ac6ec-75a5-4dff-946a-8fc070139896)


## How has this change been tested?
 - [x] Tested locally
 - [ ] Tested on playground



