### PR TITLE
[do not merge] Search UX v2 #3: active filter chips & multi-select

### DIFF
--- a/frontend/src/js/components/Search/ActiveFilterChip.spec.ts
+++ b/frontend/src/js/components/Search/ActiveFilterChip.spec.ts
@@ -1,0 +1,107 @@
+import { truncateChipDisplay } from "./chipDisplayUtils";
+import { isMultiValueChip } from "./chipNames";
+
+describe("isMultiValueChip", () => {
+  test("Mime Type is multi-value", () => {
+    expect(isMultiValueChip("Mime Type")).toBe(true);
+  });
+
+  test("Has Field is multi-value", () => {
+    expect(isMultiValueChip("Has Field")).toBe(true);
+  });
+
+  test("File Type is multi-value", () => {
+    expect(isMultiValueChip("File Type")).toBe(true);
+  });
+
+  test("Language is multi-value", () => {
+    expect(isMultiValueChip("Language")).toBe(true);
+  });
+
+  test("Dataset is multi-value", () => {
+    expect(isMultiValueChip("Dataset")).toBe(true);
+  });
+
+  test("Workspace is multi-value", () => {
+    expect(isMultiValueChip("Workspace")).toBe(true);
+  });
+
+  test("Created After is not multi-value", () => {
+    expect(isMultiValueChip("Created After")).toBe(false);
+  });
+
+  test("Created Before is not multi-value", () => {
+    expect(isMultiValueChip("Created Before")).toBe(false);
+  });
+
+  test("workspace_folder is not multi-value", () => {
+    expect(isMultiValueChip("workspace_folder")).toBe(false);
+  });
+
+  test("unknown names are not multi-value", () => {
+    expect(isMultiValueChip("Something Random")).toBe(false);
+  });
+
+  test("empty string is not multi-value", () => {
+    expect(isMultiValueChip("")).toBe(false);
+  });
+});
+
+describe("truncateChipDisplay", () => {
+  test("returns 'all' for empty labels", () => {
+    expect(truncateChipDisplay([], 36)).toBe("all");
+  });
+
+  test("returns all labels when they fit within budget", () => {
+    expect(truncateChipDisplay(["1", "2", "3", "5"], 20)).toBe("1, 2, 3, 5");
+  });
+
+  test("returns single short label without truncation", () => {
+    expect(truncateChipDisplay(["Alpha"], 36)).toBe("Alpha");
+  });
+
+  test("truncates a single very long label with ellipsis", () => {
+    const longName =
+      "This is the workspace in which we have all the details about John Smith";
+    const result = truncateChipDisplay([longName], 36);
+    expect(result.length).toBeLessThanOrEqual(36);
+    expect(result).toContain("\u2026");
+  });
+
+  test("shows +N more when not all labels fit", () => {
+    const labels = [
+      "Alpha Workspace",
+      "Beta Workspace",
+      "Gamma Workspace",
+      "Delta Workspace",
+    ];
+    const result = truncateChipDisplay(labels, 36);
+    expect(result).toMatch(/\+\d+ more/);
+    expect(result.length).toBeLessThanOrEqual(36);
+  });
+
+  test("short labels that fit together are all shown", () => {
+    expect(truncateChipDisplay(["A", "B", "C"], 10)).toBe("A, B, C");
+  });
+
+  test("fits as many labels as possible before adding +N more", () => {
+    const result = truncateChipDisplay(["Alpha", "Beta", "Gamma", "Delta"], 20);
+    expect(result).toBe("Alpha, Beta, +2 more");
+  });
+
+  test("truncates first label when it alone exceeds budget with suffix", () => {
+    const labels = ["VeryLongWorkspaceName", "Other"];
+    const result = truncateChipDisplay(labels, 20);
+    expect(result).toMatch(/\+1 more/);
+    expect(result.length).toBeLessThanOrEqual(20);
+    expect(result).toContain("\u2026");
+  });
+
+  test("handles exactly-at-budget labels", () => {
+    expect(truncateChipDisplay(["Hello", "World"], 12)).toBe("Hello, World");
+  });
+
+  test("handles single label at exactly the budget", () => {
+    expect(truncateChipDisplay(["abc"], 3)).toBe("abc");
+  });
+});

--- a/frontend/src/js/components/Search/ActiveFilterChip.tsx
+++ b/frontend/src/js/components/Search/ActiveFilterChip.tsx
@@ -1,0 +1,447 @@
+import React, { useState, useEffect, useCallback } from "react";
+import MultiSelectDropdown from "./MultiSelectDropdown";
+import { FILE_TYPE_CATEGORIES } from "./fileTypeCategories";
+import { MIME_TYPE_OPTIONS } from "./mimeTypeOptions";
+import {
+  CHIP_KIND_SINGLE,
+  CHIP_KIND_MULTI,
+  CHIP_KIND_DATE_RANGE,
+  CHIP_TYPE_DATE,
+  CHIP_TYPE_DATE_EX,
+  CHIP_TYPE_WORKSPACE_FOLDER,
+  CHIP_NAME_MIME_TYPE,
+  CHIP_NAME_FILE_TYPE,
+} from "./chipNames";
+import type { SelectOption } from "./chipDisplayUtils";
+
+// Re-export for downstream consumers
+export { truncateChipDisplay } from "./chipDisplayUtils";
+export type { SelectOption } from "./chipDisplayUtils";
+
+export type ChipEditValue = string | string[] | { from: string; to: string };
+
+export interface ActiveFilterChipProps {
+  index: number;
+  name: string;
+  value?: string;
+  values?: string[];
+  from?: string;
+  to?: string;
+  negate: boolean;
+  chipType: string;
+  kind:
+    | typeof CHIP_KIND_SINGLE
+    | typeof CHIP_KIND_MULTI
+    | typeof CHIP_KIND_DATE_RANGE;
+  options?: SelectOption[];
+  dormant?: boolean;
+  onRemove: () => void;
+  onToggleNegate: () => void;
+  onEditValue: (newValue: ChipEditValue, negate?: boolean) => void;
+}
+
+/** Resolve the options list for a multi-value chip. */
+function resolveMultiSelectOptions(
+  name: string,
+  options: SelectOption[] | undefined,
+): SelectOption[] {
+  if (name === CHIP_NAME_MIME_TYPE) return MIME_TYPE_OPTIONS;
+  if (name === CHIP_NAME_FILE_TYPE)
+    return FILE_TYPE_CATEGORIES as SelectOption[];
+  return options || [];
+}
+
+const ActiveFilterChip: React.FC<ActiveFilterChipProps> = (props) => {
+  const {
+    name,
+    value,
+    values,
+    from,
+    to,
+    negate,
+    chipType,
+    kind,
+    options,
+    dormant,
+    onRemove,
+    onToggleNegate,
+    onEditValue,
+  } = props;
+
+  const [isEditingValue, setIsEditingValue] = useState(false);
+  const [editValue, setEditValue] = useState(value || "");
+  const [pendingValues, setPendingValues] = useState<string[]>([]);
+  const [pendingNegate, setPendingNegate] = useState(false);
+
+  useEffect(() => {
+    setEditValue(value || "");
+  }, [value]);
+
+  // --- Text editing ---
+
+  const onStartEdit = useCallback(() => {
+    setIsEditingValue(true);
+    setEditValue(value ?? "");
+  }, [value]);
+
+  const commitEdit = useCallback(() => {
+    onEditValue(editValue);
+    setIsEditingValue(false);
+  }, [editValue, onEditValue]);
+
+  const cancelEdit = useCallback(() => {
+    setIsEditingValue(false);
+    setEditValue(value || "");
+  }, [value]);
+
+  const onEditKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") commitEdit();
+      else if (e.key === "Escape") cancelEdit();
+    },
+    [commitEdit, cancelEdit],
+  );
+
+  // --- Multi-value toggle ---
+
+  const toggleMultiValue = useCallback(
+    (optionValue: string) => {
+      if (dormant) {
+        setPendingValues((current) =>
+          current.includes(optionValue)
+            ? current.filter((v) => v !== optionValue)
+            : [...current, optionValue],
+        );
+      } else {
+        const currentValues = values || [];
+        const newValues = currentValues.includes(optionValue)
+          ? currentValues.filter((v) => v !== optionValue)
+          : [...currentValues, optionValue];
+        onEditValue(newValues);
+      }
+    },
+    [dormant, values, onEditValue],
+  );
+
+  const onDropdownClose = useCallback(() => {
+    if (dormant && pendingValues.length > 0) {
+      onEditValue([...pendingValues], pendingNegate);
+      setPendingValues([]);
+      setPendingNegate(false);
+    }
+  }, [dormant, pendingValues, pendingNegate, onEditValue]);
+
+  // --- Value renderers ---
+
+  const renderTextValue = () => {
+    if (isEditingValue) {
+      return (
+        <input
+          className="active-filter-chip__value-input"
+          type="text"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onKeyDown={onEditKeyDown}
+          onBlur={commitEdit}
+          autoFocus
+          aria-label={`Edit ${name} value`}
+        />
+      );
+    }
+    return (
+      <span
+        className="active-filter-chip__value-text active-filter-chip__value-text--editable"
+        role="button"
+        tabIndex={0}
+        onClick={onStartEdit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onStartEdit();
+          }
+        }}
+        aria-label={`Edit value: ${value || "empty"}`}
+        title="Click to edit value"
+      >
+        {value || <em className="active-filter-chip__empty">empty</em>}
+      </span>
+    );
+  };
+
+  const renderDateValue = () => (
+    <input
+      className="active-filter-chip__date-input"
+      type="date"
+      value={value || ""}
+      onChange={(e) => onEditValue(e.target.value)}
+      aria-label={`${name} date`}
+      title={
+        chipType === CHIP_TYPE_DATE_EX
+          ? "Select date (exclusive)"
+          : "Select date"
+      }
+    />
+  );
+
+  const renderDateRangeValue = () => (
+    <span className="active-filter-chip__date-range">
+      <input
+        className="active-filter-chip__date-input"
+        type="date"
+        value={from || ""}
+        onChange={(e) => onEditValue({ from: e.target.value, to: to || "" })}
+        aria-label="Date range start"
+        title="From date (exclusive — documents after this date)"
+      />
+      <span className="active-filter-chip__date-range-sep" aria-hidden="true">
+        to
+      </span>
+      <input
+        className="active-filter-chip__date-input"
+        type="date"
+        value={to || ""}
+        onChange={(e) => onEditValue({ from: from || "", to: e.target.value })}
+        aria-label="Date range end"
+        title="To date (documents before this date)"
+      />
+    </span>
+  );
+
+  const renderDormantDateRange = () => (
+    <span className="active-filter-chip__date-range">
+      <span className="active-filter-chip__dormant-label">all</span>
+      <input
+        className="active-filter-chip__date-input active-filter-chip__date-input--dormant"
+        type="date"
+        value=""
+        onChange={(e) => {
+          if (e.target.value) {
+            onEditValue({ from: e.target.value, to: "" }, pendingNegate);
+          }
+        }}
+        aria-label="Pick a start date to activate this filter"
+        title="Pick a start date"
+      />
+      <span className="active-filter-chip__date-range-sep" aria-hidden="true">
+        to
+      </span>
+      <input
+        className="active-filter-chip__date-input active-filter-chip__date-input--dormant"
+        type="date"
+        value=""
+        onChange={(e) => {
+          if (e.target.value) {
+            onEditValue({ from: "", to: e.target.value }, pendingNegate);
+          }
+        }}
+        aria-label="Pick an end date to activate this filter"
+        title="Pick an end date"
+      />
+    </span>
+  );
+
+  const renderWorkspaceFolderValue = () => (
+    <span className="active-filter-chip__value-text" title={value}>
+      {value || <em className="active-filter-chip__empty">folder</em>}
+    </span>
+  );
+
+  const renderDormantSingleValue = () => {
+    if (chipType === CHIP_TYPE_DATE || chipType === CHIP_TYPE_DATE_EX) {
+      return (
+        <>
+          <span className="active-filter-chip__dormant-label">all</span>
+          <input
+            className="active-filter-chip__date-input active-filter-chip__date-input--dormant"
+            type="date"
+            value=""
+            onChange={(e) => {
+              if (e.target.value) {
+                onEditValue(e.target.value, pendingNegate);
+              }
+            }}
+            aria-label={`Pick a date for ${name}`}
+            title="Pick a date to activate this filter"
+          />
+        </>
+      );
+    }
+
+    return (
+      <span
+        className="active-filter-chip__dormant-label active-filter-chip__dormant-label--clickable"
+        role="button"
+        tabIndex={0}
+        onClick={() => setIsEditingValue(true)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setIsEditingValue(true);
+          }
+        }}
+        aria-label={`Set a value for ${name}`}
+        title="Click to set a filter value"
+      >
+        {isEditingValue ? (
+          <input
+            className="active-filter-chip__value-input"
+            type="text"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && editValue) {
+                onEditValue(editValue, pendingNegate);
+                setIsEditingValue(false);
+                setPendingNegate(false);
+              } else if (e.key === "Escape") {
+                setIsEditingValue(false);
+                setEditValue("");
+              }
+            }}
+            onBlur={() => {
+              if (editValue) {
+                onEditValue(editValue, pendingNegate);
+              }
+              setIsEditingValue(false);
+              setPendingNegate(false);
+            }}
+            autoFocus
+            aria-label={`Enter value for ${name}`}
+            placeholder="Type a value..."
+          />
+        ) : (
+          "all"
+        )}
+      </span>
+    );
+  };
+
+  const renderValueEditor = () => {
+    switch (kind) {
+      case CHIP_KIND_DATE_RANGE:
+        return dormant ? renderDormantDateRange() : renderDateRangeValue();
+
+      case CHIP_KIND_MULTI:
+        return (
+          <MultiSelectDropdown
+            name={name}
+            options={resolveMultiSelectOptions(name, options)}
+            values={values}
+            pendingValues={pendingValues}
+            dormant={dormant}
+            onToggleValue={toggleMultiValue}
+            onClose={onDropdownClose}
+          />
+        );
+
+      case CHIP_KIND_SINGLE:
+      default:
+        if (dormant) return renderDormantSingleValue();
+        switch (chipType) {
+          case CHIP_TYPE_DATE:
+          case CHIP_TYPE_DATE_EX:
+            return renderDateValue();
+          case CHIP_TYPE_WORKSPACE_FOLDER:
+            return renderWorkspaceFolderValue();
+          default:
+            return renderTextValue();
+        }
+    }
+  };
+
+  // --- Render ---
+
+  const isDormant = !!dormant;
+  const isWorkspaceFolder = chipType === CHIP_TYPE_WORKSPACE_FOLDER;
+  const hasPending =
+    isDormant && kind === CHIP_KIND_MULTI && pendingValues.length > 0;
+  const effectiveNegate = isDormant ? pendingNegate : negate;
+
+  const chipClassName = [
+    "active-filter-chip",
+    effectiveNegate ? "active-filter-chip--negate" : "",
+    isDormant && !hasPending ? "active-filter-chip--dormant" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const negateInert = (isDormant && !hasPending) || isWorkspaceFolder;
+
+  return (
+    <span
+      className={chipClassName}
+      role="group"
+      aria-label={`${effectiveNegate ? "Exclude" : "Include"} ${name} filter${isDormant && !hasPending ? " (inactive)" : ""}`}
+    >
+      <button
+        className={[
+          "active-filter-chip__negate-btn",
+          negateInert ? "active-filter-chip__negate-btn--inert" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        onClick={
+          negateInert
+            ? undefined
+            : isDormant
+              ? () => setPendingNegate((prev) => !prev)
+              : onToggleNegate
+        }
+        aria-label={
+          negateInert
+            ? isWorkspaceFolder
+              ? "Including (scope filter)"
+              : "Including"
+            : effectiveNegate
+              ? "Excluding — click to include"
+              : "Including — click to exclude"
+        }
+        aria-pressed={effectiveNegate}
+        title={
+          negateInert
+            ? isWorkspaceFolder
+              ? "Including (scope filter)"
+              : "Including"
+            : effectiveNegate
+              ? "Excluding (click to include)"
+              : "Including (click to exclude)"
+        }
+      >
+        <div className="active-filter-chip__button-icon" aria-hidden="true">
+          {negateInert ? "+" : effectiveNegate ? "−" : "+"}
+        </div>
+      </button>
+
+      <span className="active-filter-chip__body">
+        <span className="active-filter-chip__name">{name}</span>
+        <span className="active-filter-chip__value">{renderValueEditor()}</span>
+      </span>
+
+      {isDormant && !hasPending ? (
+        <span className="active-filter-chip__end-cap" aria-hidden="true" />
+      ) : (
+        <button
+          className="active-filter-chip__remove-btn"
+          onClick={
+            isDormant
+              ? () => {
+                  setPendingValues([]);
+                  setPendingNegate(false);
+                }
+              : onRemove
+          }
+          aria-label={
+            hasPending ? `Clear ${name} selections` : `Remove ${name} filter`
+          }
+          title={hasPending ? "Clear selections" : "Remove filter"}
+        >
+          <div className="active-filter-chip__button-icon" aria-hidden="true">
+            ×
+          </div>
+        </button>
+      )}
+    </span>
+  );
+};
+
+export default ActiveFilterChip;

--- a/frontend/src/js/components/Search/ActiveFiltersBar.tsx
+++ b/frontend/src/js/components/Search/ActiveFiltersBar.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import ActiveFilterChip, { ChipEditValue } from "./ActiveFilterChip";
+import AddIcon from "react-icons/lib/md/add";
+import { Chip, SuggestedField } from "./chipParsing";
+import {
+  CHIP_NAME_FILE_TYPE,
+  CHIP_NAME_DATE_RANGE,
+  CHIP_NAME_DATASET,
+  CHIP_NAME_WORKSPACE,
+  CHIP_KIND_MULTI,
+  CHIP_KIND_DATE_RANGE,
+  CHIP_TYPE_FILE_TYPE,
+  CHIP_TYPE_DATE_RANGE,
+  CHIP_TYPE_DATASET,
+  CHIP_TYPE_WORKSPACE,
+} from "./chipNames";
+
+interface ActiveFiltersBarProps {
+  chips: Chip[];
+  availableFilters?: SuggestedField[];
+  onRemoveChip: (index: number) => void;
+  onToggleNegate: (index: number) => void;
+  onEditChipValue: (index: number, newValue: ChipEditValue) => void;
+  onActivateDefault: (
+    name: string,
+    value: ChipEditValue,
+    chipType: string,
+    negate?: boolean,
+  ) => void;
+  onOpenAddFilter: (chip?: Chip, index?: number) => void;
+}
+
+/**
+ * Default filter chips shown when no filters are active.
+ * These act as prompts — showing users what filters are available.
+ * Each maps to a chip type with sensible defaults.
+ */
+const DEFAULT_FILTERS = [
+  {
+    name: CHIP_NAME_DATASET,
+    chipType: CHIP_TYPE_DATASET,
+    label: CHIP_NAME_DATASET,
+    kind: CHIP_KIND_MULTI,
+  },
+  {
+    name: CHIP_NAME_WORKSPACE,
+    chipType: CHIP_TYPE_WORKSPACE,
+    label: CHIP_NAME_WORKSPACE,
+    kind: CHIP_KIND_MULTI,
+  },
+  {
+    name: CHIP_NAME_DATE_RANGE,
+    chipType: CHIP_TYPE_DATE_RANGE,
+    label: CHIP_NAME_DATE_RANGE,
+    kind: CHIP_KIND_DATE_RANGE,
+  },
+  {
+    name: CHIP_NAME_FILE_TYPE,
+    chipType: CHIP_TYPE_FILE_TYPE,
+    label: CHIP_NAME_FILE_TYPE,
+    kind: CHIP_KIND_MULTI,
+  },
+] as const;
+
+function normaliseOptions(
+  options: string[] | { value: string; label: string }[] | undefined,
+) {
+  if (!options) return undefined;
+  return options.map((o) =>
+    typeof o === "string" ? { value: o, label: o } : o,
+  );
+}
+
+/**
+ * Renders filter chips below the search box.
+ *
+ * When the user has active filters, those are shown.
+ * When no filters are active, default "dormant" chips are shown
+ * as prompts (e.g. "File Types: all") that the user can click to activate.
+ */
+const ActiveFiltersBar: React.FC<ActiveFiltersBarProps> = ({
+  chips,
+  availableFilters,
+  onRemoveChip,
+  onToggleNegate,
+  onEditChipValue,
+  onActivateDefault,
+  onOpenAddFilter,
+}) => {
+  const moreFiltersButton = (
+    <button
+      className="active-filters-bar__add-btn"
+      onClick={() => onOpenAddFilter()}
+      title="Add a filter"
+      aria-label="Add a filter"
+    >
+      <AddIcon className="active-filters-bar__add-icon" />
+      More filters
+    </button>
+  );
+
+  const renderDefaultChip = (def: (typeof DEFAULT_FILTERS)[number]) => {
+    const fieldDef = (availableFilters || []).find((f) => f.name === def.name);
+    return (
+      <ActiveFilterChip
+        key={`default-${def.name}`}
+        index={-1}
+        name={def.label}
+        value={def.kind === CHIP_KIND_MULTI ? undefined : "all"}
+        values={def.kind === CHIP_KIND_MULTI ? [] : undefined}
+        kind={def.kind}
+        negate={false}
+        chipType={def.chipType}
+        options={normaliseOptions(fieldDef ? fieldDef.options : undefined)}
+        dormant
+        onRemove={() => {}}
+        onToggleNegate={() => {}}
+        onEditValue={(newValue, negate) =>
+          onActivateDefault(def.name, newValue, def.chipType, negate)
+        }
+      />
+    );
+  };
+
+  if (chips.length > 0) {
+    const activeNames = new Set(chips.map((c) => c.name));
+    const remainingDefaults = DEFAULT_FILTERS.filter(
+      (d) => !activeNames.has(d.name),
+    );
+
+    return (
+      <div
+        className="active-filters-bar"
+        role="toolbar"
+        aria-label="Active search filters"
+      >
+        {chips.map((chip, index) => {
+          const rawOptions =
+            ("options" in chip ? chip.options : undefined) ||
+            (availableFilters || []).find((f) => f.name === chip.name)?.options;
+          const chipOptions = normaliseOptions(rawOptions);
+          return (
+            <ActiveFilterChip
+              key={`active-${index}`}
+              index={index}
+              name={chip.name}
+              value={"value" in chip ? chip.value : undefined}
+              values={"values" in chip ? chip.values : undefined}
+              from={"from" in chip ? chip.from : undefined}
+              to={"to" in chip ? chip.to : undefined}
+              kind={chip.kind}
+              negate={chip.negate}
+              chipType={chip.chipType}
+              options={chipOptions}
+              onRemove={() => onRemoveChip(index)}
+              onToggleNegate={() => onToggleNegate(index)}
+              onEditValue={(newValue) => onEditChipValue(index, newValue)}
+            />
+          );
+        })}
+        {remainingDefaults.map(renderDefaultChip)}
+        {moreFiltersButton}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="active-filters-bar"
+      role="toolbar"
+      aria-label="Search filters"
+    >
+      {DEFAULT_FILTERS.map(renderDefaultChip)}
+      {moreFiltersButton}
+    </div>
+  );
+};
+
+export default ActiveFiltersBar;

--- a/frontend/src/js/components/Search/MultiSelectDropdown.tsx
+++ b/frontend/src/js/components/Search/MultiSelectDropdown.tsx
@@ -1,0 +1,166 @@
+import React, { useRef, useCallback } from "react";
+import { useSelect } from "downshift";
+import {
+  SelectOption,
+  getDisplayLabel,
+  truncateChipDisplay,
+  MAX_DISPLAY_CHARS,
+} from "./chipDisplayUtils";
+
+interface MultiSelectDropdownProps {
+  name: string;
+  options: SelectOption[];
+  /** Currently committed values (used when the chip is active) */
+  values?: string[];
+  /** Locally accumulated values (used when the chip is dormant) */
+  pendingValues: string[];
+  dormant?: boolean;
+  onToggleValue: (value: string) => void;
+  onClose: () => void;
+}
+
+/**
+ * Multi-select dropdown for filter chips, powered by Downshift's useSelect
+ * hook which handles keyboard navigation, ARIA attributes, and focus
+ * management automatically.
+ */
+const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
+  name,
+  options,
+  values,
+  pendingValues,
+  dormant,
+  onToggleValue,
+  onClose,
+}) => {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const selectedValues = dormant ? pendingValues : values || [];
+
+  const displayText =
+    selectedValues.length === 0
+      ? "all"
+      : truncateChipDisplay(
+          selectedValues.map((v) => getDisplayLabel(v, options)),
+          MAX_DISPLAY_CHARS,
+        );
+
+  const handleSelectedItemChange = useCallback(
+    ({ selectedItem }: { selectedItem: SelectOption | null | undefined }) => {
+      if (selectedItem) {
+        onToggleValue(selectedItem.value);
+      }
+    },
+    [onToggleValue],
+  );
+
+  const {
+    isOpen,
+    getToggleButtonProps,
+    getMenuProps,
+    getItemProps,
+    highlightedIndex,
+  } = useSelect({
+    items: options,
+    // Keep the menu open after selection (multi-select behaviour).
+    // Downshift calls stateReducer on every state change, so we intercept
+    // the item-click and keydown-enter actions to prevent auto-close.
+    stateReducer: (_state, actionAndChanges) => {
+      const { changes, type } = actionAndChanges;
+      switch (type) {
+        case useSelect.stateChangeTypes.ItemClick:
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownEnter:
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownSpaceButton:
+          return { ...changes, isOpen: true };
+        default:
+          return changes;
+      }
+    },
+    onSelectedItemChange: handleSelectedItemChange,
+    itemToString: (item) => item?.label ?? "",
+  });
+
+  // Notify parent when the dropdown closes (for dormant chip commit)
+  const prevOpenRef = useRef(isOpen);
+  React.useEffect(() => {
+    if (prevOpenRef.current && !isOpen) {
+      onClose();
+    }
+    prevOpenRef.current = isOpen;
+  }, [isOpen, onClose]);
+
+  const dropdownId = `multi-select-dropdown-${name.replace(/\s+/g, "-").toLowerCase()}`;
+
+  return (
+    <span className="active-filter-chip__multi-select">
+      <button
+        {...getToggleButtonProps({
+          ref: triggerRef,
+          className: "active-filter-chip__multi-select-trigger",
+          "aria-label": `${name}: ${displayText}. Click to ${isOpen ? "close" : "open"} options`,
+          title: "Click to select values",
+        })}
+      >
+        <span aria-hidden="true">{displayText}</span>
+        <span
+          className="active-filter-chip__multi-select-arrow"
+          aria-hidden="true"
+        >
+          ▾
+        </span>
+      </button>
+      <ul
+        {...getMenuProps({
+          id: dropdownId,
+          className: `active-filter-chip__multi-select-dropdown${isOpen ? "" : " active-filter-chip__multi-select-dropdown--hidden"}`,
+        })}
+      >
+        {isOpen &&
+          options.map((opt, idx) => {
+            const isSelected = selectedValues.includes(opt.value);
+            const isFocused = highlightedIndex === idx;
+            return (
+              <li
+                key={opt.value}
+                {...getItemProps({
+                  item: opt,
+                  index: idx,
+                  className: [
+                    "active-filter-chip__multi-select-option",
+                    isFocused
+                      ? "active-filter-chip__multi-select-option--focused"
+                      : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" "),
+                  "aria-selected": isSelected,
+                })}
+              >
+                <input
+                  type="checkbox"
+                  checked={isSelected}
+                  readOnly
+                  tabIndex={-1}
+                  aria-hidden="true"
+                />
+                <span className="active-filter-chip__multi-select-option-label">
+                  {opt.label}
+                </span>
+              </li>
+            );
+          })}
+        {isOpen && options.length === 0 && (
+          <li
+            className="active-filter-chip__multi-select-empty"
+            role="option"
+            aria-selected={false}
+            aria-disabled="true"
+          >
+            No options available
+          </li>
+        )}
+      </ul>
+    </span>
+  );
+};
+
+export default MultiSelectDropdown;

--- a/frontend/src/js/components/Search/chipParsing.ts
+++ b/frontend/src/js/components/Search/chipParsing.ts
@@ -29,7 +29,7 @@ export interface SingleChip {
   value: string;
   negate: boolean;
   chipType: string;
-  options?: string[];
+  options?: string[] | { value: string; label: string }[];
   workspaceId?: string;
   folderId?: string;
 }
@@ -40,7 +40,7 @@ export interface MultiChip {
   values: string[];
   negate: boolean;
   chipType: string;
-  options?: string[];
+  options?: string[] | { value: string; label: string }[];
 }
 
 export interface DateRangeChip {
@@ -76,10 +76,10 @@ function isRawChip(el: unknown): el is RawChip {
   );
 }
 
-interface SuggestedField {
+export interface SuggestedField {
   name: string;
   type?: string;
-  options?: string[];
+  options?: string[] | { value: string; label: string }[];
 }
 
 export interface PolarityValues {

--- a/frontend/src/js/components/Search/mimeTypeOptions.ts
+++ b/frontend/src/js/components/Search/mimeTypeOptions.ts
@@ -1,0 +1,33 @@
+import { SelectOption } from "./chipDisplayUtils";
+
+/** Well-known MIME type options with friendly labels for the multi-select dropdown */
+export const MIME_TYPE_OPTIONS: SelectOption[] = [
+  { value: "application/pdf", label: "PDF" },
+  { value: "text/plain", label: "Plain Text" },
+  { value: "text/html", label: "HTML" },
+  { value: "text/csv", label: "CSV" },
+  { value: "image/jpeg", label: "JPEG Image" },
+  { value: "image/png", label: "PNG Image" },
+  { value: "image/tiff", label: "TIFF Image" },
+  { value: "application/msword", label: "Word (.doc)" },
+  {
+    value:
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    label: "Word (.docx)",
+  },
+  { value: "application/vnd.ms-excel", label: "Excel (.xls)" },
+  {
+    value: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    label: "Excel (.xlsx)",
+  },
+  { value: "application/vnd.ms-powerpoint", label: "PowerPoint (.ppt)" },
+  {
+    value:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    label: "PowerPoint (.pptx)",
+  },
+  { value: "message/rfc822", label: "Email (.eml)" },
+  { value: "application/zip", label: "ZIP Archive" },
+  { value: "audio/mpeg", label: "MP3 Audio" },
+  { value: "video/mp4", label: "MP4 Video" },
+];

--- a/frontend/src/stylesheets/components/_active-filters.scss
+++ b/frontend/src/stylesheets/components/_active-filters.scss
@@ -1,0 +1,474 @@
+// Active filters bar — shown below the search box
+// Displays committed filter chips with type-appropriate value editors
+
+.active-filters-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: calc($baseSpacing / 2);
+  margin-bottom: $baseSpacing;
+
+  &__add-btn {
+    display: inline-flex;
+    align-items: center;
+    align-self: stretch;
+    gap: 4px;
+    background: none;
+    border: 1px dashed rgba($primary, 0.4);
+    border-radius: $borderRadiusLarge;
+    color: $primary;
+    font-size: 13px;
+    padding: 0 12px 0 8px;
+    cursor: pointer;
+    transition:
+      border-color 0.15s ease,
+      color 0.15s ease;
+
+    &:hover {
+      border-color: $primary;
+      color: $primaryDark;
+    }
+  }
+
+  &__add-icon {
+    font-size: 16px;
+  }
+}
+
+// Individual active filter chip
+// Segmented visual style matching InputSupper chips:
+// [+/−] 2px [Name: value] 2px [×] — three separate $primaryDark blocks
+.active-filter-chip {
+  display: inline-block;
+  width: fit-content;
+  color: white;
+  font-size: 16px;
+  overflow: visible;
+  position: relative;
+
+  // Shared button style (negate + remove)
+  & > button {
+    display: inline-flex;
+    height: 100%;
+    width: 26px;
+    border: none;
+    padding: 0;
+    flex-direction: row;
+    justify-content: center;
+    vertical-align: top;
+    color: white;
+    cursor: pointer;
+    font-size: 16px;
+
+    &:focus-visible {
+      outline: 2px solid white;
+      outline-offset: -2px;
+    }
+  }
+
+  &__button-icon {
+    align-self: center;
+  }
+
+  // +/- toggle button — left segment with left-rounded corners
+  &__negate-btn {
+    border-radius: $borderRadiusLarge 0 0 $borderRadiusLarge;
+    background-color: $primaryDark;
+
+    &:hover {
+      background: lighten($primaryDark, 10%);
+    }
+  }
+
+  &--negate &__negate-btn {
+    background-color: $excludeColour;
+
+    &:hover {
+      background: darken($excludeColour, 8%);
+    }
+  }
+
+  // Inert negate button on dormant chips — looks present but not interactive
+  &__negate-btn--inert {
+    cursor: default;
+
+    &:hover {
+      background-color: $primaryDark;
+    }
+  }
+
+  // Body — middle segment containing name + value
+  // Separated from negate and remove by 2px margins
+  &__body {
+    display: inline-flex;
+    align-items: center;
+    height: 100%;
+    margin-left: 2px;
+    margin-right: 2px;
+    padding: 0 5px;
+    font-size: 13px;
+    background-color: $primaryDark;
+
+    &:hover {
+      background: lighten($primaryDark, 10%);
+    }
+  }
+
+  &--negate &__body {
+    background-color: $excludeColour;
+
+    &:hover {
+      background: darken($excludeColour, 8%);
+    }
+  }
+
+  // Filter name — with colon via ::after (matches InputSupper)
+  &__name {
+    margin-right: 2px;
+    font-size: 13px;
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    user-select: none;
+
+    &::after {
+      content: ":";
+    }
+  }
+
+  // Value area — contains the type-appropriate editor
+  &__value {
+    display: inline-flex;
+    align-items: center;
+    max-width: 300px;
+  }
+
+  // Click-to-edit text display
+  &__value-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 4px 2px;
+
+    &--editable {
+      cursor: pointer;
+
+      &:focus-visible {
+        outline: 2px solid white;
+        outline-offset: 1px;
+        border-radius: 2px;
+      }
+    }
+  }
+
+  // Free text input (for text chips and mime type combobox)
+  &__value-input {
+    background: rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 3px;
+    color: white;
+    font-size: 16px;
+    padding: 2px 4px;
+    width: 140px;
+    outline: none;
+
+    &:focus {
+      border-color: white;
+      background: rgba(255, 255, 255, 0.3);
+    }
+
+    &--wide {
+      width: 220px;
+    }
+
+    &::placeholder {
+      color: rgba(255, 255, 255, 0.5);
+    }
+  }
+
+  // Native date input
+  &__date-input {
+    background: none;
+    border: none;
+    border-radius: 0;
+    color: white;
+    font-size: 13px;
+    padding: 3px 4px;
+    outline: none;
+    color-scheme: dark;
+
+    &::-webkit-datetime-edit {
+      padding: 0;
+      margin: 0;
+      line-height: 1;
+    }
+
+    &::-webkit-calendar-picker-indicator {
+      margin-left: 1px;
+    }
+
+    &:not(:valid)::-webkit-datetime-edit {
+      color: transparent;
+      user-select: none;
+      width: 0;
+    }
+
+    &:focus {
+      background: rgba(255, 255, 255, 0.15);
+      border-radius: 3px;
+    }
+  }
+
+  // Compound date range: two date inputs with a separator
+  &__date-range {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  &__date-range-sep {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 13px;
+    padding: 0 2px;
+    user-select: none;
+  }
+
+  // Select dropdown (for dropdown-type chips like "Has Field")
+  &__select {
+    background: rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 3px;
+    color: white;
+    font-size: 13px;
+    padding: 2px 4px;
+    outline: none;
+    cursor: pointer;
+
+    option {
+      background: $primaryDark;
+      color: white;
+    }
+
+    &:focus {
+      border-color: white;
+      background: rgba(255, 255, 255, 0.3);
+    }
+  }
+
+  &__empty {
+    opacity: 0.5;
+    font-style: italic;
+  }
+
+  // × remove button — right segment with right-rounded corners
+  &__remove-btn {
+    border-radius: 0 $borderRadiusLarge $borderRadiusLarge 0;
+    background-color: $primaryDark;
+
+    &:hover {
+      background: lighten($primaryDark, 10%);
+    }
+  }
+
+  &--negate &__remove-btn {
+    background-color: $excludeColour;
+
+    &:hover {
+      background: darken($excludeColour, 8%);
+    }
+  }
+
+  // Right end-cap — visual bookend on dormant chips (same size as remove button, no icon)
+  &__end-cap {
+    display: inline-flex;
+    width: 26px;
+    height: 100%;
+    vertical-align: top;
+    border-radius: 0 $borderRadiusLarge $borderRadiusLarge 0;
+    background-color: $primaryDark;
+  }
+
+  &--negate &__end-cap {
+    background-color: $excludeColour;
+  }
+
+  // --- Dormant (default / placeholder) chip variant ---
+  &--dormant {
+    opacity: 0.75;
+    transition:
+      opacity 0.15s ease,
+      box-shadow 0.15s ease;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    .active-filter-chip__body {
+      background-color: $filterInactiveColour;
+
+      &:hover {
+        background: darken($filterInactiveColour, 5%);
+      }
+    }
+
+    .active-filter-chip__negate-btn {
+      background-color: $filterInactiveColour;
+    }
+
+    .active-filter-chip__negate-btn--inert:hover {
+      background-color: $filterInactiveColour;
+    }
+
+    .active-filter-chip__end-cap {
+      background-color: $filterInactiveColour;
+    }
+
+    .active-filter-chip__name {
+      font-weight: 500;
+    }
+  }
+
+  &__dormant-label {
+    padding: 4px 2px;
+    font-style: italic;
+    opacity: 0.7;
+
+    &--clickable {
+      cursor: pointer;
+
+      &:hover {
+        opacity: 1;
+      }
+
+      &:focus-visible {
+        outline: 2px solid white;
+        outline-offset: 1px;
+        border-radius: 2px;
+      }
+    }
+  }
+
+  // Dormant date input — looks like a subtle pick button
+  &__date-input--dormant {
+    width: 26px;
+    opacity: 0.5;
+    cursor: pointer;
+    margin-left: 4px;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  // Dormant select — styled as a subtle trigger
+  &__select--dormant {
+    background: transparent;
+    border-color: rgba(255, 255, 255, 0.3);
+    opacity: 0.8;
+
+    &:hover {
+      opacity: 1;
+      border-color: rgba(255, 255, 255, 0.5);
+    }
+  }
+
+  // --- Multi-select checkbox dropdown ---
+
+  &__multi-select {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  &__multi-select-trigger {
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 2px;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    white-space: nowrap;
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &:focus-visible {
+      outline: 2px solid white;
+      outline-offset: 1px;
+      border-radius: 2px;
+    }
+  }
+
+  &__multi-select-arrow {
+    font-size: 16px;
+    opacity: 0.7;
+    flex-shrink: 0;
+  }
+
+  &__multi-select-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 100;
+    min-width: 200px;
+    max-height: 280px;
+    overflow-y: auto;
+    background: $primaryDark;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    padding: 4px 0;
+    list-style: none;
+    margin: 0;
+
+    &:focus {
+      outline: none;
+    }
+
+    // Downshift keeps the <ul> in the DOM for ARIA; hide when closed
+    &--hidden {
+      display: none;
+    }
+  }
+
+  &__multi-select-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: 14px;
+    white-space: nowrap;
+
+    &:hover,
+    &--focused {
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    &--focused {
+      outline: 2px solid rgba(255, 255, 255, 0.6);
+      outline-offset: -2px;
+    }
+
+    input[type="checkbox"] {
+      accent-color: white;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+  }
+
+  &__multi-select-option-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__multi-select-empty {
+    padding: 8px 12px;
+    font-style: italic;
+    opacity: 0.5;
+  }
+}

--- a/frontend/src/stylesheets/main.scss
+++ b/frontend/src/stylesheets/main.scss
@@ -21,4 +21,5 @@
   "./components/workspace", "./components/file-browser",
   "./components/lazy-tree-browser", "./components/modal-action",
   "./components/users", "./components/page", "./components/upload-files",
-  "./components/markdown-page", "./components/docs-sidebar";
+  "./components/markdown-page", "./components/docs-sidebar",
+  "./components/active-filters";

--- a/frontend/src/stylesheets/main.scss
+++ b/frontend/src/stylesheets/main.scss
@@ -22,4 +22,4 @@
   "./components/lazy-tree-browser", "./components/modal-action",
   "./components/users", "./components/page", "./components/upload-files",
   "./components/markdown-page", "./components/docs-sidebar",
-  "./components/sidebar-comments";
+  "./components/sidebar-comments", "./components/active-filters";


### PR DESCRIPTION
## Context

Part of the [Search UX Improvements](https://github.com/guardian/giant/issues/633) epic. Closes [#636](https://github.com/guardian/giant/issues/636).

> [!IMPORTANT]
> This is the third of five PRs in the [Search UX Improvements](https://github.com/guardian/giant/issues/633) epic.
>
> ```
> PR1 Chip parsing infrastructure
>  └─ PR2 Shared utilities & Downshift dependency
>      └─ PR3 Active filter chips & multi-select  ← you are here
>          └─ PR4 Search page & AddFilterModal
>              └─ PR5 Sidebar tri-state filters
> ```

## Changes to the user experience

No visible changes yet — these components are built but not wired into the search page until PR4.

## What's included

- **ActiveFilterChip** (`ActiveFilterChip.tsx`) — interactive pill component supporting three chip kinds (single-value, multi-value, date-range), with in-place text editing, negate toggling, dormant/active states, and a multi-select dropdown for multi-value chips.
- **ActiveFiltersBar** (`ActiveFiltersBar.tsx`) — container that renders active chips or dormant defaults (Dataset, Workspace, Date Range, File Type) with a "More filters" button.
- **MultiSelectDropdown** (`MultiSelectDropdown.tsx`) — Downshift-powered multi-select dropdown with keyboard navigation, ARIA attributes, and keep-open-on-select behaviour.
- **MIME type options** (`mimeTypeOptions.ts`) — 17 MIME type options with friendly labels (PDF, Word, Excel, Email, etc.).
- **SCSS** (`_active-filters.scss`) — styling for chips and the filter bar.

### Automated tests

- `ActiveFilterChip.spec.ts` — tests for `isMultiValueChip` (6 positive cases, 3 negative cases) and `truncateChipDisplay` utility.

### Manual tests

No visible changes to test.