### PR TITLE
Use EUI tooltip for web capture items to prevent oversized drag ghost images

### DIFF
--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -78,9 +78,9 @@ import {
   EuiLoadingSpinner,
   EuiProgress,
   EuiText,
+  EuiToolTip,
 } from "@elastic/eui";
 import MdGlobeIcon from "react-icons/lib/md/public";
-import ReactTooltip from "react-tooltip";
 import { FromNowDurationText } from "../UtilComponents/FromNowDurationText";
 
 type Props = ReturnType<typeof mapStateToProps> &
@@ -271,21 +271,21 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
           <React.Fragment>
             {this.renderIcon(entry)}
             {entry.data.maybeCapturedFromURL && (
-              <>
-                <span data-tip>
-                  <MdGlobeIcon
-                    className="file-upload__icon"
-                    style={{ color: "grey", marginLeft: "5px" }}
-                  />
-                </span>
-                <ReactTooltip place="left">
+              <EuiToolTip
+                position="left"
+                content={
                   <div style={{ textAlign: "center" }}>
                     <strong>Captured from URL</strong>
                     <br />
                     {entry.data.maybeCapturedFromURL}
                   </div>
-                </ReactTooltip>
-              </>
+                }
+              >
+                <MdGlobeIcon
+                  className="file-upload__icon"
+                  style={{ color: "grey", marginLeft: "5px" }}
+                />
+              </EuiToolTip>
             )}
             <ItemName
               canEdit={canEdit}


### PR DESCRIPTION
Fixes #666 

When dragging web capture files or folders in a workspace, the drag ghost image appeared to include surrounding rows, making it look like multiple items were being moved:


<img src="https://github.com/user-attachments/assets/86f1bbb3-7cb6-46b8-a383-aee800c92b78" width="500" /> 


### Cause

The `ReactTooltip` (v4) component used for the "Captured from URL" globe icon rendered its tooltip DOM inline within the `<tr>` subtree. When the browser generates a drag ghost image for a `draggable` element, it captures the entire subtree — including the tooltip's positioned div — making the ghost appear oversized and encompass neighbouring rows.

This only affected web capture items because they were the only rows with an inline `ReactTooltip`.

### Fix

Replaced `ReactTooltip` with `EuiToolTip` (already used elsewhere in the project), which renders via a portal to `document.body`. This keeps the tooltip outside the row's DOM subtree, producing a correctly-sized drag ghost.

| Before        | After           | 
| ------------- |:-------------:| 
|  <img src="https://github.com/user-attachments/assets/6f9efaef-3e6b-4228-befa-d0bf3fbf8d22" width="350" />  | <img src="https://github.com/user-attachments/assets/b2e4477a-c3b6-4d0b-ad12-20ef930d9b64" width="350" /> |
| <img src="https://github.com/user-attachments/assets/b2c35f33-d667-4f6b-8fa0-bc17dbb40240" width="350" /> | <img src="https://github.com/user-attachments/assets/31bf8d79-b2bf-49e1-82cc-6d55688e902f" width="350" /> |

The icon, tooltip content, and all other behaviour are unchanged.

- [x] Local
- [x] Playground 