### PR TITLE
Add support for second spot asg in worker control

### DIFF
--- a/backend/app/services/Config.scala
+++ b/backend/app/services/Config.scala
@@ -186,12 +186,13 @@ case class BucketConfig(
 }
 
 case class AWSDiscoveryConfig(
-  region: String,
-  stack: String,
-  app: String,
-  stage: String,
-  runningLocally: Option[Boolean],
-  workerAutoScalingGroupName: Option[String]
+                               region: String,
+                               stack: String,
+                               app: String,
+                               stage: String,
+                               runningLocally: Option[Boolean],
+                               workerAutoScalingGroupName: Option[String],
+                               spotWorkerAutoscalingGroupName: Option[String]
 ) {
   val regionV2: Region = Region.of(region)
 }

--- a/backend/app/utils/AwsDiscovery.scala
+++ b/backend/app/utils/AwsDiscovery.scala
@@ -121,7 +121,7 @@ object AwsDiscovery extends Logging {
     }
   }
 
-  def findRunningInstances(stack: String, app: String, stage: String, ec2Client: Ec2Client): Iterable[Instance] = {
+  def findRunningInstances(stack: String, app: List[String], stage: String, ec2Client: Ec2Client): Iterable[Instance] = {
     val request = DescribeInstancesRequest.builder()
       .filters(
         Filter.builder()
@@ -130,7 +130,7 @@ object AwsDiscovery extends Logging {
         .build(),
         Filter.builder()
           .name("tag:App")
-          .values(app)
+          .values(app.asJava)
           .build(),
         Filter.builder()
           .name("tag:Stage")
@@ -176,7 +176,7 @@ object AwsDiscovery extends Logging {
   }
 
   private def buildElasticsearchHosts(stack: String, stage: String, ec2Client: Ec2Client): List[String] = {
-    val instances = findRunningInstances(stack, app = "elasticsearch", stage, ec2Client).toList
+    val instances = findRunningInstances(stack, app = List("elasticsearch"), stage, ec2Client).toList
     val hosts = instances.map(_.privateIpAddress()).map("http://" + _ + ":9200")
 
     logger.info(s"AWS discovery elasticsearch hosts: [${hosts.mkString(",")}]")
@@ -185,7 +185,7 @@ object AwsDiscovery extends Logging {
   }
 
   private def buildNeo4jUrl(stack: String, stage: String, ec2Client: Ec2Client): String = {
-    findRunningInstances(stack, app = "neo4j", stage, ec2Client).toList match {
+    findRunningInstances(stack, app = List("neo4j"), stage, ec2Client).toList match {
       case instance :: Nil =>
         val url = s"bolt://${instance.privateIpAddress()}:7687"
         logger.info(s"AWS discovery neo4j url: $url")

--- a/backend/app/utils/AwsDiscovery.scala
+++ b/backend/app/utils/AwsDiscovery.scala
@@ -24,7 +24,7 @@ object AwsDiscovery extends Logging {
     // We won't have an instance ID if running locally but against databases in S3
     val maybeInstanceId = Option(EC2MetadataUtils.getInstanceId)
 
-    val AWSDiscoveryConfig(region, stack, app, stage, _, _) = discoveryConfig
+    val AWSDiscoveryConfig(region, stack, app, stage, _, _, _) = discoveryConfig
     val runningLocally = discoveryConfig.runningLocally.getOrElse(false)
     val regionV2 = discoveryConfig.regionV2
 

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -55,7 +55,7 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
   def getWorkerDetails(implicit ec: ExecutionContext): Attempt[WorkerDetails] = for {
     myInstanceId <- Attempt.catchNonFatalBlasé { EC2MetadataUtils.getInstanceId }
     instances <- Attempt.catchNonFatalBlasé {
-      AwsDiscovery.findRunningInstances(discoveryConfig.stack, app = "pfi-worker", discoveryConfig.stage, ec2)
+      AwsDiscovery.findRunningInstances(discoveryConfig.stack, app = List("pfi-worker", "pfi-spot-worker"), discoveryConfig.stage, ec2)
     }
   } yield {
     WorkerDetails(instances.map(_.instanceId()).toSet, myInstanceId)
@@ -98,7 +98,7 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
 
   private def runningOnOldestInstance()(implicit ec: ExecutionContext): Boolean = {
     val myInstanceId = EC2MetadataUtils.getInstanceId
-    val otherInstances =  AwsDiscovery.findRunningInstances(discoveryConfig.stack, app = "pfi", discoveryConfig.stage, ec2)
+    val otherInstances =  AwsDiscovery.findRunningInstances(discoveryConfig.stack, app = List("pfi"), discoveryConfig.stage, ec2)
 
     val oldestInstance = otherInstances.toList.sortBy(_.launchTime()).headOption.map(_.instanceId())
 
@@ -201,7 +201,8 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
 
   private def breakLocksOnTerminatedWorkers(): Attempt[Unit] = {
     Attempt.catchNonFatalBlasé {
-      val runningWorkers = AwsDiscovery.findRunningInstances(discoveryConfig.stack, app = "pfi-worker", discoveryConfig.stage, ec2)
+      val runningWorkers =
+        AwsDiscovery.findRunningInstances(discoveryConfig.stack, app = List("pfi-worker", "pfi-spot-worker"), discoveryConfig.stage, ec2)
       val runningInstanceIds = runningWorkers.map(_.instanceId()).toList
 
       logger.info(s"Breaking locks for any worker not running. Running: [${runningInstanceIds.mkString(", ")}]")

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -235,10 +235,10 @@ object AWSWorkerControl {
   ) {
     override def toString: String =
       s"desiredNumberOfWorkers=$desiredNumberOfWorkers, " +
-        s"lastEventTime=${new Date(lastEventTime)}, " +
+        s"actualNumberOfWorkers=$actualNumberOfWorkers " +
         s"minimumNumberOfWorkers=$minimumNumberOfWorkers, " +
-        s"maximumNumberOfWorkers=$maximumNumberOfWorkers" +
-        s"actualNumberOfWorkers=$actualNumberOfWorkers"
+        s"maximumNumberOfWorkers=$maximumNumberOfWorkers, " +
+        s"lastEventTime=${new Date(lastEventTime)}, "
   }
 
   case class State(

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -110,17 +110,26 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
       
       logger.info(s"AWSWorkerControl on-demand asg: ${state.workerAsg} spot asg: ${state.spotWorkerAsg} inProgress: ${state.inProgress}, outstandingFromIngestStore: ${state.outstandingFromIngestStore}, outstandingFromTodos: ${state.outstandingFromTodos}, operation: $operation")
 
+    // as this check runs every minute, we assume that if there's a difference between actual/desired workers then
+    // there's a spot capacity problem, in which case we scale on demand instead of spot. Capacity is still constrained
+    // by the maximum size of the spot ASG via the check in decideOperation
+    val spotCapacityProblems = state.spotWorkerAsg.actualNumberOfWorkers < state.spotWorkerAsg.desiredNumberOfWorkers
+
       val scaleResult = operation match {
         // we scale up using the spot ASG
-        case Some(AddNewWorker) if state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers =>
+        case Some(AddNewWorker) if !spotCapacityProblems && state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers =>
           setNumberOfWorkers(state.spotWorkerAsg.desiredNumberOfWorkers + 1, spotWorkerAutoscalingGroupName)
-          // when scaling down, start with the spot ASG
+
+        case Some(AddNewWorker) if state.workerAsg.desiredNumberOfWorkers < state.workerAsg.maximumNumberOfWorkers =>
+          setNumberOfWorkers(state.workerAsg.desiredNumberOfWorkers + 1, workerAutoScalingGroupName)
+
+        // when scaling down, start with the on demand ASG
+        case Some(RemoveWorker) if state.workerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers =>
+          setNumberOfWorkers(state.workerAsg.desiredNumberOfWorkers - 1, workerAutoScalingGroupName)
+
         case Some(RemoveWorker) if state.spotWorkerAsg.desiredNumberOfWorkers > state.spotWorkerAsg.minimumNumberOfWorkers =>
           setNumberOfWorkers(state.spotWorkerAsg.desiredNumberOfWorkers - 1, spotWorkerAutoscalingGroupName)
 
-          // we only expect to need to scale down the on-demand ASG in the event that we've manually scaled it up
-        case Some(RemoveWorker) if state.workerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers =>
-          setNumberOfWorkers(state.workerAsg.desiredNumberOfWorkers - 1, workerAutoScalingGroupName)
 
         case _ =>
           Attempt.Right(())
@@ -137,6 +146,7 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
     for {
       asg <- getAutoScalingGroup(asgName)
       desiredNumberOfWorkers = asg.desiredCapacity().intValue()
+      actualNumberOfWorkers = asg.instances().size()
       minimumNumberOfWorkers = asg.minSize().intValue()
       // This is not the same as the max in the auto-scaling group as we
       // need to maintain headroom to accommodate new workers during a
@@ -144,7 +154,7 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
       maximumNumberOfWorkers = Math.max(asg.minSize(), asg.maxSize() / 2)
       lastEventTime <- getLastEventTime(asg.autoScalingGroupName())
     } yield {
-      AWSWorkerControl.AsgState(desiredNumberOfWorkers, lastEventTime, minimumNumberOfWorkers, maximumNumberOfWorkers)
+      AWSWorkerControl.AsgState(desiredNumberOfWorkers, lastEventTime, minimumNumberOfWorkers, maximumNumberOfWorkers, actualNumberOfWorkers)
       }
     }
 
@@ -220,13 +230,15 @@ object AWSWorkerControl {
     desiredNumberOfWorkers: Int,
     lastEventTime: Long,
     minimumNumberOfWorkers: Int,
-    maximumNumberOfWorkers: Int
+    maximumNumberOfWorkers: Int,
+    actualNumberOfWorkers: Int
   ) {
     override def toString: String =
       s"desiredNumberOfWorkers=$desiredNumberOfWorkers, " +
         s"lastEventTime=${new Date(lastEventTime)}, " +
         s"minimumNumberOfWorkers=$minimumNumberOfWorkers, " +
-        s"maximumNumberOfWorkers=$maximumNumberOfWorkers"
+        s"maximumNumberOfWorkers=$maximumNumberOfWorkers" +
+        s"actualNumberOfWorkers=$actualNumberOfWorkers"
   }
 
   case class State(
@@ -249,7 +261,7 @@ object AWSWorkerControl {
 
     if(inCooldown || manuallyScaledDown) {
       None
-      // we only ever automatically scale up the spot asg
+      // we scale to the maximum size of the spot ASG (capacity might end up being met in the on demand ASG if no spot capacity is availalbe)
     } else if(outstandingInTotal > 0 && state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers) {
       Some(AddNewWorker)
       // when scaling down automatically we check both asgs for excess capacity

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -107,16 +107,18 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
 
   private def scaleUpOrDownIfNeeded(state: AWSWorkerControl.State, workerAutoScalingGroupName: String, spotWorkerAutoscalingGroupName: String)(implicit ec: ExecutionContext): Unit = {
       val operation = AWSWorkerControl.decideOperation(state, Instant.now().toEpochMilli, config.controlCooldown.toMillis)
-    
-      logger.info(s"AWSWorkerControl ${state.workerAsg.toString} ${state.spotWorkerAsg.toString} desiredNumberOfWorkers: ${state.workerAsg.desiredNumberOfWorkers} spotDesiredNumberOfWorkers: ${state.spotWorkerAsg.desiredNumberOfWorkers}, inProgress: ${state.inProgress}, outstandingFromIngestStore: ${state.outstandingFromIngestStore}, outstandingFromTodos: ${state.outstandingFromTodos}, operation: $operation")
+      
+      logger.info(s"AWSWorkerControl on-demand asg: ${state.workerAsg} spot asg: ${state.spotWorkerAsg} inProgress: ${state.inProgress}, outstandingFromIngestStore: ${state.outstandingFromIngestStore}, outstandingFromTodos: ${state.outstandingFromTodos}, operation: $operation")
 
       val scaleResult = operation match {
+        // we scale up using the spot ASG
         case Some(AddNewWorker) if state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers =>
-          setNumberOfWorkers(state.spotWorkerAsg.desiredNumberOfWorkers + 1, workerAutoScalingGroupName)
-
+          setNumberOfWorkers(state.spotWorkerAsg.desiredNumberOfWorkers + 1, spotWorkerAutoscalingGroupName)
+          // when scaling down, start with the spot ASG
         case Some(RemoveWorker) if state.spotWorkerAsg.desiredNumberOfWorkers > state.spotWorkerAsg.minimumNumberOfWorkers =>
           setNumberOfWorkers(state.spotWorkerAsg.desiredNumberOfWorkers - 1, spotWorkerAutoscalingGroupName)
 
+          // we only expect to need to scale down the on-demand ASG in the event that we've manually scaled it up
         case Some(RemoveWorker) if state.workerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers =>
           setNumberOfWorkers(state.workerAsg.desiredNumberOfWorkers - 1, workerAutoScalingGroupName)
 
@@ -149,7 +151,7 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
 
   private def getCurrentState(workerAutoScalingGroupName: String, workerSpotAutoscalingGroupName: String)(implicit ec: ExecutionContext): Attempt[AWSWorkerControl.State] = {
     for {
-      workerAutoScalingGroup <- getAsgState(workerSpotAutoscalingGroupName)
+      workerAutoScalingGroup <- getAsgState(workerAutoScalingGroupName)
       spotWorkerAutoscalingGroup <- getAsgState(workerSpotAutoscalingGroupName)
       extractorWorkCounts <- Attempt.fromEither(manifest.getWorkCounts())
       filesLeftInS3UploadBucket <- Attempt.fromEither(ingestStorage.list)
@@ -221,10 +223,10 @@ object AWSWorkerControl {
     maximumNumberOfWorkers: Int
   ) {
     override def toString: String =
-      s"AsgState(desiredNumberOfWorkers=$desiredNumberOfWorkers, " +
+      s"desiredNumberOfWorkers=$desiredNumberOfWorkers, " +
         s"lastEventTime=${new Date(lastEventTime)}, " +
         s"minimumNumberOfWorkers=$minimumNumberOfWorkers, " +
-        s"maximumNumberOfWorkers=$maximumNumberOfWorkers)"
+        s"maximumNumberOfWorkers=$maximumNumberOfWorkers"
   }
 
   case class State(

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -67,18 +67,18 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
   }
 
   override def start(scheduler: Scheduler)(implicit ec: ExecutionContext): Unit = {
-    discoveryConfig.workerAutoScalingGroupName match {
-      case Some(workerAutoScalingGroupName) =>
+    (discoveryConfig.workerAutoScalingGroupName, discoveryConfig.spotWorkerAutoscalingGroupName) match {
+      case (Some(workerAutoScalingGroupName), Some(spotWorkerAutoscalingGroupName)) =>
         scheduler.scheduleWithFixedDelay(config.controlInterval, config.controlInterval)(() => {
           // Only run the check on the oldest instance to get as close as we running the checks as a "singleton"
           if(runningOnOldestInstance()) {
-            val state = getCurrentState(workerAutoScalingGroupName)
+            val state = getCurrentState(workerAutoScalingGroupName, spotWorkerAutoscalingGroupName)
             // reuse the state needed for worker control to report cloudwatch metrics on work remaining
             state.foreach(publishStateMetrics)
             if(AwsDiscovery.isRiffRaffDeployRunning(discoveryConfig.stack, discoveryConfig.stage, ec2)) {
               logger.info("AWSWorkerControl - not running check as Riff-Raff deploy is running (instances are running and tagged as Magenta:Terminate)")
             } else {
-              state.foreach(s => scaleUpOrDownIfNeeded(s, workerAutoScalingGroupName))
+              state.foreach(s => scaleUpOrDownIfNeeded(s, workerAutoScalingGroupName, spotWorkerAutoscalingGroupName))
               breakLocksOnTerminatedWorkers()
             }
           } else {
@@ -86,8 +86,8 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
           }
         })
 
-      case None =>
-        logger.warn("Missing aws.workerAutoScalingGroupName setting, cannot automatically update workers")
+      case _ =>
+        logger.warn("Missing aws.workerAutoScalingGroupName or aws.spotWorkerAutoscalingGroupName setting, cannot automatically update workers")
     }
   }
 
@@ -105,17 +105,20 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
     oldestInstance.isEmpty || oldestInstance.contains(myInstanceId)
   }
 
-  private def scaleUpOrDownIfNeeded(state: AWSWorkerControl.State, workerAutoScalingGroupName: String)(implicit ec: ExecutionContext): Unit = {
+  private def scaleUpOrDownIfNeeded(state: AWSWorkerControl.State, workerAutoScalingGroupName: String, spotWorkerAutoscalingGroupName: String)(implicit ec: ExecutionContext): Unit = {
       val operation = AWSWorkerControl.decideOperation(state, Instant.now().toEpochMilli, config.controlCooldown.toMillis)
-
-      logger.info(s"AWSWorkerControl desiredNumberOfWorkers: ${state.desiredNumberOfWorkers}, inProgress: ${state.inProgress}, outstandingFromIngestStore: ${state.outstandingFromIngestStore}, outstandingFromTodos: ${state.outstandingFromTodos} lastEventTime: ${new Date(state.lastEventTime)}, minimumNumberOfWorkers: ${state.minimumNumberOfWorkers}, maximumNumberOfWorkers: ${state.maximumNumberOfWorkers}, operation: $operation")
+    
+      logger.info(s"AWSWorkerControl ${state.workerAsg.toString} ${state.spotWorkerAsg.toString} desiredNumberOfWorkers: ${state.workerAsg.desiredNumberOfWorkers} spotDesiredNumberOfWorkers: ${state.spotWorkerAsg.desiredNumberOfWorkers}, inProgress: ${state.inProgress}, outstandingFromIngestStore: ${state.outstandingFromIngestStore}, outstandingFromTodos: ${state.outstandingFromTodos}, operation: $operation")
 
       val scaleResult = operation match {
-        case Some(AddNewWorker) if state.desiredNumberOfWorkers < state.maximumNumberOfWorkers =>
-          setNumberOfWorkers(state.desiredNumberOfWorkers + 1, workerAutoScalingGroupName)
+        case Some(AddNewWorker) if state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers =>
+          setNumberOfWorkers(state.spotWorkerAsg.desiredNumberOfWorkers + 1, workerAutoScalingGroupName)
 
-        case Some(RemoveWorker) if state.desiredNumberOfWorkers > state.minimumNumberOfWorkers =>
-          setNumberOfWorkers(state.desiredNumberOfWorkers - 1, workerAutoScalingGroupName)
+        case Some(RemoveWorker) if state.spotWorkerAsg.desiredNumberOfWorkers > state.spotWorkerAsg.minimumNumberOfWorkers =>
+          setNumberOfWorkers(state.spotWorkerAsg.desiredNumberOfWorkers - 1, spotWorkerAutoscalingGroupName)
+
+        case Some(RemoveWorker) if state.workerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers =>
+          setNumberOfWorkers(state.workerAsg.desiredNumberOfWorkers - 1, workerAutoScalingGroupName)
 
         case _ =>
           Attempt.Right(())
@@ -128,22 +131,31 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
     }
   }
 
-  private def getCurrentState(workerAutoScalingGroupName: String)(implicit ec: ExecutionContext): Attempt[AWSWorkerControl.State] = {
+  private def getAsgState(asgName: String)(implicit ec: ExecutionContext): Attempt[AWSWorkerControl.AsgState] = {
     for {
-      workerAutoScalingGroup <- getAutoScalingGroup(workerAutoScalingGroupName)
-      desiredNumberOfWorkers = workerAutoScalingGroup.desiredCapacity().intValue()
-      minimumNumberOfWorkers = workerAutoScalingGroup.minSize().intValue()
+      asg <- getAutoScalingGroup(asgName)
+      desiredNumberOfWorkers = asg.desiredCapacity().intValue()
+      minimumNumberOfWorkers = asg.minSize().intValue()
       // This is not the same as the max in the auto-scaling group as we
       // need to maintain headroom to accommodate new workers during a
       // deploy even if we're scaled up due to the number of tasks
-      maximumNumberOfWorkers = Math.max(workerAutoScalingGroup.minSize(), workerAutoScalingGroup.maxSize() / 2)
-      lastEventTime <- getLastEventTime(workerAutoScalingGroup.autoScalingGroupName())
+      maximumNumberOfWorkers = Math.max(asg.minSize(), asg.maxSize() / 2)
+      lastEventTime <- getLastEventTime(asg.autoScalingGroupName())
+    } yield {
+      AWSWorkerControl.AsgState(desiredNumberOfWorkers, lastEventTime, minimumNumberOfWorkers, maximumNumberOfWorkers)
+      }
+    }
 
+
+  private def getCurrentState(workerAutoScalingGroupName: String, workerSpotAutoscalingGroupName: String)(implicit ec: ExecutionContext): Attempt[AWSWorkerControl.State] = {
+    for {
+      workerAutoScalingGroup <- getAsgState(workerSpotAutoscalingGroupName)
+      spotWorkerAutoscalingGroup <- getAsgState(workerSpotAutoscalingGroupName)
       extractorWorkCounts <- Attempt.fromEither(manifest.getWorkCounts())
       filesLeftInS3UploadBucket <- Attempt.fromEither(ingestStorage.list)
     } yield {
-      AWSWorkerControl.State(desiredNumberOfWorkers, extractorWorkCounts.inProgress, filesLeftInS3UploadBucket.size,
-        extractorWorkCounts.outstanding, lastEventTime, minimumNumberOfWorkers, maximumNumberOfWorkers)
+      AWSWorkerControl.State(extractorWorkCounts.inProgress, filesLeftInS3UploadBucket.size,
+        extractorWorkCounts.outstanding, workerAutoScalingGroup, spotWorkerAutoscalingGroup)
     }
   }
 
@@ -200,14 +212,26 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
 }
 
 object AWSWorkerControl {
-  case class State(
+
+  case class AsgState(
     desiredNumberOfWorkers: Int,
-    inProgress: Int,
-    outstandingFromIngestStore: Int,
-    outstandingFromTodos: Int,
     lastEventTime: Long,
     minimumNumberOfWorkers: Int,
     maximumNumberOfWorkers: Int
+  ) {
+    override def toString: String =
+      s"AsgState(desiredNumberOfWorkers=$desiredNumberOfWorkers, " +
+        s"lastEventTime=${new Date(lastEventTime)}, " +
+        s"minimumNumberOfWorkers=$minimumNumberOfWorkers, " +
+        s"maximumNumberOfWorkers=$maximumNumberOfWorkers)"
+  }
+
+  case class State(
+    inProgress: Int,
+    outstandingFromIngestStore: Int,
+    outstandingFromTodos: Int,
+    workerAsg: AsgState,
+    spotWorkerAsg: AsgState
   )
 
   sealed trait Operation
@@ -215,16 +239,18 @@ object AWSWorkerControl {
   case object RemoveWorker extends Operation
 
   def decideOperation(state: State, now: Long, cooldown: Long): Option[Operation] = {
-    val inCooldown = state.lastEventTime > (now - cooldown)
-    val manuallyScaledDown = state.desiredNumberOfWorkers == 0
+    val inCooldown = state.workerAsg.lastEventTime > (now - cooldown) || state.spotWorkerAsg.lastEventTime > (now - cooldown)
+    val manuallyScaledDown = state.workerAsg.desiredNumberOfWorkers == 0
 
     val outstandingInTotal = state.outstandingFromIngestStore + state.outstandingFromTodos
 
     if(inCooldown || manuallyScaledDown) {
       None
-    } else if(outstandingInTotal > 0 && state.desiredNumberOfWorkers < state.maximumNumberOfWorkers) {
+      // we only ever automatically scale up the spot asg
+    } else if(outstandingInTotal > 0 && state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers) {
       Some(AddNewWorker)
-    } else if(outstandingInTotal == 0 && state.inProgress == 0 && state.desiredNumberOfWorkers > state.minimumNumberOfWorkers) {
+      // when scaling down automatically we check both asgs for excess capacity
+    } else if(outstandingInTotal == 0 && state.inProgress == 0 && state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers + state.spotWorkerAsg.minimumNumberOfWorkers) {
       Some(RemoveWorker)
     } else {
       None

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -54,6 +54,16 @@ deployments:
     dependencies:
       - pfi
 
+  pfi-spot-worker:
+    type: autoscaling
+    parameters:
+      bucketSsmKey: /pfi-playground/artifact.bucket
+      bucketSsmLookup: true
+    actions:
+      - deploy
+    dependencies:
+      - pfi
+
   pfi-cli:
     type: aws-s3
     parameters:


### PR DESCRIPTION
## What does this change?

We'd like to introduce a spot instance pool to Giant when running in AWS. This will reduce costs when performing large ingestions. This PR updates the worker control in giant to support having a second worker autoscaling group.

The general idea is:
 - If we need more workers and the spot ASG is not full, we scale up the spot ASG
 - If we are trying to scale up the spot ASG but we notice that actual instances < desiredInstances then we scale up the on demand ASG instead, assuming a problem with spot capacity
 -  Giant will scale DOWN both asgs if it runs out of work, starting with the on demand ASG

The associated infrastructure changes are here: https://github.com/guardian/investigations-platform/pull/620

## How has this change been tested?
 - [ ] Tested locally
 - [x] Tested on playground
