### PR TITLE
Document viewer nav #1: Karpow that workspace folder

### DIFF
--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -107,7 +107,7 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
 
   private def scaleUpOrDownIfNeeded(state: AWSWorkerControl.State, workerAutoScalingGroupName: String)(implicit ec: ExecutionContext): Unit = {
       val operation = AWSWorkerControl.decideOperation(state, Instant.now().toEpochMilli, config.controlCooldown.toMillis)
-      
+
       logger.info(s"AWSWorkerControl desiredNumberOfWorkers: ${state.desiredNumberOfWorkers}, inProgress: ${state.inProgress}, outstandingFromIngestStore: ${state.outstandingFromIngestStore}, outstandingFromTodos: ${state.outstandingFromTodos} lastEventTime: ${new Date(state.lastEventTime)}, minimumNumberOfWorkers: ${state.minimumNumberOfWorkers}, maximumNumberOfWorkers: ${state.maximumNumberOfWorkers}, operation: $operation")
 
       val scaleResult = operation match {

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -105,12 +105,14 @@ export const PageViewerOrFallback: FC<{}> = () => {
   const navId = searchParams.get("navId");
   const navIndexParam = searchParams.get("navIndex");
   const navIndex = navIndexParam !== null ? parseInt(navIndexParam, 10) : null;
-  const workspaceNav = useWorkspaceNavigation(
-    uri,
-    navId,
-    Number.isFinite(navIndex) ? navIndex : null,
-    history.push,
-  );
+  const workspaceNav = navId
+    ? useWorkspaceNavigation(
+        uri,
+        navId,
+        Number.isFinite(navIndex) ? navIndex : null,
+        history.push,
+      )
+    : undefined;
 
   const [response, setResponse] = useState<PageCountResponse | null>(null);
   const view = useSelector<GiantState, string | undefined>(
@@ -174,18 +176,6 @@ export const PageViewerOrFallback: FC<{}> = () => {
         </div>
         {resource && (
           <div className="document__status">
-            {workspaceNav.goToNext && (
-              <KeyboardShortcut
-                shortcut={keyboardShortcuts.nextResult}
-                func={workspaceNav.goToNext}
-              />
-            )}
-            {workspaceNav.goToPrevious && (
-              <KeyboardShortcut
-                shortcut={keyboardShortcuts.previousResult}
-                func={workspaceNav.goToPrevious}
-              />
-            )}
             {/* Left spacer: document__status uses space-between to match the legacy StatusBar two-span layout */}
             <span />
             <span className="doc-nav-buttons">
@@ -194,20 +184,33 @@ export const PageViewerOrFallback: FC<{}> = () => {
                 resource={resource}
                 totalPages={response.pageCount}
               />
-              {(workspaceNav.hasPrevious || workspaceNav.hasNext) && (
-                <>
-                  <DocNavButton
-                    direction="previous"
-                    title="Previous in folder"
-                    onClick={workspaceNav.goToPrevious}
-                  />
-                  <DocNavButton
-                    direction="next"
-                    title="Next in folder"
-                    onClick={workspaceNav.goToNext}
-                  />
-                </>
-              )}
+              {workspaceNav &&
+                (workspaceNav.goToPrevious || workspaceNav.goToNext) && (
+                  <>
+                    {workspaceNav.goToNext && (
+                      <KeyboardShortcut
+                        shortcut={keyboardShortcuts.nextResult}
+                        func={workspaceNav.goToNext}
+                      />
+                    )}
+                    {workspaceNav.goToPrevious && (
+                      <KeyboardShortcut
+                        shortcut={keyboardShortcuts.previousResult}
+                        func={workspaceNav.goToPrevious}
+                      />
+                    )}
+                    <DocNavButton
+                      direction="previous"
+                      title="Previous in folder"
+                      onClick={workspaceNav.goToPrevious}
+                    />
+                    <DocNavButton
+                      direction="next"
+                      title="Next in folder"
+                      onClick={workspaceNav.goToNext}
+                    />
+                  </>
+                )}
             </span>
           </div>
         )}

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -146,7 +146,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
             func={workspaceNav.goToPrevious}
           />
         )}
-        <Viewer match={{ params: { uri } }} />
+        <Viewer key={uri} match={{ params: { uri } }} />
         <div className="document__status">
           <span />
           <span className="doc-nav-buttons">
@@ -172,6 +172,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
           {showTextContent ? (
             <div className="document">
               <PageViewerContent
+                key={uri}
                 uri={uri}
                 totalPages={response.pageCount}
                 firstPageDimensions={response.dimensions ?? undefined}
@@ -180,6 +181,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
             </div>
           ) : (
             <PageViewerContent
+              key={uri}
               uri={uri}
               totalPages={response.pageCount}
               firstPageDimensions={response.dimensions ?? undefined}

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -105,14 +105,12 @@ export const PageViewerOrFallback: FC<{}> = () => {
   const navId = searchParams.get("navId");
   const navIndexParam = searchParams.get("navIndex");
   const navIndex = navIndexParam !== null ? parseInt(navIndexParam, 10) : null;
-  const workspaceNav = navId
-    ? useWorkspaceNavigation(
-        uri,
-        navId,
-        Number.isFinite(navIndex) ? navIndex : null,
-        history.push,
-      )
-    : undefined;
+  const workspaceNav = useWorkspaceNavigation(
+    uri,
+    navId,
+    Number.isFinite(navIndex) ? navIndex : null,
+    history.push,
+  );
 
   const [response, setResponse] = useState<PageCountResponse | null>(null);
   const view = useSelector<GiantState, string | undefined>(

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -101,8 +101,16 @@ type PageCountResponse = {
 
 export const PageViewerOrFallback: FC<{}> = () => {
   const { uri } = useParams<{ uri: string }>();
-  const navId = new URLSearchParams(window.location.search).get("navId");
-  const workspaceNav = useWorkspaceNavigation(uri, navId, history.push);
+  const searchParams = new URLSearchParams(window.location.search);
+  const navId = searchParams.get("navId");
+  const navIndexParam = searchParams.get("navIndex");
+  const navIndex = navIndexParam !== null ? parseInt(navIndexParam, 10) : null;
+  const workspaceNav = useWorkspaceNavigation(
+    uri,
+    navId,
+    Number.isFinite(navIndex) ? navIndex : null,
+    history.push,
+  );
 
   const [response, setResponse] = useState<PageCountResponse | null>(null);
   const view = useSelector<GiantState, string | undefined>(

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -16,6 +16,11 @@ import { PageDimensions } from "./PageViewer/model";
 import { setResourceView } from "../actions/urlParams/setViews";
 import { getComments } from "../actions/resources/getComments";
 import { setSelection } from "../actions/resources/setSelection";
+import history from "../util/history";
+import { useWorkspaceNavigation } from "../util/workspaceNavigation";
+import { DocNavButton } from "./viewer/DocNavButton";
+import { keyboardShortcuts } from "../util/keyboardShortcuts";
+import { KeyboardShortcut } from "./UtilComponents/KeyboardShortcut";
 
 const COMBINED_VIEW = "combined";
 
@@ -96,6 +101,8 @@ type PageCountResponse = {
 
 export const PageViewerOrFallback: FC<{}> = () => {
   const { uri } = useParams<{ uri: string }>();
+  const navId = new URLSearchParams(window.location.search).get("navId");
+  const workspaceNav = useWorkspaceNavigation(uri, navId, history.push);
 
   const [response, setResponse] = useState<PageCountResponse | null>(null);
   const view = useSelector<GiantState, string | undefined>(
@@ -125,7 +132,38 @@ export const PageViewerOrFallback: FC<{}> = () => {
   if (response === null) {
     return null;
   } else if (response.pageCount === 0) {
-    return <Viewer match={{ params: { uri } }} />;
+    return (
+      <div>
+        {workspaceNav.goToNext && (
+          <KeyboardShortcut
+            shortcut={keyboardShortcuts.nextResult}
+            func={workspaceNav.goToNext}
+          />
+        )}
+        {workspaceNav.goToPrevious && (
+          <KeyboardShortcut
+            shortcut={keyboardShortcuts.previousResult}
+            func={workspaceNav.goToPrevious}
+          />
+        )}
+        <Viewer match={{ params: { uri } }} />
+        <div className="document__status">
+          <span />
+          <span className="doc-nav-buttons">
+            <DocNavButton
+              direction="previous"
+              title="Previous in folder"
+              onClick={workspaceNav.goToPrevious}
+            />
+            <DocNavButton
+              direction="next"
+              title="Next in folder"
+              onClick={workspaceNav.goToNext}
+            />
+          </span>
+        </div>
+      </div>
+    );
   } else {
     const showTextContent = !isCombinedOrUnset(view);
     return (
@@ -151,13 +189,35 @@ export const PageViewerOrFallback: FC<{}> = () => {
         </div>
         {resource && (
           <div className="document__status">
+            {workspaceNav.goToNext && (
+              <KeyboardShortcut
+                shortcut={keyboardShortcuts.nextResult}
+                func={workspaceNav.goToNext}
+              />
+            )}
+            {workspaceNav.goToPrevious && (
+              <KeyboardShortcut
+                shortcut={keyboardShortcuts.previousResult}
+                func={workspaceNav.goToPrevious}
+              />
+            )}
             {/* Left spacer: document__status uses space-between to match the legacy StatusBar two-span layout */}
             <span />
-            <span>
+            <span className="doc-nav-buttons">
               <PreviewSwitcher
                 view={view}
                 resource={resource}
                 totalPages={response.pageCount}
+              />
+              <DocNavButton
+                direction="previous"
+                title="Previous in folder"
+                onClick={workspaceNav.goToPrevious}
+              />
+              <DocNavButton
+                direction="next"
+                title="Next in folder"
+                onClick={workspaceNav.goToNext}
               />
             </span>
           </div>

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -132,40 +132,12 @@ export const PageViewerOrFallback: FC<{}> = () => {
   if (response === null) {
     return null;
   } else if (response.pageCount === 0) {
-    const hasWorkspaceNav = workspaceNav.hasPrevious || workspaceNav.hasNext;
     return (
-      <div>
-        {workspaceNav.goToNext && (
-          <KeyboardShortcut
-            shortcut={keyboardShortcuts.nextResult}
-            func={workspaceNav.goToNext}
-          />
-        )}
-        {workspaceNav.goToPrevious && (
-          <KeyboardShortcut
-            shortcut={keyboardShortcuts.previousResult}
-            func={workspaceNav.goToPrevious}
-          />
-        )}
-        <Viewer key={uri} match={{ params: { uri } }} />
-        {hasWorkspaceNav && (
-          <div className="document__status">
-            <span />
-            <span className="doc-nav-buttons">
-              <DocNavButton
-                direction="previous"
-                title="Previous in folder"
-                onClick={workspaceNav.goToPrevious}
-              />
-              <DocNavButton
-                direction="next"
-                title="Next in folder"
-                onClick={workspaceNav.goToNext}
-              />
-            </span>
-          </div>
-        )}
-      </div>
+      <Viewer
+        key={uri}
+        match={{ params: { uri } }}
+        workspaceNav={workspaceNav}
+      />
     );
   } else {
     const showTextContent = !isCombinedOrUnset(view);

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -132,6 +132,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
   if (response === null) {
     return null;
   } else if (response.pageCount === 0) {
+    const hasWorkspaceNav = workspaceNav.hasPrevious || workspaceNav.hasNext;
     return (
       <div>
         {workspaceNav.goToNext && (
@@ -147,21 +148,23 @@ export const PageViewerOrFallback: FC<{}> = () => {
           />
         )}
         <Viewer key={uri} match={{ params: { uri } }} />
-        <div className="document__status">
-          <span />
-          <span className="doc-nav-buttons">
-            <DocNavButton
-              direction="previous"
-              title="Previous in folder"
-              onClick={workspaceNav.goToPrevious}
-            />
-            <DocNavButton
-              direction="next"
-              title="Next in folder"
-              onClick={workspaceNav.goToNext}
-            />
-          </span>
-        </div>
+        {hasWorkspaceNav && (
+          <div className="document__status">
+            <span />
+            <span className="doc-nav-buttons">
+              <DocNavButton
+                direction="previous"
+                title="Previous in folder"
+                onClick={workspaceNav.goToPrevious}
+              />
+              <DocNavButton
+                direction="next"
+                title="Next in folder"
+                onClick={workspaceNav.goToNext}
+              />
+            </span>
+          </div>
+        )}
       </div>
     );
   } else {
@@ -211,16 +214,20 @@ export const PageViewerOrFallback: FC<{}> = () => {
                 resource={resource}
                 totalPages={response.pageCount}
               />
-              <DocNavButton
-                direction="previous"
-                title="Previous in folder"
-                onClick={workspaceNav.goToPrevious}
-              />
-              <DocNavButton
-                direction="next"
-                title="Next in folder"
-                onClick={workspaceNav.goToNext}
-              />
+              {(workspaceNav.hasPrevious || workspaceNav.hasNext) && (
+                <>
+                  <DocNavButton
+                    direction="previous"
+                    title="Previous in folder"
+                    onClick={workspaceNav.goToPrevious}
+                  />
+                  <DocNavButton
+                    direction="next"
+                    title="Next in folder"
+                    onClick={workspaceNav.goToNext}
+                  />
+                </>
+              )}
             </span>
           </div>
         )}

--- a/frontend/src/js/components/viewer/DocNavButton.tsx
+++ b/frontend/src/js/components/viewer/DocNavButton.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from "react";
+import PlayArrow from "react-icons/lib/md/play-arrow";
+
+type DocNavButtonProps = {
+  title: string;
+  onClick?: () => void;
+  direction: "previous" | "next";
+};
+
+export const DocNavButton: FC<DocNavButtonProps> = ({
+  title,
+  onClick,
+  direction,
+}) => {
+  const isActive = !!onClick;
+  const className = isActive
+    ? "doc-nav-button doc-nav-button--active"
+    : "doc-nav-button doc-nav-button--inactive";
+  const rotation = direction === "previous" ? "doc-nav-button--previous" : "";
+
+  return (
+    <span
+      title={title}
+      className={`${className} ${rotation}`}
+      onClick={isActive ? onClick : undefined}
+      role="button"
+      tabIndex={isActive ? 0 : -1}
+    >
+      <PlayArrow />
+    </span>
+  );
+};

--- a/frontend/src/js/components/viewer/Viewer.tsx
+++ b/frontend/src/js/components/viewer/Viewer.tsx
@@ -43,9 +43,11 @@ import LazyTreeBrowser from "./LazyTreeBrowser";
 import { SearchResults } from "../../types/SearchResults";
 import { getDefaultView } from "../../util/resourceUtils";
 import DownloadButton from "./DownloadButton";
+import { WorkspaceNavigation } from "../../util/workspaceNavigation";
 
 type Props = {
   match: { params: { uri: string } };
+  workspaceNav?: WorkspaceNavigation;
   auth: Auth;
   preferences: any;
   urlParams: UrlParamsState;
@@ -441,11 +443,19 @@ class Viewer extends React.Component<Props, State> {
       <div className="viewer">
         <KeyboardShortcut
           shortcut={keyboardShortcuts.nextResult}
-          func={this.nextResult}
+          func={
+            this.hasNextResult()
+              ? this.nextResult
+              : this.props.workspaceNav?.goToNext
+          }
         />
         <KeyboardShortcut
           shortcut={keyboardShortcuts.previousResult}
-          func={this.previousResult}
+          func={
+            this.hasPreviousResult()
+              ? this.previousResult
+              : this.props.workspaceNav?.goToPrevious
+          }
         />
 
         {this.renderResource(this.props.resource)}
@@ -456,9 +466,15 @@ class Viewer extends React.Component<Props, State> {
             currentHighlight={this.props.currentHighlight}
             totalHighlights={this.props.totalHighlights}
             previousFn={
-              this.hasPreviousResult() ? () => this.previousResult() : undefined
+              this.hasPreviousResult()
+                ? () => this.previousResult()
+                : this.props.workspaceNav?.goToPrevious
             }
-            nextFn={this.hasNextResult() ? () => this.nextResult() : undefined}
+            nextFn={
+              this.hasNextResult()
+                ? () => this.nextResult()
+                : this.props.workspaceNav?.goToNext
+            }
           />
         </div>
       </div>

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -73,6 +73,7 @@ import history from "../../util/history";
 import { takeOwnershipOfWorkspace } from "../../actions/workspaces/takeOwnershipOfWorkspace";
 import { setNodesAsExpanded } from "../../actions/workspaces/setNodesAsExpanded";
 import { FileAndFolderCounts } from "../UtilComponents/TreeBrowser/FileAndFolderCounts";
+import { storeWorkspaceSiblingUris } from "../../util/workspaceNavigation";
 import {
   EuiButtonIcon,
   EuiLoadingSpinner,
@@ -1033,7 +1034,13 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
       // if it could know that because it's a TreeLeaf the type parameter is a WorkspaceLeaf.
       // don't know of a way to do it though...
       if (isWorkspaceLeaf(entry.data) && !this.props.entryBeingRenamed) {
-        window.open(`/viewer/${entry.data.uri}`, "_blank");
+        const navId = storeWorkspaceSiblingUris(
+          workspace.rootNode,
+          entry,
+          this.state.columnsConfig,
+        );
+        const navParam = navId ? `?navId=${navId}` : "";
+        window.open(`/viewer/${entry.data.uri}${navParam}`, "_blank");
       }
     };
 

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -1034,12 +1034,14 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
       // if it could know that because it's a TreeLeaf the type parameter is a WorkspaceLeaf.
       // don't know of a way to do it though...
       if (isWorkspaceLeaf(entry.data) && !this.props.entryBeingRenamed) {
-        const navId = storeWorkspaceSiblingUris(
+        const result = storeWorkspaceSiblingUris(
           workspace.rootNode,
           entry,
           this.state.columnsConfig,
         );
-        const navParam = navId ? `?navId=${navId}` : "";
+        const navParam = result
+          ? `?navId=${result.navId}&navIndex=${result.navIndex}`
+          : "";
         window.open(`/viewer/${entry.data.uri}${navParam}`, "_blank");
       }
     };

--- a/frontend/src/js/util/uuid.ts
+++ b/frontend/src/js/util/uuid.ts
@@ -1,0 +1,12 @@
+// randomUUID() is supported in all browsers but typescript doesn't recognise it yet so we do this
+// see mdn docs here https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID
+export function uuidOrFallback(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    "randomUUID" in crypto &&
+    typeof (crypto as any).randomUUID === "function"
+  ) {
+    return (crypto as any).randomUUID();
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}

--- a/frontend/src/js/util/workspaceNavigation.spec.ts
+++ b/frontend/src/js/util/workspaceNavigation.spec.ts
@@ -146,7 +146,7 @@ describe("findNodeById", () => {
 describe("storeWorkspaceSiblingUris", () => {
   beforeEach(() => sessionStorage.clear());
 
-  test("returns a navId and stores sibling URIs keyed by it", () => {
+  test("returns a navId and navIndex and stores sibling URIs", () => {
     const parentNode = folder("parent", [
       leaf("a.pdf", "uri-a", "parent"),
       leaf("b.pdf", "uri-b", "parent"),
@@ -154,13 +154,27 @@ describe("storeWorkspaceSiblingUris", () => {
     const root = folder("root", [parentNode]);
     const entry = leaf("a.pdf", "uri-a", "parent");
 
-    const navId = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
+    const result = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
 
-    expect(navId).toBeDefined();
+    expect(result).toBeDefined();
+    expect(result!.navIndex).toBe(0);
     const stored = JSON.parse(
-      sessionStorage.getItem(`workspaceSiblingUris:${navId}`)!,
+      sessionStorage.getItem(`workspaceSiblingUris:${result!.navId}`)!,
     );
     expect(stored).toEqual(["uri-a", "uri-b"]);
+  });
+
+  test("returns correct navIndex for second entry", () => {
+    const parentNode = folder("parent", [
+      leaf("a.pdf", "uri-a", "parent"),
+      leaf("b.pdf", "uri-b", "parent"),
+    ]);
+    const root = folder("root", [parentNode]);
+    const entry = leaf("b.pdf", "uri-b", "parent");
+
+    const result = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
+
+    expect(result!.navIndex).toBe(1);
   });
 
   test("uses root node when entry has no parent id", () => {
@@ -170,11 +184,11 @@ describe("storeWorkspaceSiblingUris", () => {
     ]);
     const entry = leaf("a.pdf", "uri-a");
 
-    const navId = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
+    const result = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
 
-    expect(navId).toBeDefined();
+    expect(result).toBeDefined();
     const stored = JSON.parse(
-      sessionStorage.getItem(`workspaceSiblingUris:${navId}`)!,
+      sessionStorage.getItem(`workspaceSiblingUris:${result!.navId}`)!,
     );
     expect(stored).toEqual(["uri-a", "uri-b"]);
   });
@@ -183,10 +197,10 @@ describe("storeWorkspaceSiblingUris", () => {
     const root = folder("root", [leaf("a.pdf", "uri-a")]);
     const entry = leaf("a.pdf", "uri-a");
 
-    const id1 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
-    const id2 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
+    const r1 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
+    const r2 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
 
-    expect(id1).not.toEqual(id2);
+    expect(r1!.navId).not.toEqual(r2!.navId);
   });
 });
 
@@ -195,7 +209,13 @@ describe("computeWorkspaceNavigation", () => {
   const navId = "test-nav-id";
 
   test("returns hasPrevious and hasNext for a middle item", () => {
-    const nav = computeWorkspaceNavigation(leafUris, "uri-b", navId, jest.fn());
+    const nav = computeWorkspaceNavigation(
+      leafUris,
+      "uri-b",
+      navId,
+      1,
+      jest.fn(),
+    );
     expect(nav.hasPrevious).toBe(true);
     expect(nav.hasNext).toBe(true);
     expect(nav.goToPrevious).toBeDefined();
@@ -203,7 +223,13 @@ describe("computeWorkspaceNavigation", () => {
   });
 
   test("first item has no previous", () => {
-    const nav = computeWorkspaceNavigation(leafUris, "uri-a", navId, jest.fn());
+    const nav = computeWorkspaceNavigation(
+      leafUris,
+      "uri-a",
+      navId,
+      0,
+      jest.fn(),
+    );
     expect(nav.hasPrevious).toBe(false);
     expect(nav.hasNext).toBe(true);
     expect(nav.goToPrevious).toBeUndefined();
@@ -211,7 +237,13 @@ describe("computeWorkspaceNavigation", () => {
   });
 
   test("last item has no next", () => {
-    const nav = computeWorkspaceNavigation(leafUris, "uri-c", navId, jest.fn());
+    const nav = computeWorkspaceNavigation(
+      leafUris,
+      "uri-c",
+      navId,
+      2,
+      jest.fn(),
+    );
     expect(nav.hasPrevious).toBe(true);
     expect(nav.hasNext).toBe(false);
     expect(nav.goToPrevious).toBeDefined();
@@ -223,6 +255,7 @@ describe("computeWorkspaceNavigation", () => {
       leafUris,
       "uri-unknown",
       navId,
+      null,
       jest.fn(),
     );
     expect(nav.hasPrevious).toBe(false);
@@ -232,7 +265,7 @@ describe("computeWorkspaceNavigation", () => {
   });
 
   test("empty leaf list returns no navigation", () => {
-    const nav = computeWorkspaceNavigation([], "uri-a", navId, jest.fn());
+    const nav = computeWorkspaceNavigation([], "uri-a", navId, null, jest.fn());
     expect(nav.hasPrevious).toBe(false);
     expect(nav.hasNext).toBe(false);
   });
@@ -242,33 +275,93 @@ describe("computeWorkspaceNavigation", () => {
       ["uri-a"],
       "uri-a",
       navId,
+      0,
       jest.fn(),
     );
     expect(nav.hasPrevious).toBe(false);
     expect(nav.hasNext).toBe(false);
   });
 
-  test("goToNext navigates to the correct URI with navId", () => {
+  test("goToNext navigates with navId and navIndex", () => {
     const navigate = jest.fn();
-    const nav = computeWorkspaceNavigation(leafUris, "uri-a", navId, navigate);
+    const nav = computeWorkspaceNavigation(
+      leafUris,
+      "uri-a",
+      navId,
+      0,
+      navigate,
+    );
     nav.goToNext!();
     expect(navigate).toHaveBeenCalledWith(
-      `/viewer/${encodeURIComponent("uri-b")}?navId=${navId}`,
+      `/viewer/${encodeURIComponent("uri-b")}?navId=${navId}&navIndex=1`,
     );
   });
 
-  test("goToPrevious navigates to the correct URI with navId", () => {
+  test("goToPrevious navigates with navId and navIndex", () => {
     const navigate = jest.fn();
-    const nav = computeWorkspaceNavigation(leafUris, "uri-c", navId, navigate);
+    const nav = computeWorkspaceNavigation(
+      leafUris,
+      "uri-c",
+      navId,
+      2,
+      navigate,
+    );
     nav.goToPrevious!();
     expect(navigate).toHaveBeenCalledWith(
-      `/viewer/${encodeURIComponent("uri-b")}?navId=${navId}`,
+      `/viewer/${encodeURIComponent("uri-b")}?navId=${navId}&navIndex=1`,
     );
   });
 
   test("null navId returns no navigation", () => {
-    const nav = computeWorkspaceNavigation([], "uri-a", null, jest.fn());
+    const nav = computeWorkspaceNavigation([], "uri-a", null, null, jest.fn());
     expect(nav.hasPrevious).toBe(false);
     expect(nav.hasNext).toBe(false);
+  });
+
+  test("falls back to indexOf when navIndex is null", () => {
+    const nav = computeWorkspaceNavigation(
+      leafUris,
+      "uri-b",
+      navId,
+      null,
+      jest.fn(),
+    );
+    expect(nav.hasPrevious).toBe(true);
+    expect(nav.hasNext).toBe(true);
+  });
+
+  test("uses navIndex to distinguish duplicate URIs", () => {
+    const dupes = ["uri-a", "uri-dup", "uri-dup", "uri-b"];
+    const navigate = jest.fn();
+    // At index 2 (the second "uri-dup")
+    const nav = computeWorkspaceNavigation(
+      dupes,
+      "uri-dup",
+      navId,
+      2,
+      navigate,
+    );
+    expect(nav.hasPrevious).toBe(true);
+    expect(nav.hasNext).toBe(true);
+    nav.goToNext!();
+    expect(navigate).toHaveBeenCalledWith(
+      `/viewer/${encodeURIComponent("uri-b")}?navId=${navId}&navIndex=3`,
+    );
+  });
+
+  test("navigates past duplicates from first occurrence", () => {
+    const dupes = ["uri-a", "uri-dup", "uri-dup", "uri-b"];
+    const navigate = jest.fn();
+    const nav = computeWorkspaceNavigation(
+      dupes,
+      "uri-dup",
+      navId,
+      1,
+      navigate,
+    );
+    nav.goToNext!();
+    expect(navigate).toHaveBeenCalledWith(
+      `/viewer/${encodeURIComponent("uri-dup")}?navId=${navId}&navIndex=2`,
+    );
   });
 });

--- a/frontend/src/js/util/workspaceNavigation.spec.ts
+++ b/frontend/src/js/util/workspaceNavigation.spec.ts
@@ -1,8 +1,7 @@
 import {
-  leafUrisOfChildren,
-  findNodeById,
   storeWorkspaceSiblingUris,
   computeWorkspaceNavigation,
+  sortedLeafChildren,
 } from "./workspaceNavigation";
 import { ColumnsConfig, TreeEntry, TreeNode } from "../types/Tree";
 import { WorkspaceEntry, WorkspaceNode } from "../types/Workspaces";
@@ -30,7 +29,18 @@ const nameAscColumnsConfig: ColumnsConfig<WorkspaceEntry> = {
   ],
 };
 
-function leaf(
+/**
+ * Given a tree node, return the URIs of its immediate leaf children
+ * (i.e. files, not folders) in the provided sort order.
+ */
+function leafUrisOfChildren(
+  node: TreeNode<WorkspaceEntry>,
+  columnsConfig: ColumnsConfig<WorkspaceEntry>,
+): string[] {
+  return sortedLeafChildren(node, columnsConfig).map((child) => child.data.uri);
+}
+
+export function makeLeaf(
   name: string,
   uri: string,
   maybeParentId?: string,
@@ -49,7 +59,7 @@ function leaf(
   };
 }
 
-function folder(
+export function makeNode(
   name: string,
   children: TreeEntry<WorkspaceEntry>[],
 ): TreeNode<WorkspaceEntry> {
@@ -64,15 +74,15 @@ function folder(
 describe("leafUrisOfChildren", () => {
   test("returns empty array for an empty folder", () => {
     expect(
-      leafUrisOfChildren(folder("root", []), nameAscColumnsConfig),
+      leafUrisOfChildren(makeNode("root", []), nameAscColumnsConfig),
     ).toEqual([]);
   });
 
   test("returns URIs of immediate leaf children only", () => {
-    const root = folder("root", [
-      leaf("a.pdf", "uri-a"),
-      folder("sub", [leaf("b.pdf", "uri-b")]),
-      leaf("c.pdf", "uri-c"),
+    const root = makeNode("root", [
+      makeLeaf("a.pdf", "uri-a"),
+      makeNode("sub", [makeLeaf("b.pdf", "uri-b")]),
+      makeLeaf("c.pdf", "uri-c"),
     ]);
     expect(leafUrisOfChildren(root, nameAscColumnsConfig)).toEqual([
       "uri-a",
@@ -81,18 +91,18 @@ describe("leafUrisOfChildren", () => {
   });
 
   test("skips sub-folder entries", () => {
-    const root = folder("root", [
-      folder("empty", []),
-      leaf("doc.pdf", "uri-1"),
+    const root = makeNode("root", [
+      makeNode("empty", []),
+      makeLeaf("doc.pdf", "uri-1"),
     ]);
     expect(leafUrisOfChildren(root, nameAscColumnsConfig)).toEqual(["uri-1"]);
   });
 
   test("respects sort order", () => {
-    const root = folder("root", [
-      leaf("c.pdf", "uri-c"),
-      leaf("a.pdf", "uri-a"),
-      leaf("b.pdf", "uri-b"),
+    const root = makeNode("root", [
+      makeLeaf("c.pdf", "uri-c"),
+      makeLeaf("a.pdf", "uri-a"),
+      makeLeaf("b.pdf", "uri-b"),
     ]);
     expect(leafUrisOfChildren(root, nameAscColumnsConfig)).toEqual([
       "uri-a",
@@ -106,10 +116,10 @@ describe("leafUrisOfChildren", () => {
       ...nameAscColumnsConfig,
       sortDescending: true,
     };
-    const root = folder("root", [
-      leaf("a.pdf", "uri-a"),
-      leaf("c.pdf", "uri-c"),
-      leaf("b.pdf", "uri-b"),
+    const root = makeNode("root", [
+      makeLeaf("a.pdf", "uri-a"),
+      makeLeaf("c.pdf", "uri-c"),
+      makeLeaf("b.pdf", "uri-b"),
     ]);
     expect(leafUrisOfChildren(root, descConfig)).toEqual([
       "uri-c",
@@ -119,40 +129,16 @@ describe("leafUrisOfChildren", () => {
   });
 });
 
-describe("findNodeById", () => {
-  test("returns the root when id matches", () => {
-    const root = folder("root", []);
-    expect(findNodeById(root, "root")).toBe(root);
-  });
-
-  test("returns a nested node", () => {
-    const inner = folder("inner", [leaf("doc.pdf", "uri-1")]);
-    const root = folder("root", [inner]);
-    expect(findNodeById(root, "inner")).toBe(inner);
-  });
-
-  test("returns undefined when not found", () => {
-    const root = folder("root", [leaf("doc.pdf", "uri-1")]);
-    expect(findNodeById(root, "nonexistent")).toBeUndefined();
-  });
-
-  test("finds deeply nested node", () => {
-    const deep = folder("deep", []);
-    const root = folder("root", [folder("a", [folder("b", [deep])])]);
-    expect(findNodeById(root, "deep")).toBe(deep);
-  });
-});
-
 describe("storeWorkspaceSiblingUris", () => {
   beforeEach(() => sessionStorage.clear());
 
   test("returns a navId and navIndex and stores sibling URIs", () => {
-    const parentNode = folder("parent", [
-      leaf("a.pdf", "uri-a", "parent"),
-      leaf("b.pdf", "uri-b", "parent"),
+    const parentNode = makeNode("parent", [
+      makeLeaf("a.pdf", "uri-a", "parent"),
+      makeLeaf("b.pdf", "uri-b", "parent"),
     ]);
-    const root = folder("root", [parentNode]);
-    const entry = leaf("a.pdf", "uri-a", "parent");
+    const root = makeNode("root", [parentNode]);
+    const entry = makeLeaf("a.pdf", "uri-a", "parent");
 
     const result = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
 
@@ -165,37 +151,33 @@ describe("storeWorkspaceSiblingUris", () => {
   });
 
   test("returns correct navIndex for second entry", () => {
-    const parentNode = folder("parent", [
-      leaf("a.pdf", "uri-a", "parent"),
-      leaf("b.pdf", "uri-b", "parent"),
+    const parentNode = makeNode("parent", [
+      makeLeaf("a.pdf", "uri-a", "parent"),
+      makeLeaf("b.pdf", "uri-b", "parent"),
     ]);
-    const root = folder("root", [parentNode]);
-    const entry = leaf("b.pdf", "uri-b", "parent");
+    const root = makeNode("root", [parentNode]);
+    const entry = makeLeaf("b.pdf", "uri-b", "parent");
 
     const result = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
 
     expect(result!.navIndex).toBe(1);
   });
 
-  test("uses root node when entry has no parent id", () => {
-    const root = folder("root", [
-      leaf("a.pdf", "uri-a"),
-      leaf("b.pdf", "uri-b"),
+  test("uses undefined when entry has no parent id", () => {
+    const root = makeNode("root", [
+      makeLeaf("a.pdf", "uri-a"),
+      makeLeaf("b.pdf", "uri-b"),
     ]);
-    const entry = leaf("a.pdf", "uri-a");
+    const entry = makeLeaf("a.pdf", "uri-a");
 
     const result = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
 
-    expect(result).toBeDefined();
-    const stored = JSON.parse(
-      sessionStorage.getItem(`workspaceSiblingUris:${result!.navId}`)!,
-    );
-    expect(stored).toEqual(["uri-a", "uri-b"]);
+    expect(result).toBeUndefined();
   });
 
   test("each call produces a unique navId", () => {
-    const root = folder("root", [leaf("a.pdf", "uri-a")]);
-    const entry = leaf("a.pdf", "uri-a");
+    const root = makeNode("root", [makeLeaf("a.pdf", "uri-a")]);
+    const entry = makeLeaf("a.pdf", "uri-a");
 
     const r1 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
     const r2 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);

--- a/frontend/src/js/util/workspaceNavigation.spec.ts
+++ b/frontend/src/js/util/workspaceNavigation.spec.ts
@@ -1,0 +1,274 @@
+import {
+  leafUrisOfChildren,
+  findNodeById,
+  storeWorkspaceSiblingUris,
+  computeWorkspaceNavigation,
+} from "./workspaceNavigation";
+import { ColumnsConfig, TreeEntry, TreeNode } from "../types/Tree";
+import { WorkspaceEntry, WorkspaceNode } from "../types/Workspaces";
+
+const nodeData: WorkspaceNode = {
+  addedBy: { username: "joe", displayName: "joe" },
+  descendantsNodeCount: 0,
+  descendantsLeafCount: 0,
+  descendantsProcessingTaskCount: 0,
+  descendantsFailedCount: 0,
+};
+
+// Sort by name ascending — matches the default workspace sort
+const nameAscColumnsConfig: ColumnsConfig<WorkspaceEntry> = {
+  sortDescending: false,
+  sortColumn: "Name",
+  columns: [
+    {
+      name: "Name",
+      align: "left",
+      style: {},
+      render: () => null as any,
+      sort: (a, b) => a.name.localeCompare(b.name),
+    },
+  ],
+};
+
+function leaf(
+  name: string,
+  uri: string,
+  maybeParentId?: string,
+): TreeEntry<WorkspaceEntry> {
+  return {
+    id: name,
+    name,
+    isExpandable: false,
+    data: {
+      uri,
+      addedBy: { username: "joe", displayName: "joe" },
+      mimeType: "application/pdf",
+      processingStage: { type: "processed" },
+      maybeParentId,
+    },
+  };
+}
+
+function folder(
+  name: string,
+  children: TreeEntry<WorkspaceEntry>[],
+): TreeNode<WorkspaceEntry> {
+  return {
+    id: name,
+    name,
+    children,
+    data: nodeData,
+  };
+}
+
+describe("leafUrisOfChildren", () => {
+  test("returns empty array for an empty folder", () => {
+    expect(
+      leafUrisOfChildren(folder("root", []), nameAscColumnsConfig),
+    ).toEqual([]);
+  });
+
+  test("returns URIs of immediate leaf children only", () => {
+    const root = folder("root", [
+      leaf("a.pdf", "uri-a"),
+      folder("sub", [leaf("b.pdf", "uri-b")]),
+      leaf("c.pdf", "uri-c"),
+    ]);
+    expect(leafUrisOfChildren(root, nameAscColumnsConfig)).toEqual([
+      "uri-a",
+      "uri-c",
+    ]);
+  });
+
+  test("skips sub-folder entries", () => {
+    const root = folder("root", [
+      folder("empty", []),
+      leaf("doc.pdf", "uri-1"),
+    ]);
+    expect(leafUrisOfChildren(root, nameAscColumnsConfig)).toEqual(["uri-1"]);
+  });
+
+  test("respects sort order", () => {
+    const root = folder("root", [
+      leaf("c.pdf", "uri-c"),
+      leaf("a.pdf", "uri-a"),
+      leaf("b.pdf", "uri-b"),
+    ]);
+    expect(leafUrisOfChildren(root, nameAscColumnsConfig)).toEqual([
+      "uri-a",
+      "uri-b",
+      "uri-c",
+    ]);
+  });
+
+  test("respects descending sort", () => {
+    const descConfig: ColumnsConfig<WorkspaceEntry> = {
+      ...nameAscColumnsConfig,
+      sortDescending: true,
+    };
+    const root = folder("root", [
+      leaf("a.pdf", "uri-a"),
+      leaf("c.pdf", "uri-c"),
+      leaf("b.pdf", "uri-b"),
+    ]);
+    expect(leafUrisOfChildren(root, descConfig)).toEqual([
+      "uri-c",
+      "uri-b",
+      "uri-a",
+    ]);
+  });
+});
+
+describe("findNodeById", () => {
+  test("returns the root when id matches", () => {
+    const root = folder("root", []);
+    expect(findNodeById(root, "root")).toBe(root);
+  });
+
+  test("returns a nested node", () => {
+    const inner = folder("inner", [leaf("doc.pdf", "uri-1")]);
+    const root = folder("root", [inner]);
+    expect(findNodeById(root, "inner")).toBe(inner);
+  });
+
+  test("returns undefined when not found", () => {
+    const root = folder("root", [leaf("doc.pdf", "uri-1")]);
+    expect(findNodeById(root, "nonexistent")).toBeUndefined();
+  });
+
+  test("finds deeply nested node", () => {
+    const deep = folder("deep", []);
+    const root = folder("root", [folder("a", [folder("b", [deep])])]);
+    expect(findNodeById(root, "deep")).toBe(deep);
+  });
+});
+
+describe("storeWorkspaceSiblingUris", () => {
+  beforeEach(() => sessionStorage.clear());
+
+  test("returns a navId and stores sibling URIs keyed by it", () => {
+    const parentNode = folder("parent", [
+      leaf("a.pdf", "uri-a", "parent"),
+      leaf("b.pdf", "uri-b", "parent"),
+    ]);
+    const root = folder("root", [parentNode]);
+    const entry = leaf("a.pdf", "uri-a", "parent");
+
+    const navId = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
+
+    expect(navId).toBeDefined();
+    const stored = JSON.parse(
+      sessionStorage.getItem(`workspaceSiblingUris:${navId}`)!,
+    );
+    expect(stored).toEqual(["uri-a", "uri-b"]);
+  });
+
+  test("uses root node when entry has no parent id", () => {
+    const root = folder("root", [
+      leaf("a.pdf", "uri-a"),
+      leaf("b.pdf", "uri-b"),
+    ]);
+    const entry = leaf("a.pdf", "uri-a");
+
+    const navId = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
+
+    expect(navId).toBeDefined();
+    const stored = JSON.parse(
+      sessionStorage.getItem(`workspaceSiblingUris:${navId}`)!,
+    );
+    expect(stored).toEqual(["uri-a", "uri-b"]);
+  });
+
+  test("each call produces a unique navId", () => {
+    const root = folder("root", [leaf("a.pdf", "uri-a")]);
+    const entry = leaf("a.pdf", "uri-a");
+
+    const id1 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
+    const id2 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
+
+    expect(id1).not.toEqual(id2);
+  });
+});
+
+describe("computeWorkspaceNavigation", () => {
+  const leafUris = ["uri-a", "uri-b", "uri-c"];
+  const navId = "test-nav-id";
+
+  test("returns hasPrevious and hasNext for a middle item", () => {
+    const nav = computeWorkspaceNavigation(leafUris, "uri-b", navId, jest.fn());
+    expect(nav.hasPrevious).toBe(true);
+    expect(nav.hasNext).toBe(true);
+    expect(nav.goToPrevious).toBeDefined();
+    expect(nav.goToNext).toBeDefined();
+  });
+
+  test("first item has no previous", () => {
+    const nav = computeWorkspaceNavigation(leafUris, "uri-a", navId, jest.fn());
+    expect(nav.hasPrevious).toBe(false);
+    expect(nav.hasNext).toBe(true);
+    expect(nav.goToPrevious).toBeUndefined();
+    expect(nav.goToNext).toBeDefined();
+  });
+
+  test("last item has no next", () => {
+    const nav = computeWorkspaceNavigation(leafUris, "uri-c", navId, jest.fn());
+    expect(nav.hasPrevious).toBe(true);
+    expect(nav.hasNext).toBe(false);
+    expect(nav.goToPrevious).toBeDefined();
+    expect(nav.goToNext).toBeUndefined();
+  });
+
+  test("unknown URI returns no navigation", () => {
+    const nav = computeWorkspaceNavigation(
+      leafUris,
+      "uri-unknown",
+      navId,
+      jest.fn(),
+    );
+    expect(nav.hasPrevious).toBe(false);
+    expect(nav.hasNext).toBe(false);
+    expect(nav.goToPrevious).toBeUndefined();
+    expect(nav.goToNext).toBeUndefined();
+  });
+
+  test("empty leaf list returns no navigation", () => {
+    const nav = computeWorkspaceNavigation([], "uri-a", navId, jest.fn());
+    expect(nav.hasPrevious).toBe(false);
+    expect(nav.hasNext).toBe(false);
+  });
+
+  test("single item has neither previous nor next", () => {
+    const nav = computeWorkspaceNavigation(
+      ["uri-a"],
+      "uri-a",
+      navId,
+      jest.fn(),
+    );
+    expect(nav.hasPrevious).toBe(false);
+    expect(nav.hasNext).toBe(false);
+  });
+
+  test("goToNext navigates to the correct URI with navId", () => {
+    const navigate = jest.fn();
+    const nav = computeWorkspaceNavigation(leafUris, "uri-a", navId, navigate);
+    nav.goToNext!();
+    expect(navigate).toHaveBeenCalledWith(
+      `/viewer/${encodeURIComponent("uri-b")}?navId=${navId}`,
+    );
+  });
+
+  test("goToPrevious navigates to the correct URI with navId", () => {
+    const navigate = jest.fn();
+    const nav = computeWorkspaceNavigation(leafUris, "uri-c", navId, navigate);
+    nav.goToPrevious!();
+    expect(navigate).toHaveBeenCalledWith(
+      `/viewer/${encodeURIComponent("uri-b")}?navId=${navId}`,
+    );
+  });
+
+  test("null navId returns no navigation", () => {
+    const nav = computeWorkspaceNavigation([], "uri-a", null, jest.fn());
+    expect(nav.hasPrevious).toBe(false);
+    expect(nav.hasNext).toBe(false);
+  });
+});

--- a/frontend/src/js/util/workspaceNavigation.spec.ts
+++ b/frontend/src/js/util/workspaceNavigation.spec.ts
@@ -200,6 +200,8 @@ describe("computeWorkspaceNavigation", () => {
     );
     expect(nav.goToPrevious).toBeDefined();
     expect(nav.goToNext).toBeDefined();
+    expect(nav.hasPrevious).toBe(true);
+    expect(nav.hasNext).toBe(true);
   });
 
   test("first item has no previous", () => {
@@ -212,6 +214,8 @@ describe("computeWorkspaceNavigation", () => {
     );
     expect(nav.goToPrevious).toBeUndefined();
     expect(nav.goToNext).toBeDefined();
+    expect(nav.hasPrevious).toBe(false);
+    expect(nav.hasNext).toBe(true);
   });
 
   test("last item has no next", () => {
@@ -224,6 +228,8 @@ describe("computeWorkspaceNavigation", () => {
     );
     expect(nav.goToPrevious).toBeDefined();
     expect(nav.goToNext).toBeUndefined();
+    expect(nav.hasPrevious).toBe(true);
+    expect(nav.hasNext).toBe(false);
   });
 
   test("unknown URI returns no navigation", () => {
@@ -236,6 +242,8 @@ describe("computeWorkspaceNavigation", () => {
     );
     expect(nav.goToPrevious).toBeUndefined();
     expect(nav.goToNext).toBeUndefined();
+    expect(nav.hasPrevious).toBe(false);
+    expect(nav.hasNext).toBe(false);
   });
 
   test("single item has neither previous nor next", () => {
@@ -248,6 +256,8 @@ describe("computeWorkspaceNavigation", () => {
     );
     expect(nav.goToPrevious).toBeUndefined();
     expect(nav.goToNext).toBeUndefined();
+    expect(nav.hasPrevious).toBe(false);
+    expect(nav.hasNext).toBe(false);
   });
 
   test("goToNext navigates with navId and navIndex", () => {

--- a/frontend/src/js/util/workspaceNavigation.spec.ts
+++ b/frontend/src/js/util/workspaceNavigation.spec.ts
@@ -176,8 +176,8 @@ describe("storeWorkspaceSiblingUris", () => {
   });
 
   test("each call produces a unique navId", () => {
-    const root = makeNode("root", [makeLeaf("a.pdf", "uri-a")]);
-    const entry = makeLeaf("a.pdf", "uri-a");
+    const root = makeNode("root", [makeLeaf("a.pdf", "uri-a", "root")]);
+    const entry = makeLeaf("a.pdf", "uri-a", "root");
 
     const r1 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
     const r2 = storeWorkspaceSiblingUris(root, entry, nameAscColumnsConfig);
@@ -198,8 +198,6 @@ describe("computeWorkspaceNavigation", () => {
       1,
       jest.fn(),
     );
-    expect(nav.hasPrevious).toBe(true);
-    expect(nav.hasNext).toBe(true);
     expect(nav.goToPrevious).toBeDefined();
     expect(nav.goToNext).toBeDefined();
   });
@@ -212,8 +210,6 @@ describe("computeWorkspaceNavigation", () => {
       0,
       jest.fn(),
     );
-    expect(nav.hasPrevious).toBe(false);
-    expect(nav.hasNext).toBe(true);
     expect(nav.goToPrevious).toBeUndefined();
     expect(nav.goToNext).toBeDefined();
   });
@@ -226,8 +222,6 @@ describe("computeWorkspaceNavigation", () => {
       2,
       jest.fn(),
     );
-    expect(nav.hasPrevious).toBe(true);
-    expect(nav.hasNext).toBe(false);
     expect(nav.goToPrevious).toBeDefined();
     expect(nav.goToNext).toBeUndefined();
   });
@@ -240,16 +234,8 @@ describe("computeWorkspaceNavigation", () => {
       null,
       jest.fn(),
     );
-    expect(nav.hasPrevious).toBe(false);
-    expect(nav.hasNext).toBe(false);
     expect(nav.goToPrevious).toBeUndefined();
     expect(nav.goToNext).toBeUndefined();
-  });
-
-  test("empty leaf list returns no navigation", () => {
-    const nav = computeWorkspaceNavigation([], "uri-a", navId, null, jest.fn());
-    expect(nav.hasPrevious).toBe(false);
-    expect(nav.hasNext).toBe(false);
   });
 
   test("single item has neither previous nor next", () => {
@@ -260,8 +246,8 @@ describe("computeWorkspaceNavigation", () => {
       0,
       jest.fn(),
     );
-    expect(nav.hasPrevious).toBe(false);
-    expect(nav.hasNext).toBe(false);
+    expect(nav.goToPrevious).toBeUndefined();
+    expect(nav.goToNext).toBeUndefined();
   });
 
   test("goToNext navigates with navId and navIndex", () => {
@@ -294,12 +280,6 @@ describe("computeWorkspaceNavigation", () => {
     );
   });
 
-  test("null navId returns no navigation", () => {
-    const nav = computeWorkspaceNavigation([], "uri-a", null, null, jest.fn());
-    expect(nav.hasPrevious).toBe(false);
-    expect(nav.hasNext).toBe(false);
-  });
-
   test("falls back to indexOf when navIndex is null", () => {
     const nav = computeWorkspaceNavigation(
       leafUris,
@@ -308,8 +288,8 @@ describe("computeWorkspaceNavigation", () => {
       null,
       jest.fn(),
     );
-    expect(nav.hasPrevious).toBe(true);
-    expect(nav.hasNext).toBe(true);
+    expect(nav.goToPrevious).toBeDefined();
+    expect(nav.goToNext).toBeDefined();
   });
 
   test("uses navIndex to distinguish duplicate URIs", () => {
@@ -323,8 +303,8 @@ describe("computeWorkspaceNavigation", () => {
       2,
       navigate,
     );
-    expect(nav.hasPrevious).toBe(true);
-    expect(nav.hasNext).toBe(true);
+    expect(nav.goToPrevious).toBeDefined();
+    expect(nav.goToNext).toBeDefined();
     nav.goToNext!();
     expect(navigate).toHaveBeenCalledWith(
       `/viewer/${encodeURIComponent("uri-b")}?navId=${navId}&navIndex=3`,

--- a/frontend/src/js/util/workspaceNavigation.ts
+++ b/frontend/src/js/util/workspaceNavigation.ts
@@ -1,92 +1,59 @@
 import { useMemo } from "react";
-import { ColumnsConfig, TreeEntry, TreeNode, isTreeNode } from "../types/Tree";
-import { WorkspaceEntry, isWorkspaceLeaf } from "../types/Workspaces";
+import {
+  ColumnsConfig,
+  TreeEntry,
+  TreeNode,
+  isTreeNode,
+  isTreeLeaf,
+  TreeLeaf,
+} from "../types/Tree";
+import {
+  WorkspaceEntry,
+  WorkspaceLeaf,
+  isWorkspaceLeaf,
+} from "../types/Workspaces";
 import { sortEntries } from "./treeUtils";
+import { uuidOrFallback } from "./uuid";
+import { findNodeById } from "./workspaceUtils";
 
 const STORAGE_KEY_PREFIX = "workspaceSiblingUris:";
 const MAX_STORED_NAV_ENTRIES = 20;
-
-function generateNavId(): string {
-  if (
-    typeof crypto !== "undefined" &&
-    "randomUUID" in crypto &&
-    typeof (crypto as any).randomUUID === "function"
-  ) {
-    return (crypto as any).randomUUID();
-  }
-  return Math.random().toString(36).slice(2) + Date.now().toString(36);
-}
 
 /**
  * Remove the oldest entries when we exceed the limit, to avoid filling sessionStorage.
  */
 function pruneOldNavEntries(): void {
-  try {
-    const keys = [];
-    for (let i = 0; i < sessionStorage.length; i++) {
-      const key = sessionStorage.key(i);
-      if (key?.startsWith(STORAGE_KEY_PREFIX)) {
-        keys.push(key);
-      }
+  const keys = [];
+  for (let i = 0; i < sessionStorage.length; i++) {
+    const key = sessionStorage.key(i);
+    if (key?.startsWith(STORAGE_KEY_PREFIX)) {
+      keys.push(key);
     }
-    if (keys.length > MAX_STORED_NAV_ENTRIES) {
-      keys
-        .slice(0, keys.length - MAX_STORED_NAV_ENTRIES)
-        .forEach((key) => sessionStorage.removeItem(key));
-    }
-  } catch {
-    // best-effort cleanup
+  }
+  if (keys.length > MAX_STORED_NAV_ENTRIES) {
+    keys
+      .slice(0, keys.length - MAX_STORED_NAV_ENTRIES)
+      .forEach((key) => sessionStorage.removeItem(key));
   }
 }
 
 /**
  * Return the immediate leaf children of a node sorted by the given config.
  */
-function sortedLeafChildren(
+export function sortedLeafChildren(
   node: TreeNode<WorkspaceEntry>,
   columnsConfig: ColumnsConfig<WorkspaceEntry>,
-): (TreeEntry<WorkspaceEntry> & { data: { uri: string } })[] {
+): TreeLeaf<WorkspaceLeaf>[] {
   return sortEntries(node.children, columnsConfig).filter(
-    (child): child is TreeEntry<WorkspaceEntry> & { data: { uri: string } } =>
-      !isTreeNode(child) && isWorkspaceLeaf(child.data),
+    (child): child is TreeLeaf<WorkspaceLeaf> =>
+      isTreeLeaf(child) && isWorkspaceLeaf(child.data),
   );
 }
 
 /**
- * Given a tree node, return the URIs of its immediate leaf children
- * (i.e. files, not folders) in the provided sort order.
- */
-export function leafUrisOfChildren(
-  node: TreeNode<WorkspaceEntry>,
-  columnsConfig: ColumnsConfig<WorkspaceEntry>,
-): string[] {
-  return sortedLeafChildren(node, columnsConfig).map((child) => child.data.uri);
-}
-
-/**
- * Find the parent node of an entry by its maybeParentId.
- * Returns the matching node, or undefined if not found.
- */
-export function findNodeById(
-  root: TreeNode<WorkspaceEntry>,
-  targetId: string,
-): TreeNode<WorkspaceEntry> | undefined {
-  if (root.id === targetId) {
-    return root;
-  }
-  for (const child of root.children) {
-    if (isTreeNode(child)) {
-      const found = findNodeById(child, targetId);
-      if (found) return found;
-    }
-  }
-  return undefined;
-}
-
-/**
  * Called from the workspace page before opening a document in a new tab.
- * Writes the sibling leaf URIs to sessionStorage keyed by a unique nonce,
- * and returns the nonce plus the index of the clicked entry so both can be
+ * Writes the sibling leaf URIs to sessionStorage keyed by a unique uuid,
+ * and returns the uuid plus the index of the clicked entry so both can be
  * passed to the viewer via query params.
  */
 export function storeWorkspaceSiblingUris(
@@ -95,36 +62,27 @@ export function storeWorkspaceSiblingUris(
   columnsConfig: ColumnsConfig<WorkspaceEntry>,
 ): { navId: string; navIndex: number } | undefined {
   const parentId = entry.data.maybeParentId;
-  const parentNode = parentId ? findNodeById(rootNode, parentId) : rootNode;
+  const parentNode = parentId ? findNodeById(rootNode, parentId) : undefined;
 
   if (!parentNode) return undefined;
 
   const leaves = sortedLeafChildren(parentNode, columnsConfig);
-  const siblingUris = leaves.map((child) => child.data.uri);
   const navIndex = leaves.findIndex((child) => child.id === entry.id);
-  const navId = generateNavId();
-  try {
-    pruneOldNavEntries();
-    sessionStorage.setItem(
-      `${STORAGE_KEY_PREFIX}${navId}`,
-      JSON.stringify(siblingUris),
-    );
-  } catch {
-    // sessionStorage may be full or unavailable — degrade gracefully
-    return undefined;
-  }
-  return { navId, navIndex: navIndex >= 0 ? navIndex : 0 };
+  const siblingUris = leaves.map((child) => child.data.uri);
+  const navId = uuidOrFallback();
+  pruneOldNavEntries();
+  sessionStorage.setItem(
+    `${STORAGE_KEY_PREFIX}${navId}`,
+    JSON.stringify(siblingUris),
+  );
+  return { navId, navIndex: navIndex };
 }
 
 function readWorkspaceSiblingUris(navId: string | null): string[] {
   if (!navId) return [];
-  try {
-    const stored = sessionStorage.getItem(`${STORAGE_KEY_PREFIX}${navId}`);
-    if (stored) {
-      return JSON.parse(stored);
-    }
-  } catch {
-    // corrupt or unavailable — degrade gracefully
+  const stored = sessionStorage.getItem(`${STORAGE_KEY_PREFIX}${navId}`);
+  if (stored) {
+    return JSON.parse(stored);
   }
   return [];
 }

--- a/frontend/src/js/util/workspaceNavigation.ts
+++ b/frontend/src/js/util/workspaceNavigation.ts
@@ -87,6 +87,8 @@ function readWorkspaceSiblingUris(navId: string): string[] {
 }
 
 export type WorkspaceNavigation = {
+  hasPrevious: boolean;
+  hasNext: boolean;
   goToPrevious: (() => void) | undefined;
   goToNext: (() => void) | undefined;
 };
@@ -130,7 +132,7 @@ export function computeWorkspaceNavigation(
       }
     : undefined;
 
-  return { goToPrevious, goToNext };
+  return { hasPrevious, hasNext, goToPrevious, goToNext };
 }
 
 export function useWorkspaceNavigation(
@@ -145,6 +147,8 @@ export function useWorkspaceNavigation(
   );
   if (!navId) {
     return {
+      hasPrevious: false,
+      hasNext: false,
       goToPrevious: undefined,
       goToNext: undefined,
     };

--- a/frontend/src/js/util/workspaceNavigation.ts
+++ b/frontend/src/js/util/workspaceNavigation.ts
@@ -78,7 +78,7 @@ export function storeWorkspaceSiblingUris(
   return { navId, navIndex: navIndex };
 }
 
-function readWorkspaceSiblingUris(navId: string | null): string[] {
+function readWorkspaceSiblingUris(navId: string): string[] {
   if (!navId) return [];
   const stored = sessionStorage.getItem(`${STORAGE_KEY_PREFIX}${navId}`);
   if (stored) {
@@ -88,35 +88,33 @@ function readWorkspaceSiblingUris(navId: string | null): string[] {
 }
 
 export type WorkspaceNavigation = {
-  hasPrevious: boolean;
-  hasNext: boolean;
   goToPrevious: (() => void) | undefined;
   goToNext: (() => void) | undefined;
 };
 
 export function computeWorkspaceNavigation(
-  leafUris: string[],
+  siblingUris: string[],
   currentUri: string,
   navId: string | null,
   navIndex: number | null,
   navigate: (path: string) => void,
 ): WorkspaceNavigation {
-  // Use the explicit index when it's valid (matching the current URI),
-  // otherwise fall back to indexOf — which still works when URIs are unique.
+  // In the (impossible via the UI) event that we have a navId but no navIndex then we can just search the list of siblings
+  // for it. navIndex is preferred as there may be lots of siblings to search through
   const currentIndex =
     navIndex !== null &&
     navIndex >= 0 &&
-    navIndex < leafUris.length &&
-    leafUris[navIndex] === currentUri
+    navIndex < siblingUris.length &&
+    siblingUris[navIndex] === currentUri
       ? navIndex
-      : leafUris.indexOf(currentUri);
+      : siblingUris.indexOf(currentUri);
   const hasPrevious = currentIndex > 0;
-  const hasNext = currentIndex >= 0 && currentIndex < leafUris.length - 1;
+  const hasNext = currentIndex >= 0 && currentIndex < siblingUris.length - 1;
 
   const goToPrevious = hasPrevious
     ? () => {
         const prevIndex = currentIndex - 1;
-        const prevUri = leafUris[prevIndex];
+        const prevUri = siblingUris[prevIndex];
         navigate(
           `/viewer/${encodeURIComponent(prevUri)}?navId=${navId}&navIndex=${prevIndex}`,
         );
@@ -126,25 +124,25 @@ export function computeWorkspaceNavigation(
   const goToNext = hasNext
     ? () => {
         const nextIndex = currentIndex + 1;
-        const nextUri = leafUris[nextIndex];
+        const nextUri = siblingUris[nextIndex];
         navigate(
           `/viewer/${encodeURIComponent(nextUri)}?navId=${navId}&navIndex=${nextIndex}`,
         );
       }
     : undefined;
 
-  return { hasPrevious, hasNext, goToPrevious, goToNext };
+  return { goToPrevious, goToNext };
 }
 
 export function useWorkspaceNavigation(
   currentUri: string,
-  navId: string | null,
+  navId: string,
   navIndex: number | null,
   navigate: (path: string) => void,
 ): WorkspaceNavigation {
-  const leafUris = useMemo(() => readWorkspaceSiblingUris(navId), [navId]);
+  const siblingUris = useMemo(() => readWorkspaceSiblingUris(navId), [navId]);
   return computeWorkspaceNavigation(
-    leafUris,
+    siblingUris,
     currentUri,
     navId,
     navIndex,

--- a/frontend/src/js/util/workspaceNavigation.ts
+++ b/frontend/src/js/util/workspaceNavigation.ts
@@ -139,13 +139,16 @@ export function useWorkspaceNavigation(
   navIndex: number | null,
   navigate: (path: string) => void,
 ): WorkspaceNavigation {
+  const siblingUris = useMemo(
+    () => (navId ? readWorkspaceSiblingUris(navId) : []),
+    [navId],
+  );
   if (!navId) {
     return {
       goToPrevious: undefined,
       goToNext: undefined,
     };
   }
-  const siblingUris = useMemo(() => readWorkspaceSiblingUris(navId), [navId]);
   return computeWorkspaceNavigation(
     siblingUris,
     currentUri,

--- a/frontend/src/js/util/workspaceNavigation.ts
+++ b/frontend/src/js/util/workspaceNavigation.ts
@@ -3,7 +3,6 @@ import {
   ColumnsConfig,
   TreeEntry,
   TreeNode,
-  isTreeNode,
   isTreeLeaf,
   TreeLeaf,
 } from "../types/Tree";
@@ -95,12 +94,12 @@ export type WorkspaceNavigation = {
 export function computeWorkspaceNavigation(
   siblingUris: string[],
   currentUri: string,
-  navId: string | null,
+  navId: string,
   navIndex: number | null,
   navigate: (path: string) => void,
 ): WorkspaceNavigation {
   // In the (impossible via the UI) event that we have a navId but no navIndex then we can just search the list of siblings
-  // for it. navIndex is preferred as there may be lots of siblings to search through
+  // for it. navIndex is preferred as there may be lots of siblings to search through, or siblings with the same uri
   const currentIndex =
     navIndex !== null &&
     navIndex >= 0 &&

--- a/frontend/src/js/util/workspaceNavigation.ts
+++ b/frontend/src/js/util/workspaceNavigation.ts
@@ -40,6 +40,19 @@ function pruneOldNavEntries(): void {
 }
 
 /**
+ * Return the immediate leaf children of a node sorted by the given config.
+ */
+function sortedLeafChildren(
+  node: TreeNode<WorkspaceEntry>,
+  columnsConfig: ColumnsConfig<WorkspaceEntry>,
+): (TreeEntry<WorkspaceEntry> & { data: { uri: string } })[] {
+  return sortEntries(node.children, columnsConfig).filter(
+    (child): child is TreeEntry<WorkspaceEntry> & { data: { uri: string } } =>
+      !isTreeNode(child) && isWorkspaceLeaf(child.data),
+  );
+}
+
+/**
  * Given a tree node, return the URIs of its immediate leaf children
  * (i.e. files, not folders) in the provided sort order.
  */
@@ -47,12 +60,7 @@ export function leafUrisOfChildren(
   node: TreeNode<WorkspaceEntry>,
   columnsConfig: ColumnsConfig<WorkspaceEntry>,
 ): string[] {
-  return sortEntries(node.children, columnsConfig)
-    .filter(
-      (child): child is TreeEntry<WorkspaceEntry> & { data: { uri: string } } =>
-        !isTreeNode(child) && isWorkspaceLeaf(child.data),
-    )
-    .map((child) => child.data.uri);
+  return sortedLeafChildren(node, columnsConfig).map((child) => child.data.uri);
 }
 
 /**
@@ -78,19 +86,22 @@ export function findNodeById(
 /**
  * Called from the workspace page before opening a document in a new tab.
  * Writes the sibling leaf URIs to sessionStorage keyed by a unique nonce,
- * and returns the nonce so it can be passed to the viewer via query param.
+ * and returns the nonce plus the index of the clicked entry so both can be
+ * passed to the viewer via query params.
  */
 export function storeWorkspaceSiblingUris(
   rootNode: TreeNode<WorkspaceEntry>,
   entry: TreeEntry<WorkspaceEntry>,
   columnsConfig: ColumnsConfig<WorkspaceEntry>,
-): string | undefined {
+): { navId: string; navIndex: number } | undefined {
   const parentId = entry.data.maybeParentId;
   const parentNode = parentId ? findNodeById(rootNode, parentId) : rootNode;
 
   if (!parentNode) return undefined;
 
-  const siblingUris = leafUrisOfChildren(parentNode, columnsConfig);
+  const leaves = sortedLeafChildren(parentNode, columnsConfig);
+  const siblingUris = leaves.map((child) => child.data.uri);
+  const navIndex = leaves.findIndex((child) => child.id === entry.id);
   const navId = generateNavId();
   try {
     pruneOldNavEntries();
@@ -102,7 +113,7 @@ export function storeWorkspaceSiblingUris(
     // sessionStorage may be full or unavailable — degrade gracefully
     return undefined;
   }
-  return navId;
+  return { navId, navIndex: navIndex >= 0 ? navIndex : 0 };
 }
 
 function readWorkspaceSiblingUris(navId: string | null): string[] {
@@ -129,23 +140,38 @@ export function computeWorkspaceNavigation(
   leafUris: string[],
   currentUri: string,
   navId: string | null,
+  navIndex: number | null,
   navigate: (path: string) => void,
 ): WorkspaceNavigation {
-  const currentIndex = leafUris.indexOf(currentUri);
+  // Use the explicit index when it's valid (matching the current URI),
+  // otherwise fall back to indexOf — which still works when URIs are unique.
+  const currentIndex =
+    navIndex !== null &&
+    navIndex >= 0 &&
+    navIndex < leafUris.length &&
+    leafUris[navIndex] === currentUri
+      ? navIndex
+      : leafUris.indexOf(currentUri);
   const hasPrevious = currentIndex > 0;
   const hasNext = currentIndex >= 0 && currentIndex < leafUris.length - 1;
 
   const goToPrevious = hasPrevious
     ? () => {
-        const prevUri = leafUris[currentIndex - 1];
-        navigate(`/viewer/${encodeURIComponent(prevUri)}?navId=${navId}`);
+        const prevIndex = currentIndex - 1;
+        const prevUri = leafUris[prevIndex];
+        navigate(
+          `/viewer/${encodeURIComponent(prevUri)}?navId=${navId}&navIndex=${prevIndex}`,
+        );
       }
     : undefined;
 
   const goToNext = hasNext
     ? () => {
-        const nextUri = leafUris[currentIndex + 1];
-        navigate(`/viewer/${encodeURIComponent(nextUri)}?navId=${navId}`);
+        const nextIndex = currentIndex + 1;
+        const nextUri = leafUris[nextIndex];
+        navigate(
+          `/viewer/${encodeURIComponent(nextUri)}?navId=${navId}&navIndex=${nextIndex}`,
+        );
       }
     : undefined;
 
@@ -155,8 +181,15 @@ export function computeWorkspaceNavigation(
 export function useWorkspaceNavigation(
   currentUri: string,
   navId: string | null,
+  navIndex: number | null,
   navigate: (path: string) => void,
 ): WorkspaceNavigation {
   const leafUris = useMemo(() => readWorkspaceSiblingUris(navId), [navId]);
-  return computeWorkspaceNavigation(leafUris, currentUri, navId, navigate);
+  return computeWorkspaceNavigation(
+    leafUris,
+    currentUri,
+    navId,
+    navIndex,
+    navigate,
+  );
 }

--- a/frontend/src/js/util/workspaceNavigation.ts
+++ b/frontend/src/js/util/workspaceNavigation.ts
@@ -1,0 +1,162 @@
+import { useMemo } from "react";
+import { ColumnsConfig, TreeEntry, TreeNode, isTreeNode } from "../types/Tree";
+import { WorkspaceEntry, isWorkspaceLeaf } from "../types/Workspaces";
+import { sortEntries } from "./treeUtils";
+
+const STORAGE_KEY_PREFIX = "workspaceSiblingUris:";
+const MAX_STORED_NAV_ENTRIES = 20;
+
+function generateNavId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    "randomUUID" in crypto &&
+    typeof (crypto as any).randomUUID === "function"
+  ) {
+    return (crypto as any).randomUUID();
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+/**
+ * Remove the oldest entries when we exceed the limit, to avoid filling sessionStorage.
+ */
+function pruneOldNavEntries(): void {
+  try {
+    const keys = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const key = sessionStorage.key(i);
+      if (key?.startsWith(STORAGE_KEY_PREFIX)) {
+        keys.push(key);
+      }
+    }
+    if (keys.length > MAX_STORED_NAV_ENTRIES) {
+      keys
+        .slice(0, keys.length - MAX_STORED_NAV_ENTRIES)
+        .forEach((key) => sessionStorage.removeItem(key));
+    }
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+/**
+ * Given a tree node, return the URIs of its immediate leaf children
+ * (i.e. files, not folders) in the provided sort order.
+ */
+export function leafUrisOfChildren(
+  node: TreeNode<WorkspaceEntry>,
+  columnsConfig: ColumnsConfig<WorkspaceEntry>,
+): string[] {
+  return sortEntries(node.children, columnsConfig)
+    .filter(
+      (child): child is TreeEntry<WorkspaceEntry> & { data: { uri: string } } =>
+        !isTreeNode(child) && isWorkspaceLeaf(child.data),
+    )
+    .map((child) => child.data.uri);
+}
+
+/**
+ * Find the parent node of an entry by its maybeParentId.
+ * Returns the matching node, or undefined if not found.
+ */
+export function findNodeById(
+  root: TreeNode<WorkspaceEntry>,
+  targetId: string,
+): TreeNode<WorkspaceEntry> | undefined {
+  if (root.id === targetId) {
+    return root;
+  }
+  for (const child of root.children) {
+    if (isTreeNode(child)) {
+      const found = findNodeById(child, targetId);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Called from the workspace page before opening a document in a new tab.
+ * Writes the sibling leaf URIs to sessionStorage keyed by a unique nonce,
+ * and returns the nonce so it can be passed to the viewer via query param.
+ */
+export function storeWorkspaceSiblingUris(
+  rootNode: TreeNode<WorkspaceEntry>,
+  entry: TreeEntry<WorkspaceEntry>,
+  columnsConfig: ColumnsConfig<WorkspaceEntry>,
+): string | undefined {
+  const parentId = entry.data.maybeParentId;
+  const parentNode = parentId ? findNodeById(rootNode, parentId) : rootNode;
+
+  if (!parentNode) return undefined;
+
+  const siblingUris = leafUrisOfChildren(parentNode, columnsConfig);
+  const navId = generateNavId();
+  try {
+    pruneOldNavEntries();
+    sessionStorage.setItem(
+      `${STORAGE_KEY_PREFIX}${navId}`,
+      JSON.stringify(siblingUris),
+    );
+  } catch {
+    // sessionStorage may be full or unavailable — degrade gracefully
+    return undefined;
+  }
+  return navId;
+}
+
+function readWorkspaceSiblingUris(navId: string | null): string[] {
+  if (!navId) return [];
+  try {
+    const stored = sessionStorage.getItem(`${STORAGE_KEY_PREFIX}${navId}`);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // corrupt or unavailable — degrade gracefully
+  }
+  return [];
+}
+
+export type WorkspaceNavigation = {
+  hasPrevious: boolean;
+  hasNext: boolean;
+  goToPrevious: (() => void) | undefined;
+  goToNext: (() => void) | undefined;
+};
+
+export function computeWorkspaceNavigation(
+  leafUris: string[],
+  currentUri: string,
+  navId: string | null,
+  navigate: (path: string) => void,
+): WorkspaceNavigation {
+  const currentIndex = leafUris.indexOf(currentUri);
+  const hasPrevious = currentIndex > 0;
+  const hasNext = currentIndex >= 0 && currentIndex < leafUris.length - 1;
+
+  const goToPrevious = hasPrevious
+    ? () => {
+        const prevUri = leafUris[currentIndex - 1];
+        navigate(`/viewer/${encodeURIComponent(prevUri)}?navId=${navId}`);
+      }
+    : undefined;
+
+  const goToNext = hasNext
+    ? () => {
+        const nextUri = leafUris[currentIndex + 1];
+        navigate(`/viewer/${encodeURIComponent(nextUri)}?navId=${navId}`);
+      }
+    : undefined;
+
+  return { hasPrevious, hasNext, goToPrevious, goToNext };
+}
+
+export function useWorkspaceNavigation(
+  currentUri: string,
+  navId: string | null,
+  navigate: (path: string) => void,
+): WorkspaceNavigation {
+  const leafUris = useMemo(() => readWorkspaceSiblingUris(navId), [navId]);
+  return computeWorkspaceNavigation(leafUris, currentUri, navId, navigate);
+}

--- a/frontend/src/js/util/workspaceNavigation.ts
+++ b/frontend/src/js/util/workspaceNavigation.ts
@@ -135,10 +135,16 @@ export function computeWorkspaceNavigation(
 
 export function useWorkspaceNavigation(
   currentUri: string,
-  navId: string,
+  navId: string | null,
   navIndex: number | null,
   navigate: (path: string) => void,
 ): WorkspaceNavigation {
+  if (!navId) {
+    return {
+      goToPrevious: undefined,
+      goToNext: undefined,
+    };
+  }
   const siblingUris = useMemo(() => readWorkspaceSiblingUris(navId), [navId]);
   return computeWorkspaceNavigation(
     siblingUris,

--- a/frontend/src/js/util/workspaceUtils.spec.ts
+++ b/frontend/src/js/util/workspaceUtils.spec.ts
@@ -1,4 +1,4 @@
-import { workspaceHasProcessingFiles } from "./workspaceUtils";
+import { findNodeById, workspaceHasProcessingFiles } from "./workspaceUtils";
 import {
   workspaceFlatWithOneProcessing,
   workspaceFlatWithZeroProcessing,
@@ -8,6 +8,7 @@ import {
   workspaceWithZeroProcessing,
   workspaceWithZeroProcessingBottomHeavyTree,
 } from "./workspaceUtils.fixtures";
+import { makeLeaf, makeNode } from "./workspaceNavigation.spec";
 
 test("workspaceHasProcessingFiles", () => {
   expect(workspaceHasProcessingFiles(workspaceWithZeroProcessing)).toBe(false);
@@ -26,4 +27,22 @@ test("workspaceHasProcessingFiles", () => {
   expect(workspaceHasProcessingFiles(workspaceFlatWithOneProcessing)).toBe(
     true,
   );
+});
+
+describe("findNodeById", () => {
+  test("returns the root when id matches", () => {
+    const root = makeNode("root", []);
+    expect(findNodeById(root, "root")).toBe(root);
+  });
+
+  test("returns undefined when not found", () => {
+    const root = makeNode("root", [makeLeaf("doc.pdf", "uri-1")]);
+    expect(findNodeById(root, "nonexistent")).toBeUndefined();
+  });
+
+  test("finds deeply nested node", () => {
+    const deep = makeNode("deep", []);
+    const root = makeNode("root", [makeNode("a", [makeNode("b", [deep])])]);
+    expect(findNodeById(root, "deep")).toBe(deep);
+  });
 });

--- a/frontend/src/js/util/workspaceUtils.ts
+++ b/frontend/src/js/util/workspaceUtils.ts
@@ -8,6 +8,22 @@ import { isTreeLeaf, isTreeNode, TreeEntry, TreeNode } from "../types/Tree";
 import { ProcessingStage } from "../types/Resource";
 import { useRouteMatch } from "react-router-dom";
 
+export function findNodeById(
+  root: TreeNode<WorkspaceEntry>,
+  targetId: string,
+): TreeNode<WorkspaceEntry> | undefined {
+  if (root.id === targetId) {
+    return root;
+  }
+  for (const child of root.children) {
+    if (isTreeNode(child)) {
+      const found = findNodeById(child, targetId);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
 export const findPath = (
   targetId: string,
   currentParents: TreeEntry<WorkspaceEntry>[],

--- a/frontend/src/stylesheets/components/_document.scss
+++ b/frontend/src/stylesheets/components/_document.scss
@@ -267,42 +267,40 @@ comment-highlight.comment-highlight--focused {
   }
 }
 
-comment-highlight {
-  position: relative;
-  display: inline-block;
-  font-weight: bold;
-  font-style: italic;
-  z-index: 2;
-  white-space: pre;
+.doc-nav-buttons {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
 
-  &:nth-of-type(4n-3):before {
-    transform: rotate(-3deg);
-  }
+.doc-nav-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  cursor: default;
 
-  &:nth-of-type(4n-2):before {
-    transform: rotate(2deg);
-  }
-
-  &:nth-of-type(4n-1):before {
-    transform: rotate(-1deg);
-  }
-
-  &:before {
-    content: " ";
-    background-color: lightpink;
-    position: absolute;
-    width: calc(100% + 5px);
-    left: -3px;
-    top: 1px;
-    height: 100%;
-    opacity: 0.5;
-    transform: rotate(-2deg);
-    pointer-events: none;
+  svg {
+    font-size: 20px;
   }
 }
 
-comment-highlight.comment-highlight--focused {
-  &:before {
-    background-color: hotpink;
+.doc-nav-button--active {
+  cursor: pointer;
+  color: white;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.15);
   }
+}
+
+.doc-nav-button--inactive {
+  color: rgba(255, 255, 255, 0.3);
+  pointer-events: none;
+}
+
+.doc-nav-button--previous {
+  transform: rotate(180deg);
 }


### PR DESCRIPTION
> [!NOTE]
> This PR is ~700 lines but a big chunk of that is a massive test file. Will cut the tests back if you say it's overkill.

## Previous/next document navigation from workspaces

Partially addresses #470 and #620 , both of which will disappear entirely in the subsequent stages.

Previously, the prev/next navigation only worked when a document was opened from a search result. Users working through documents in a workspace had to go back to the workspace tab, click the next file, and wait for a new viewer tab to open. This is particularly tedious when reviewing many files in sequence.

With this change, when a user opens a document from a workspace, they can use previous/next buttons (and `shift+left`/`shift+right` keyboard shortcuts) to cycle through sibling documents in the same folder — matching the existing behaviour for cycling through search results.

![2026-04-03 12 10 52](https://github.com/user-attachments/assets/e4b404e8-2c3d-4c07-ac3b-e9644cd3f4f0)


### How it works

1. **On double-click in workspace:** Before opening the new tab, the workspace page writes the sibling leaf URIs (files in the same folder, in the user's current sort order) to `sessionStorage`, keyed by a unique nonce.
2. **In the viewer tab:** A `useWorkspaceNavigation` hook reads the sibling URIs from `sessionStorage` on mount and provides `goToPrevious`/`goToNext` functions. The nonce is passed via `?navId=` query param.
3. **Fallback logic:** When a document is opened from search, search result navigation takes priority. When opened from a workspace, workspace navigation is used instead. The existing StatusBar buttons and keyboard shortcuts handle both — no separate UI is added.
4. The keyboard shortcuts associated with the prev/next icons when used from search (shift left, shift right) also work in this mode. This is the real win. To be able to navigate through a folder using the keyboard while checking each doc is a significant usability gain. 

This approach avoids any additional API calls — the workspace page already has the tree in memory, and `sessionStorage` is scoped to the originating tab so there's no leakage to shared links. Old entries are pruned by count (max 20) rather than consumed on read, so refreshing the page doesn't break navigation.

### Design changes

New previous and next buttons have been added to the "combined" (pageviewer) mode:

- Both buttons are now adjacent on the right side of the toolbar (instead of at opposite ends)
- Icons changed from subtle chevrons to filled play-arrow triangles for better visibility
- Hover state and clearer active/inactive styling

### What this doesn't do

- Doesn't touch `StatusBar.js` or add a _new_ footer component — that's covered in the next stage (branch `ljh-document-footer`). As a consequence the nav in non-pageviewer view modes is still the old style.
- Doesn't mess with the document prev and next function for search results, so that remains unavailable in pageview documents. (It's addressed in `ljh-document-footer`.)
- No change to the Pageviewer's control widget that provides find-in-document, zoom, and rotate features. Those will be consolidated into a the page footer in the third branch (`ljh-combined-view`).
- Navigation is scoped to siblings in the same folder, not the entire workspace tree. I didn't want to take on trees with a million leaves.

### Dependency graph
    main
     └── ljh-workspace-nav        ← this PR
          └── ljh-document-footer  (DocumentFooter refactor + search stepper)
               └── ljh-combined-view (find-in-doc, zoom, rotate for paged view)

### Tests

## Integration tests
200-odd lines of tests covering `leafUrisOfChildren`, `findNodeById`, `computeWorkspaceNavigation`, and `storeWorkspaceSiblingUris`. All 133 existing tests continue to pass.

## Manual tests
 - [x] Tested locally
 - [x] Tested on playground (build 6433 [ljh-workspace-nav] )