### PR TITLE
[do not merge] Search UX v2 #2: shared utilities & Downshift dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "connected-react-router": "^6.8.0",
         "d3": "^v7.9.0",
         "date-fns": "^2.27.0",
+        "downshift": "^9.3.2",
         "history": "^4.10.1",
         "http-proxy-middleware": "3.0.0",
         "human-date": "^1.4.0",
@@ -2145,12 +2146,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -6912,6 +6910,11 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8518,6 +8521,31 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
+    },
+    "node_modules/downshift": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.2.tgz",
+      "integrity": "sha512-5VD0WZLQDhipWiDU+K5ili3VDhGrXwlvOlSaSG1Cb0eS4XpssxVuoD09JNgju+bAzxB2Wvlwx+FwTE/FNdrqow==",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/downshift/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/downshift/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -18990,11 +19018,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "connected-react-router": "^6.8.0",
     "d3": "^v7.9.0",
     "date-fns": "^2.27.0",
+    "downshift": "^9.3.2",
     "history": "^4.10.1",
     "http-proxy-middleware": "3.0.0",
     "human-date": "^1.4.0",

--- a/frontend/src/js/components/Search/chipDisplayUtils.ts
+++ b/frontend/src/js/components/Search/chipDisplayUtils.ts
@@ -1,0 +1,81 @@
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+/** Get the display label for a value given an options list. */
+export function getDisplayLabel(
+  value: string,
+  allOptions: SelectOption[] | null | undefined,
+): string {
+  if (!allOptions) return value;
+  const opt = allOptions.find((o) => o.value === value);
+  return opt ? opt.label : value;
+}
+
+/** Maximum character budget for display text in a multi-value chip.
+ * Individual labels are ellipsis-truncated to fit, and a "+N more"
+ * suffix is appended when not all values fit within the budget. */
+export const MAX_DISPLAY_CHARS = 36;
+
+/**
+ * Build a character-budget-aware display string from an array of labels.
+ *
+ * Algorithm:
+ * 1. If all labels joined with ", " fit within `budget`, return them.
+ * 2. Otherwise greedily add labels while they fit. Each label after the
+ *    first costs an extra 2 chars for ", ". Reserve space for the
+ *    " +N more" suffix (where N = remaining items).
+ * 3. A single label that exceeds the budget is ellipsis-truncated so
+ *    there's always at least one visible name.
+ */
+export function truncateChipDisplay(labels: string[], budget: number): string {
+  if (labels.length === 0) return "all";
+
+  const full = labels.join(", ");
+  if (full.length <= budget) return full;
+
+  const ELLIPSIS = "\u2026"; // …
+  const SEPARATOR = ", ";
+  const shown: string[] = [];
+  let used = 0;
+
+  for (let i = 0; i < labels.length; i++) {
+    const label = labels[i];
+    const remaining = labels.length - i - 1;
+    const sepCost = shown.length > 0 ? SEPARATOR.length : 0;
+    const suffixStr = remaining > 0 ? `${SEPARATOR}+${remaining} more` : "";
+    const suffixCost =
+      shown.length > 0
+        ? suffixStr.length
+        : remaining > 0
+          ? suffixStr.length
+          : 0;
+    const available = budget - used - sepCost - suffixCost;
+
+    if (available <= 0 && shown.length > 0) break;
+
+    if (label.length <= available) {
+      shown.push(label);
+      used += sepCost + label.length;
+    } else if (shown.length === 0) {
+      // First label must always appear — truncate it with ellipsis
+      const truncLen = Math.max(1, budget - suffixCost - ELLIPSIS.length);
+      shown.push(label.slice(0, truncLen) + ELLIPSIS);
+      used = shown[0].length;
+      const leftover = labels.length - 1;
+      if (leftover > 0) {
+        return `${shown[0]}${SEPARATOR}+${leftover} more`;
+      }
+      return shown[0];
+    } else {
+      break;
+    }
+  }
+
+  const leftover = labels.length - shown.length;
+  if (leftover > 0) {
+    return `${shown.join(SEPARATOR)}${SEPARATOR}+${leftover} more`;
+  }
+  return shown.join(SEPARATOR);
+}

--- a/frontend/src/js/components/Search/triStateCycle.spec.ts
+++ b/frontend/src/js/components/Search/triStateCycle.spec.ts
@@ -1,0 +1,67 @@
+import { getTriState, triStateCycle } from "./triStateCycle";
+
+describe("getTriState", () => {
+  test("returns 'positive' when key is in positive array", () => {
+    expect(getTriState("pdf", ["pdf", "image"], [])).toBe("positive");
+  });
+
+  test("returns 'negative' when key is in negative array", () => {
+    expect(getTriState("pdf", [], ["pdf"])).toBe("negative");
+  });
+
+  test("returns 'off' when key is in neither array", () => {
+    expect(getTriState("pdf", ["image"], ["video"])).toBe("off");
+  });
+
+  test("returns 'off' for empty arrays", () => {
+    expect(getTriState("pdf", [], [])).toBe("off");
+  });
+});
+
+describe("triStateCycle", () => {
+  test("off → positive: adds key to positive", () => {
+    const result = triStateCycle("image", ["pdf"], []);
+    expect(result).toEqual({ positive: ["pdf", "image"], negative: [] });
+  });
+
+  test("positive → negative: moves key from positive to negative", () => {
+    const result = triStateCycle("pdf", ["pdf", "image"], []);
+    expect(result).toEqual({ positive: ["image"], negative: ["pdf"] });
+  });
+
+  test("negative → off: removes key from negative", () => {
+    const result = triStateCycle("pdf", [], ["pdf"]);
+    expect(result).toEqual({ positive: [], negative: [] });
+  });
+
+  test("cycling three times returns to original state", () => {
+    const initial = { positive: ["image"], negative: [] };
+    const step1 = triStateCycle("pdf", initial.positive, initial.negative);
+    const step2 = triStateCycle("pdf", step1.positive, step1.negative);
+    const step3 = triStateCycle("pdf", step2.positive, step2.negative);
+    expect(step3).toEqual(initial);
+  });
+
+  test("does not mutate input arrays", () => {
+    const positive = ["pdf", "image"];
+    const negative = ["video"];
+    const posCopy = [...positive];
+    const negCopy = [...negative];
+    triStateCycle("pdf", positive, negative);
+    expect(positive).toEqual(posCopy);
+    expect(negative).toEqual(negCopy);
+  });
+
+  test("works with empty arrays", () => {
+    const result = triStateCycle("pdf", [], []);
+    expect(result).toEqual({ positive: ["pdf"], negative: [] });
+  });
+
+  test("preserves other keys when cycling", () => {
+    const result = triStateCycle("pdf", ["pdf", "image", "video"], ["audio"]);
+    expect(result).toEqual({
+      positive: ["image", "video"],
+      negative: ["audio", "pdf"],
+    });
+  });
+});

--- a/frontend/src/js/components/Search/triStateCycle.ts
+++ b/frontend/src/js/components/Search/triStateCycle.ts
@@ -1,0 +1,55 @@
+/**
+ * Tri-state cycling logic shared by all filter components.
+ *
+ * Each filter value can be in one of three states:
+ *   off → positive (include) → negative (exclude) → off
+ *
+ * This module provides a pure function that computes the next
+ * positive/negative arrays after toggling a single key.
+ */
+
+export type TriState = "off" | "positive" | "negative";
+
+export interface PolarityArrays {
+  positive: string[];
+  negative: string[];
+}
+
+/** Determine the current tri-state for a key. */
+export function getTriState(
+  key: string,
+  positive: string[],
+  negative: string[],
+): TriState {
+  if (positive.includes(key)) return "positive";
+  if (negative.includes(key)) return "negative";
+  return "off";
+}
+
+/**
+ * Cycle a single key through: off → positive → negative → off.
+ *
+ * Returns new positive/negative arrays (the originals are not mutated).
+ */
+export function triStateCycle(
+  key: string,
+  positive: string[],
+  negative: string[],
+): PolarityArrays {
+  const state = getTriState(key, positive, negative);
+
+  switch (state) {
+    case "off":
+      return { positive: [...positive, key], negative };
+    case "positive":
+      return {
+        positive: positive.filter((k) => k !== key),
+        negative: [...negative, key],
+      };
+    case "negative":
+      return {
+        positive,
+        negative: negative.filter((k) => k !== key),
+      };
+  }
+}

--- a/frontend/src/js/components/UtilComponents/TriStateCheckbox.tsx
+++ b/frontend/src/js/components/UtilComponents/TriStateCheckbox.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import BlankCheckboxIcon from "react-icons/lib/md/check-box-outline-blank";
+import CheckBoxIcon from "react-icons/lib/md/check-box";
+import IndeterminateCheckBoxIcon from "react-icons/lib/md/indeterminate-check-box";
+import { TriState } from "./triStateCycle";
+
+interface TriStateCheckboxProps {
+  state: TriState;
+  onClick: (e: React.MouseEvent) => void;
+}
+
+export const TriStateCheckbox: React.FC<TriStateCheckboxProps> = (props) => {
+  const stateClass =
+    props.state === "positive"
+      ? "checkbox--checked"
+      : props.state === "negative"
+        ? "checkbox--negative"
+        : "";
+
+  const Icon =
+    props.state === "positive"
+      ? CheckBoxIcon
+      : props.state === "negative"
+        ? IndeterminateCheckBoxIcon
+        : BlankCheckboxIcon;
+
+  return (
+    <div className={`checkbox ${stateClass}`} onClick={(e) => props.onClick(e)}>
+      <div className="checkbox__icon">
+        <Icon />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/js/components/UtilComponents/TriStateCheckbox.tsx
+++ b/frontend/src/js/components/UtilComponents/TriStateCheckbox.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import BlankCheckboxIcon from "react-icons/lib/md/check-box-outline-blank";
 import CheckBoxIcon from "react-icons/lib/md/check-box";
 import IndeterminateCheckBoxIcon from "react-icons/lib/md/indeterminate-check-box";
-import { TriState } from "./triStateCycle";
+import { TriState } from "../Search/triStateCycle";
 
 interface TriStateCheckboxProps {
   state: TriState;

--- a/frontend/src/stylesheets/components/_checkbox.scss
+++ b/frontend/src/stylesheets/components/_checkbox.scss
@@ -13,6 +13,14 @@
 
   .checkbox__icon {
     opacity: 1;
+    color: $primaryDark;
+  }
+}
+
+.checkbox--negative {
+  .checkbox__icon {
+    opacity: 1;
+    color: $excludeColour;
   }
 }
 
@@ -23,6 +31,13 @@
 .checkbox:hover {
   .checkbox__icon {
     opacity: 1;
+    color: $primaryDark;
+  }
+}
+
+.checkbox--negative:hover {
+  .checkbox__icon {
+    color: $excludeColour;
   }
 }
 
@@ -31,6 +46,7 @@
   position: relative;
   margin-left: 5px;
   flex-shrink: 0;
+  color: $filterInactiveColour;
   opacity: 0.7;
   transition: opacity 0.1s ease;
   height: 25px;


### PR DESCRIPTION
> [!NOTE]
> THIS IS A PLACEHOLDER PR SO I CAN REMEMBER WHAT WAS DONE IN THIS BRANCH. 
> It'll probably get rewritten entirely should we actually get here.


## Context

Part of the [Search UX Improvements](https://github.com/guardian/giant/issues/633) epic. Closes [#635](https://github.com/guardian/giant/issues/635).

> [!IMPORTANT]
> This is the second of five PRs in the [Search UX Improvements](https://github.com/guardian/giant/issues/633) epic.
>
> ```
> PR1 Chip parsing infrastructure
>  └─ PR2 Shared utilities & Downshift dependency  ← you are here
>      └─ PR3 Active filter chips & multi-select
>          └─ PR4 Search page & AddFilterModal
>              └─ PR5 Sidebar tri-state filters
> ```

## Changes to the user experience

This PR is purely infrastructure — no visible changes yet. It adds building blocks consumed by PR3–PR5.

## What's included

- **Tri-state cycling logic** (`triStateCycle.ts`) — pure functions for cycling filter values through off → include → exclude → off, with `getTriState` and `triStateCycle` helpers.
- **Chip display utilities** (`chipDisplayUtils.ts`) — `truncateChipDisplay()` builds character-budget-aware display strings for multi-value chips (ellipsis truncation + "+N more" suffix), plus `getDisplayLabel()` for option lookups.
- **TriStateCheckbox component** (`TriStateCheckbox.tsx`) — reusable checkbox rendering three visual states (blank, checked, indeterminate/negative) with colour-coded styling.
- **SCSS** — new `.checkbox--negative` style using `$excludeColour`, plus hover state for negative checkboxes.
- **Downshift dependency** — added to `package.json` for accessible multi-select dropdowns in PR3.

### Automated tests

- `triStateCycle.spec.ts` — 7 tests covering `getTriState` (4 cases) and `triStateCycle` (full cycle, immutability, preservation of other keys, empty arrays).

### Manual tests

No visible changes to test.