### PR TITLE
Document viewer nav #2 PR: shared footer component for all document types

### DIFF
--- a/frontend/src/js/components/PageViewer/SearchStepper.module.css
+++ b/frontend/src/js/components/PageViewer/SearchStepper.module.css
@@ -1,0 +1,42 @@
+.container {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(0, 0, 0, 0.75);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.query {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.8;
+}
+
+.count {
+  font-variant-numeric: tabular-nums;
+}
+
+.navButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: white;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.navButton:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}

--- a/frontend/src/js/components/PageViewer/SearchStepper.tsx
+++ b/frontend/src/js/components/PageViewer/SearchStepper.tsx
@@ -1,0 +1,69 @@
+import React, { FC } from "react";
+import ChevronLeft from "react-icons/lib/fa/chevron-left";
+import ChevronRight from "react-icons/lib/fa/chevron-right";
+import styles from "./SearchStepper.module.css";
+
+function formatQuery(raw: string): string {
+  try {
+    const parts = JSON.parse(raw);
+    if (!Array.isArray(parts)) return raw;
+    return parts
+      .map((part: unknown) => {
+        if (typeof part === "string") return part;
+        if (part && typeof part === "object" && "n" in part) {
+          const chip = part as { n: string; v: string; op?: string };
+          const prefix = chip.op === "-" ? "-" : "";
+          return `${prefix}${chip.n}: ${chip.v}`;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join(" ");
+  } catch {
+    return raw;
+  }
+}
+
+type SearchStepperProps = {
+  query: string;
+  current: number | undefined;
+  total: number;
+  isPending?: boolean;
+  onNext: () => void;
+  onPrevious: () => void;
+};
+
+export const SearchStepper: FC<SearchStepperProps> = ({
+  query,
+  current,
+  total,
+  isPending,
+  onNext,
+  onPrevious,
+}) => {
+  if (!query || (total === 0 && !isPending)) {
+    return null;
+  }
+
+  const displayQuery = formatQuery(query);
+
+  const countText =
+    current !== undefined ? `${current + 1} of ${total}` : `${total} results`;
+
+  return (
+    <div className={styles.container}>
+      <span className={styles.query}>{displayQuery}</span>
+      <span className={styles.count}>{isPending ? "..." : countText}</span>
+      <button
+        className={styles.navButton}
+        onClick={onPrevious}
+        title="Previous match"
+      >
+        <ChevronLeft />
+      </button>
+      <button className={styles.navButton} onClick={onNext} title="Next match">
+        <ChevronRight />
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/js/components/PageViewer/SearchStepper.tsx
+++ b/frontend/src/js/components/PageViewer/SearchStepper.tsx
@@ -2,7 +2,9 @@ import React, { FC } from "react";
 import ChevronLeft from "react-icons/lib/fa/chevron-left";
 import ChevronRight from "react-icons/lib/fa/chevron-right";
 import styles from "./SearchStepper.module.css";
+import { SearchHighlightStepper } from "../viewer/useSearchHighlightStepper";
 
+// unfortunately in GiantState q is just a string so we have to do all this to tease out the type and format it nicely
 function formatQuery(raw: string): string {
   try {
     const parts = JSON.parse(raw);
@@ -17,7 +19,6 @@ function formatQuery(raw: string): string {
         }
         return "";
       })
-      .filter(Boolean)
       .join(" ");
   } catch {
     return raw;
@@ -25,30 +26,26 @@ function formatQuery(raw: string): string {
 }
 
 type SearchStepperProps = {
-  query: string;
-  current: number | undefined;
-  total: number;
+  highlightStepper: SearchHighlightStepper;
   isPending?: boolean;
-  onNext: () => void;
-  onPrevious: () => void;
 };
 
 export const SearchStepper: FC<SearchStepperProps> = ({
-  query,
-  current,
-  total,
+  highlightStepper,
   isPending,
-  onNext,
-  onPrevious,
 }) => {
-  if (!query || (total === 0 && !isPending)) {
+  const { query, currentHighlight, totalHighlights, next, previous } =
+    highlightStepper;
+  if (!query || (totalHighlights === 0 && !isPending)) {
     return null;
   }
 
   const displayQuery = formatQuery(query);
 
   const countText =
-    current !== undefined ? `${current + 1} of ${total}` : `${total} results`;
+    currentHighlight !== undefined
+      ? `${currentHighlight + 1} of ${totalHighlights}`
+      : `${totalHighlights} results`;
 
   return (
     <div className={styles.container}>
@@ -56,12 +53,12 @@ export const SearchStepper: FC<SearchStepperProps> = ({
       <span className={styles.count}>{isPending ? "..." : countText}</span>
       <button
         className={styles.navButton}
-        onClick={onPrevious}
+        onClick={previous}
         title="Previous match"
       >
         <ChevronLeft />
       </button>
-      <button className={styles.navButton} onClick={onNext} title="Next match">
+      <button className={styles.navButton} onClick={next} title="Next match">
         <ChevronRight />
       </button>
     </div>

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -100,6 +100,30 @@ type PageCountResponse = {
   dimensions: PageDimensions | null;
 };
 
+const SearchStepperOverlay: FC<{
+  highlightStepper: ReturnType<typeof useSearchHighlightStepper>;
+}> = ({ highlightStepper }) => (
+  <>
+    <KeyboardShortcut
+      shortcut={keyboardShortcuts.previousHighlight}
+      func={highlightStepper.previous}
+    />
+    <KeyboardShortcut
+      shortcut={keyboardShortcuts.nextHighlight}
+      func={highlightStepper.next}
+    />
+    <div className="search-stepper-overlay">
+      <SearchStepper
+        query={highlightStepper.query}
+        current={highlightStepper.currentHighlight}
+        total={highlightStepper.totalHighlights}
+        onNext={highlightStepper.next}
+        onPrevious={highlightStepper.previous}
+      />
+    </div>
+  </>
+);
+
 export const PageViewerOrFallback: FC<{}> = () => {
   const { uri } = useParams<{ uri: string }>();
   const searchParams = new URLSearchParams(window.location.search);
@@ -163,23 +187,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
   } else if (response.pageCount === 0) {
     return (
       <div style={{ position: "relative" }}>
-        <KeyboardShortcut
-          shortcut={keyboardShortcuts.previousHighlight}
-          func={highlightStepper.previous}
-        />
-        <KeyboardShortcut
-          shortcut={keyboardShortcuts.nextHighlight}
-          func={highlightStepper.next}
-        />
-        <div className="search-stepper-overlay">
-          <SearchStepper
-            query={highlightStepper.query}
-            current={highlightStepper.currentHighlight}
-            total={highlightStepper.totalHighlights}
-            onNext={highlightStepper.next}
-            onPrevious={highlightStepper.previous}
-          />
-        </div>
+        <SearchStepperOverlay highlightStepper={highlightStepper} />
         <Viewer
           key={uri}
           match={{ params: { uri } }}
@@ -195,25 +203,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
         style={{ position: "relative" }}
       >
         {showTextContent && (
-          <>
-            <KeyboardShortcut
-              shortcut={keyboardShortcuts.previousHighlight}
-              func={highlightStepper.previous}
-            />
-            <KeyboardShortcut
-              shortcut={keyboardShortcuts.nextHighlight}
-              func={highlightStepper.next}
-            />
-            <div className="search-stepper-overlay">
-              <SearchStepper
-                query={highlightStepper.query}
-                current={highlightStepper.currentHighlight}
-                total={highlightStepper.totalHighlights}
-                onNext={highlightStepper.next}
-                onPrevious={highlightStepper.previous}
-              />
-            </div>
-          </>
+          <SearchStepperOverlay highlightStepper={highlightStepper} />
         )}
         <div className="document__page-viewer-content">
           {showTextContent ? (

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -11,7 +11,10 @@ import { TablePreview } from "./viewer/TablePreview";
 import DownloadButton from "./viewer/DownloadButton";
 import { DocumentFooter } from "./viewer/DocumentFooter";
 import { SearchStepper } from "./PageViewer/SearchStepper";
-import { useSearchHighlightStepper } from "./viewer/useSearchHighlightStepper";
+import {
+  SearchHighlightStepper,
+  useSearchHighlightStepper,
+} from "./viewer/useSearchHighlightStepper";
 import { GiantState } from "../types/redux/GiantState";
 import { Resource } from "../types/Resource";
 import { PageDimensions } from "./PageViewer/model";
@@ -101,7 +104,7 @@ type PageCountResponse = {
 };
 
 const SearchStepperOverlay: FC<{
-  highlightStepper: ReturnType<typeof useSearchHighlightStepper>;
+  highlightStepper: SearchHighlightStepper;
 }> = ({ highlightStepper }) => (
   <>
     <KeyboardShortcut
@@ -113,13 +116,7 @@ const SearchStepperOverlay: FC<{
       func={highlightStepper.next}
     />
     <div className="search-stepper-overlay">
-      <SearchStepper
-        query={highlightStepper.query}
-        current={highlightStepper.currentHighlight}
-        total={highlightStepper.totalHighlights}
-        onNext={highlightStepper.next}
-        onPrevious={highlightStepper.previous}
-      />
+      <SearchStepper highlightStepper={highlightStepper} />
     </div>
   </>
 );

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -8,19 +8,20 @@ import { PageViewer } from "./PageViewer/PageViewer";
 import { TextPreview } from "./viewer/TextPreview";
 import { Preview } from "./viewer/Preview";
 import { TablePreview } from "./viewer/TablePreview";
-import PreviewSwitcher from "./viewer/PreviewSwitcher";
 import DownloadButton from "./viewer/DownloadButton";
+import { DocumentFooter } from "./viewer/DocumentFooter";
+import { SearchStepper } from "./PageViewer/SearchStepper";
+import { useSearchHighlightStepper } from "./viewer/useSearchHighlightStepper";
 import { GiantState } from "../types/redux/GiantState";
 import { Resource } from "../types/Resource";
 import { PageDimensions } from "./PageViewer/model";
 import { setResourceView } from "../actions/urlParams/setViews";
 import { getComments } from "../actions/resources/getComments";
 import { setSelection } from "../actions/resources/setSelection";
-import history from "../util/history";
-import { useWorkspaceNavigation } from "../util/workspaceNavigation";
-import { DocNavButton } from "./viewer/DocNavButton";
 import { keyboardShortcuts } from "../util/keyboardShortcuts";
 import { KeyboardShortcut } from "./UtilComponents/KeyboardShortcut";
+import history from "../util/history";
+import { useWorkspaceNavigation } from "../util/workspaceNavigation";
 
 const COMBINED_VIEW = "combined";
 
@@ -111,6 +112,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
     Number.isFinite(navIndex) ? navIndex : null,
     history.push,
   );
+  const highlightStepper = useSearchHighlightStepper();
 
   const [response, setResponse] = useState<PageCountResponse | null>(null);
   const view = useSelector<GiantState, string | undefined>(
@@ -141,16 +143,55 @@ export const PageViewerOrFallback: FC<{}> = () => {
     return null;
   } else if (response.pageCount === 0) {
     return (
-      <Viewer
-        key={uri}
-        match={{ params: { uri } }}
-        workspaceNav={workspaceNav}
-      />
+      <div style={{ position: "relative" }}>
+        <KeyboardShortcut
+          shortcut={keyboardShortcuts.previousHighlight}
+          func={highlightStepper.previous}
+        />
+        <KeyboardShortcut
+          shortcut={keyboardShortcuts.nextHighlight}
+          func={highlightStepper.next}
+        />
+        <div className="search-stepper-overlay">
+          <SearchStepper
+            query={highlightStepper.query}
+            current={highlightStepper.currentHighlight}
+            total={highlightStepper.totalHighlights}
+            onNext={highlightStepper.next}
+            onPrevious={highlightStepper.previous}
+          />
+        </div>
+        <Viewer key={uri} match={{ params: { uri } }} workspaceNav={workspaceNav} />
+      </div>
     );
   } else {
     const showTextContent = !isCombinedOrUnset(view);
     return (
-      <div className="document__page-viewer-wrapper">
+      <div
+        className="document__page-viewer-wrapper"
+        style={{ position: "relative" }}
+      >
+        {showTextContent && (
+          <>
+            <KeyboardShortcut
+              shortcut={keyboardShortcuts.previousHighlight}
+              func={highlightStepper.previous}
+            />
+            <KeyboardShortcut
+              shortcut={keyboardShortcuts.nextHighlight}
+              func={highlightStepper.next}
+            />
+            <div className="search-stepper-overlay">
+              <SearchStepper
+                query={highlightStepper.query}
+                current={highlightStepper.currentHighlight}
+                total={highlightStepper.totalHighlights}
+                onNext={highlightStepper.next}
+                onPrevious={highlightStepper.previous}
+              />
+            </div>
+          </>
+        )}
         <div className="document__page-viewer-content">
           {showTextContent ? (
             <div className="document">
@@ -173,44 +214,11 @@ export const PageViewerOrFallback: FC<{}> = () => {
           )}
         </div>
         {resource && (
-          <div className="document__status">
-            {/* Left spacer: document__status uses space-between to match the legacy StatusBar two-span layout */}
-            <span />
-            <span className="doc-nav-buttons">
-              <PreviewSwitcher
-                view={view}
-                resource={resource}
-                totalPages={response.pageCount}
-              />
-              {workspaceNav &&
-                (workspaceNav.goToPrevious || workspaceNav.goToNext) && (
-                  <>
-                    {workspaceNav.goToNext && (
-                      <KeyboardShortcut
-                        shortcut={keyboardShortcuts.nextResult}
-                        func={workspaceNav.goToNext}
-                      />
-                    )}
-                    {workspaceNav.goToPrevious && (
-                      <KeyboardShortcut
-                        shortcut={keyboardShortcuts.previousResult}
-                        func={workspaceNav.goToPrevious}
-                      />
-                    )}
-                    <DocNavButton
-                      direction="previous"
-                      title="Previous in folder"
-                      onClick={workspaceNav.goToPrevious}
-                    />
-                    <DocNavButton
-                      direction="next"
-                      title="Next in folder"
-                      onClick={workspaceNav.goToNext}
-                    />
-                  </>
-                )}
-            </span>
-          </div>
+          <DocumentFooter
+            uri={uri}
+            workspaceNav={workspaceNav}
+            totalPages={response.pageCount}
+          />
         )}
       </div>
     );

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -186,7 +186,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
     return null;
   } else if (response.pageCount === 0) {
     return (
-      <div style={{ position: "relative" }}>
+      <div className="document__viewer-fallback">
         <SearchStepperOverlay highlightStepper={highlightStepper} />
         <Viewer
           key={uri}
@@ -198,16 +198,13 @@ export const PageViewerOrFallback: FC<{}> = () => {
   } else {
     const showTextContent = !isCombinedOrUnset(view);
     return (
-      <div
-        className="document__page-viewer-wrapper"
-        style={{ position: "relative" }}
-      >
+      <div className="document__page-viewer-wrapper">
         {showTextContent && (
           <SearchStepperOverlay highlightStepper={highlightStepper} />
         )}
         <div className="document__page-viewer-content">
           {showTextContent ? (
-            <div className="document" style={{ flexGrow: 1 }}>
+            <div className="document document--text-content">
               <PageViewerContent
                 key={uri}
                 uri={uri}

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -114,6 +114,25 @@ export const PageViewerOrFallback: FC<{}> = () => {
   );
   const highlightStepper = useSearchHighlightStepper();
 
+  // Scroll to the focused search highlight in text views of paged documents
+  useEffect(() => {
+    if (
+      highlightStepper.totalHighlights > 0 &&
+      highlightStepper.currentHighlight !== undefined
+    ) {
+      const highlights = document.querySelectorAll("result-highlight");
+      const prev = document.querySelector(".result-highlight--focused");
+      if (prev) {
+        prev.classList.remove("result-highlight--focused");
+      }
+      const el = highlights[highlightStepper.currentHighlight];
+      if (el) {
+        el.classList.add("result-highlight--focused");
+        el.scrollIntoView({ inline: "center", block: "center" });
+      }
+    }
+  }, [highlightStepper.currentHighlight, highlightStepper.totalHighlights]);
+
   const [response, setResponse] = useState<PageCountResponse | null>(null);
   const view = useSelector<GiantState, string | undefined>(
     (state) => state.urlParams.view,
@@ -161,7 +180,11 @@ export const PageViewerOrFallback: FC<{}> = () => {
             onPrevious={highlightStepper.previous}
           />
         </div>
-        <Viewer key={uri} match={{ params: { uri } }} workspaceNav={workspaceNav} />
+        <Viewer
+          key={uri}
+          match={{ params: { uri } }}
+          workspaceNav={workspaceNav}
+        />
       </div>
     );
   } else {
@@ -194,7 +217,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
         )}
         <div className="document__page-viewer-content">
           {showTextContent ? (
-            <div className="document">
+            <div className="document" style={{ flexGrow: 1 }}>
               <PageViewerContent
                 key={uri}
                 uri={uri}

--- a/frontend/src/js/components/viewer/DocumentFooter.tsx
+++ b/frontend/src/js/components/viewer/DocumentFooter.tsx
@@ -43,8 +43,7 @@ export const DocumentFooter: FC<DocumentFooterProps> = ({
   }, [currentResults, uri]);
 
   const hasPreviousResult =
-    currentResults !== undefined &&
-    (currentResults.page > 1 || (resultIdx !== -1 && resultIdx > 0));
+    currentResults !== undefined && (currentResults.page > 1 || resultIdx > 0);
 
   const hasNextResult =
     currentResults !== undefined &&

--- a/frontend/src/js/components/viewer/DocumentFooter.tsx
+++ b/frontend/src/js/components/viewer/DocumentFooter.tsx
@@ -90,7 +90,7 @@ export const DocumentFooter: FC<DocumentFooterProps> = ({
   }
 
   return (
-    <div className="document__status">
+    <div className="document__status" style={{ flexShrink: 0 }}>
       {effectiveNextFn && (
         <KeyboardShortcut
           shortcut={keyboardShortcuts.nextResult}

--- a/frontend/src/js/components/viewer/DocumentFooter.tsx
+++ b/frontend/src/js/components/viewer/DocumentFooter.tsx
@@ -1,0 +1,134 @@
+import React, { FC, useMemo } from "react";
+import { useSelector } from "react-redux";
+
+import PreviewSwitcher from "./PreviewSwitcher";
+import { DocNavButton } from "./DocNavButton";
+import { keyboardShortcuts } from "../../util/keyboardShortcuts";
+import { KeyboardShortcut } from "../UtilComponents/KeyboardShortcut";
+
+import { GiantState, UrlParamsState } from "../../types/redux/GiantState";
+import { Resource } from "../../types/Resource";
+import { SearchResults } from "../../types/SearchResults";
+import { WorkspaceNavigation } from "../../util/workspaceNavigation";
+
+import history from "../../util/history";
+import buildLink from "../../util/buildLink";
+
+type DocumentFooterProps = {
+  uri: string;
+  workspaceNav: WorkspaceNavigation;
+  totalPages?: number;
+};
+
+export const DocumentFooter: FC<DocumentFooterProps> = ({
+  uri,
+  workspaceNav,
+  totalPages,
+}) => {
+  const resource = useSelector<GiantState, Resource | null>(
+    (state) => state.resource,
+  );
+  const currentResults = useSelector<GiantState, SearchResults | undefined>(
+    (state) => state.search.currentResults,
+  );
+  const urlParams = useSelector<GiantState, UrlParamsState>(
+    (state) => state.urlParams,
+  );
+
+  // --- Search result navigation (stepping between documents) ---
+
+  const resultIdx = useMemo(() => {
+    if (!currentResults) return -1;
+    return currentResults.results.findIndex((r) => r.uri === uri);
+  }, [currentResults, uri]);
+
+  const hasPreviousResult =
+    currentResults !== undefined &&
+    (currentResults.page > 1 || (resultIdx !== -1 && resultIdx > 0));
+
+  const hasNextResult =
+    currentResults !== undefined &&
+    (currentResults.page < currentResults.pages ||
+      (resultIdx !== -1 && resultIdx < currentResults.results.length - 1));
+
+  const previousResult = hasPreviousResult
+    ? () => {
+        const idx = resultIdx - 1;
+        if (idx >= 0) {
+          const to = currentResults!.results[idx].uri;
+          history.push(buildLink(to, urlParams, {}));
+        }
+      }
+    : undefined;
+
+  const nextResult = hasNextResult
+    ? () => {
+        const idx = resultIdx + 1;
+        if (idx < currentResults!.results.length) {
+          const to = currentResults!.results[idx].uri;
+          history.push(buildLink(to, urlParams, {}));
+        }
+      }
+    : undefined;
+
+  // --- Effective navigation (search results take priority over workspace) ---
+
+  const navContext: "search" | "workspace" | undefined =
+    hasPreviousResult || hasNextResult
+      ? "search"
+      : workspaceNav.hasPrevious || workspaceNav.hasNext
+        ? "workspace"
+        : undefined;
+
+  const effectivePreviousFn = previousResult ?? workspaceNav.goToPrevious;
+  const effectiveNextFn = nextResult ?? workspaceNav.goToNext;
+
+  // --- Render ---
+
+  if (!resource) {
+    return null;
+  }
+
+  return (
+    <div className="document__status">
+      {effectiveNextFn && (
+        <KeyboardShortcut
+          shortcut={keyboardShortcuts.nextResult}
+          func={effectiveNextFn}
+        />
+      )}
+      {effectivePreviousFn && (
+        <KeyboardShortcut
+          shortcut={keyboardShortcuts.previousResult}
+          func={effectivePreviousFn}
+        />
+      )}
+      <span />
+      <span className="doc-nav-buttons">
+        <PreviewSwitcher
+          view={urlParams.view}
+          resource={resource}
+          totalPages={totalPages}
+        />
+        <DocNavButton
+          direction="previous"
+          title={
+            navContext === "workspace"
+              ? `Previous in folder (${keyboardShortcuts.previousResult})`
+              : `Previous document in search results (${keyboardShortcuts.previousResult})`
+          }
+          onClick={effectivePreviousFn}
+        />
+        <DocNavButton
+          direction="next"
+          title={
+            navContext === "workspace"
+              ? `Next in folder (${keyboardShortcuts.nextResult})`
+              : `Next document in search results (${keyboardShortcuts.nextResult})`
+          }
+          onClick={effectiveNextFn}
+        />
+      </span>
+    </div>
+  );
+};

--- a/frontend/src/js/components/viewer/DocumentFooter.tsx
+++ b/frontend/src/js/components/viewer/DocumentFooter.tsx
@@ -90,7 +90,7 @@ export const DocumentFooter: FC<DocumentFooterProps> = ({
   }
 
   return (
-    <div className="document__status" style={{ flexShrink: 0 }}>
+    <div className="document__status">
       {effectiveNextFn && (
         <KeyboardShortcut
           shortcut={keyboardShortcuts.nextResult}

--- a/frontend/src/js/components/viewer/Viewer.tsx
+++ b/frontend/src/js/components/viewer/Viewer.tsx
@@ -1,19 +1,14 @@
 import React from "react";
 
-import history from "../../util/history";
-import buildLink from "../../util/buildLink";
-
 import { HighlightableText, Resource } from "../../types/Resource";
 
 import { TablePreview } from "./TablePreview";
-import StatusBar from "./StatusBar";
+import { DocumentFooter } from "./DocumentFooter";
 import { Preview } from "./Preview";
 import { EmailDetails } from "./EmailDetails";
 import { TextPreview } from "./TextPreview";
 import { calculateResourceTitle } from "../UtilComponents/documentTitle";
 
-import { keyboardShortcuts } from "../../util/keyboardShortcuts";
-import { KeyboardShortcut } from "../UtilComponents/KeyboardShortcut";
 import _ from "lodash";
 
 import { connect } from "react-redux";
@@ -40,7 +35,6 @@ import {
 import { Auth } from "../../types/Auth";
 import { GiantDispatch } from "../../types/redux/GiantDispatch";
 import LazyTreeBrowser from "./LazyTreeBrowser";
-import { SearchResults } from "../../types/SearchResults";
 import { getDefaultView } from "../../util/resourceUtils";
 import DownloadButton from "./DownloadButton";
 import { WorkspaceNavigation } from "../../util/workspaceNavigation";
@@ -54,7 +48,6 @@ type Props = {
   resource: Resource | null;
   isLoadingResource: boolean;
   descendantResources: DescendantResources;
-  currentResults?: SearchResults;
   currentHighlight?: number;
   totalHighlights?: number;
   getResource: typeof getResource;
@@ -68,32 +61,11 @@ type Props = {
   setSelection: typeof setSelection;
 };
 
-type State = {
-  resultIdx: number;
-};
+type State = {};
 
 // A viewport for the current search result
 class Viewer extends React.Component<Props, State> {
-  state = {
-    // Default to negative number to prevent next-previous when you're outside the context of a search set
-    resultIdx: -10,
-  };
-
-  setupSearchContext(props: Props) {
-    if (!props.currentResults) {
-      return;
-    }
-
-    const currentSearchIndex = props.currentResults.results.findIndex(
-      (result) => result.uri === props.match.params.uri,
-    );
-
-    if (currentSearchIndex !== -1) {
-      this.setState({
-        resultIdx: currentSearchIndex,
-      });
-    }
-  }
+  state = {};
 
   UNSAFE_componentWillReceiveProps(props: Props) {
     if (
@@ -103,23 +75,9 @@ class Viewer extends React.Component<Props, State> {
       // See comment below in componentDidMount about not racing these two requests
       this.props.getResource(props.match.params.uri, props.urlParams.q);
     }
-
-    const currentUri = this.props.resource
-      ? this.props.resource.uri
-      : undefined;
-
-    if (
-      props.resource &&
-      props.currentResults &&
-      props.resource.uri !== currentUri
-    ) {
-      this.setupSearchContext(props);
-    }
   }
 
   componentDidMount() {
-    this.setupSearchContext(this.props);
-
     // This has to happen early, because otherwise state changes will get synced to the URL
     // (and the URL state thus lost) before we have a chance to do it the other way round
 
@@ -238,66 +196,6 @@ class Viewer extends React.Component<Props, State> {
   componentWillUnmount() {
     document.title = "Giant";
     this.props.resetResource();
-  }
-
-  previousResult = () => {
-    const currentHits = this.props.currentResults
-      ? this.props.currentResults.results
-      : undefined;
-    if (currentHits) {
-      const idx = this.state.resultIdx - 1;
-      if (idx >= 0) {
-        const to = `${currentHits[idx].uri}`;
-        history.push(buildLink(to, this.props.urlParams, {}));
-      }
-    }
-  };
-
-  nextResult = () => {
-    const currentHits = this.props.currentResults
-      ? this.props.currentResults.results
-      : undefined;
-    if (currentHits) {
-      const idx = this.state.resultIdx + 1;
-      if (idx < currentHits.length) {
-        const to = `${currentHits[idx].uri}`;
-        history.push(buildLink(to, this.props.urlParams, {}));
-      }
-    }
-  };
-
-  hasPreviousResult() {
-    if (!this.props.currentResults || this.props.resource === undefined) {
-      return false;
-    }
-
-    const { page, results } = this.props.currentResults;
-
-    if (page > 1) {
-      return true;
-    } else {
-      const ix = results.findIndex(
-        ({ uri }) => uri === this.props.resource!.uri,
-      );
-      return ix !== -1 && ix > 0;
-    }
-  }
-
-  hasNextResult() {
-    if (!this.props.currentResults || this.props.resource === undefined) {
-      return false;
-    }
-
-    const { page, pages, results } = this.props.currentResults;
-
-    if (page < pages) {
-      return true;
-    } else {
-      const ix = results.findIndex(
-        ({ uri }) => uri === this.props.resource!.uri,
-      );
-      return ix !== -1 && ix < results.length - 1;
-    }
   }
 
   renderTextPreview(
@@ -441,39 +339,17 @@ class Viewer extends React.Component<Props, State> {
 
     return (
       <div className="viewer">
-        <KeyboardShortcut
-          shortcut={keyboardShortcuts.nextResult}
-          func={
-            this.hasNextResult()
-              ? this.nextResult
-              : this.props.workspaceNav?.goToNext
-          }
-        />
-        <KeyboardShortcut
-          shortcut={keyboardShortcuts.previousResult}
-          func={
-            this.hasPreviousResult()
-              ? this.previousResult
-              : this.props.workspaceNav?.goToPrevious
-          }
-        />
-
         {this.renderResource(this.props.resource)}
         <div className="viewer__footer">
-          <StatusBar
-            resource={this.props.resource}
-            view={this.props.urlParams.view}
-            currentHighlight={this.props.currentHighlight}
-            totalHighlights={this.props.totalHighlights}
-            previousFn={
-              this.hasPreviousResult()
-                ? () => this.previousResult()
-                : this.props.workspaceNav?.goToPrevious
-            }
-            nextFn={
-              this.hasNextResult()
-                ? () => this.nextResult()
-                : this.props.workspaceNav?.goToNext
+          <DocumentFooter
+            uri={this.props.match.params.uri}
+            workspaceNav={
+              this.props.workspaceNav ?? {
+                hasPrevious: false,
+                hasNext: false,
+                goToPrevious: undefined,
+                goToNext: undefined,
+              }
             }
           />
         </div>
@@ -506,7 +382,6 @@ function mapStateToProps(state: GiantState) {
     resource: state.resource,
     isLoadingResource: state.isLoadingResource,
     descendantResources: state.descendantResources,
-    currentResults: state.search.currentResults,
     preferences: state.app.preferences,
     currentHighlight,
     totalHighlights,

--- a/frontend/src/js/components/viewer/useSearchHighlightStepper.ts
+++ b/frontend/src/js/components/viewer/useSearchHighlightStepper.ts
@@ -5,7 +5,15 @@ import { GiantState } from "../../types/redux/GiantState";
 import { Resource } from "../../types/Resource";
 import { setCurrentHighlight } from "../../actions/highlights";
 
-export function useSearchHighlightStepper() {
+export interface SearchHighlightStepper {
+  query: string;
+  currentHighlight?: number;
+  totalHighlights: number;
+  next: () => void;
+  previous: () => void;
+}
+
+export function useSearchHighlightStepper(): SearchHighlightStepper {
   const dispatch = useDispatch();
 
   const resource = useSelector<GiantState, Resource | null>(
@@ -14,62 +22,53 @@ export function useSearchHighlightStepper() {
   const view = useSelector<GiantState, string | undefined>(
     (state) => state.urlParams.view,
   );
-  const q = useSelector<GiantState, string>((state) => state.urlParams.q);
+  const query = useSelector<GiantState, string>((state) => state.urlParams.q);
 
   const { currentHighlight, totalHighlights } = useSelector(
     (state: GiantState) => {
-      let currentHighlight: number | undefined;
-      let totalHighlights = 0;
-
       if (state.resource && state.urlParams.view) {
         const highlights =
           state.highlights[`${state.resource.uri}-${state.urlParams.q}`];
-        if (highlights && _.get(highlights, state.urlParams.view)) {
-          currentHighlight = _.get(
-            highlights,
-            state.urlParams.view,
-          ).currentHighlight;
-        }
-        const viewItem = _.get(state.resource, state.urlParams.view);
-        if (viewItem) {
-          totalHighlights = viewItem.highlights
-            ? viewItem.highlights.length
-            : 0;
-        }
+        const highlightForView = _.get(highlights, state.urlParams.view);
+        const currentHighlight = highlightForView?.currentHighlight;
+        const viewItemHighlights = _.get(
+          state.resource,
+          state.urlParams.view,
+        )?.highlights;
+        const totalHighlights = viewItemHighlights
+          ? viewItemHighlights.length
+          : 0;
+        return { currentHighlight, totalHighlights };
       }
 
-      return { currentHighlight, totalHighlights };
+      return { currentHighlight: undefined, totalHighlights: 0 };
     },
   );
 
   const next = useCallback(() => {
     if (!resource || !view) return;
-    let newHighlight: number;
-    if (totalHighlights > 0 && currentHighlight === totalHighlights - 1) {
-      newHighlight = 0;
-    } else if (currentHighlight === undefined) {
-      newHighlight = 0;
-    } else {
-      newHighlight = currentHighlight + 1;
-    }
-    dispatch(setCurrentHighlight(resource.uri, q, view, newHighlight));
-  }, [resource, view, q, currentHighlight, totalHighlights, dispatch]);
+    const isLastHighlight =
+      totalHighlights > 0 && currentHighlight === totalHighlights - 1;
+    const newHighlight =
+      currentHighlight === undefined || isLastHighlight
+        ? 0
+        : currentHighlight + 1;
+    dispatch(setCurrentHighlight(resource.uri, query, view, newHighlight));
+  }, [resource, view, query, currentHighlight, totalHighlights, dispatch]);
 
   const previous = useCallback(() => {
     if (!resource || !view) return;
-    let newHighlight: number;
-    if (currentHighlight === 0) {
-      newHighlight = (totalHighlights || 1) - 1;
-    } else if (currentHighlight === undefined) {
-      newHighlight = (totalHighlights || 1) - 1;
-    } else {
-      newHighlight = currentHighlight - 1;
-    }
-    dispatch(setCurrentHighlight(resource.uri, q, view, newHighlight));
-  }, [resource, view, q, currentHighlight, totalHighlights, dispatch]);
+    const isFirstHighlight =
+      currentHighlight === undefined || currentHighlight === 0;
+    const lastHighlight = totalHighlights > 0 ? totalHighlights - 1 : 0;
+    const newHighlight = isFirstHighlight
+      ? lastHighlight
+      : currentHighlight - 1;
+    dispatch(setCurrentHighlight(resource.uri, query, view, newHighlight));
+  }, [resource, view, query, currentHighlight, totalHighlights, dispatch]);
 
   return {
-    query: q,
+    query: query,
     currentHighlight,
     totalHighlights,
     next,

--- a/frontend/src/js/components/viewer/useSearchHighlightStepper.ts
+++ b/frontend/src/js/components/viewer/useSearchHighlightStepper.ts
@@ -1,0 +1,78 @@
+import { useCallback } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import _ from "lodash";
+import { GiantState } from "../../types/redux/GiantState";
+import { Resource } from "../../types/Resource";
+import { setCurrentHighlight } from "../../actions/highlights";
+
+export function useSearchHighlightStepper() {
+  const dispatch = useDispatch();
+
+  const resource = useSelector<GiantState, Resource | null>(
+    (state) => state.resource,
+  );
+  const view = useSelector<GiantState, string | undefined>(
+    (state) => state.urlParams.view,
+  );
+  const q = useSelector<GiantState, string>((state) => state.urlParams.q);
+
+  const { currentHighlight, totalHighlights } = useSelector(
+    (state: GiantState) => {
+      let currentHighlight: number | undefined;
+      let totalHighlights = 0;
+
+      if (state.resource && state.urlParams.view) {
+        const highlights =
+          state.highlights[`${state.resource.uri}-${state.urlParams.q}`];
+        if (highlights && _.get(highlights, state.urlParams.view)) {
+          currentHighlight = _.get(
+            highlights,
+            state.urlParams.view,
+          ).currentHighlight;
+        }
+        const viewItem = _.get(state.resource, state.urlParams.view);
+        if (viewItem) {
+          totalHighlights = viewItem.highlights
+            ? viewItem.highlights.length
+            : 0;
+        }
+      }
+
+      return { currentHighlight, totalHighlights };
+    },
+  );
+
+  const next = useCallback(() => {
+    if (!resource || !view) return;
+    let newHighlight: number;
+    if (totalHighlights > 0 && currentHighlight === totalHighlights - 1) {
+      newHighlight = 0;
+    } else if (currentHighlight === undefined) {
+      newHighlight = 0;
+    } else {
+      newHighlight = currentHighlight + 1;
+    }
+    dispatch(setCurrentHighlight(resource.uri, q, view, newHighlight));
+  }, [resource, view, q, currentHighlight, totalHighlights, dispatch]);
+
+  const previous = useCallback(() => {
+    if (!resource || !view) return;
+    let newHighlight: number;
+    if (currentHighlight === 0) {
+      newHighlight = (totalHighlights || 1) - 1;
+    } else if (currentHighlight === undefined) {
+      newHighlight = (totalHighlights || 1) - 1;
+    } else {
+      newHighlight = currentHighlight - 1;
+    }
+    dispatch(setCurrentHighlight(resource.uri, q, view, newHighlight));
+  }, [resource, view, q, currentHighlight, totalHighlights, dispatch]);
+
+  return {
+    query: q,
+    currentHighlight,
+    totalHighlights,
+    next,
+    previous,
+  };
+}

--- a/frontend/src/stylesheets/components/_document.scss
+++ b/frontend/src/stylesheets/components/_document.scss
@@ -82,6 +82,13 @@
   user-select: none;
 }
 
+.search-stepper-overlay {
+  position: absolute;
+  right: 20px;
+  top: 0;
+  z-index: 1000;
+}
+
 .document__status-icon {
   height: 20px;
   margin-right: 5px;

--- a/frontend/src/stylesheets/components/_document.scss
+++ b/frontend/src/stylesheets/components/_document.scss
@@ -18,6 +18,14 @@
   padding: 10px;
 }
 
+.document--text-content {
+  flex-grow: 1;
+}
+
+.document__viewer-fallback {
+  position: relative;
+}
+
 .document--full-height {
   height: calc(100vh - 100px);
 }
@@ -54,6 +62,7 @@
 }
 
 .document__page-viewer-wrapper {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -73,6 +82,7 @@
   position: relative;
   display: flex;
   flex-wrap: wrap;
+  flex-shrink: 0;
   justify-content: space-between;
   align-items: center;
   padding: 5px;

--- a/frontend/src/stylesheets/components/_document.scss
+++ b/frontend/src/stylesheets/components/_document.scss
@@ -72,10 +72,11 @@
 .document__status {
   position: relative;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   padding: 5px;
-  height: 30px;
+  min-height: 30px;
   font-weight: bold;
   background-color: $primaryDark;
   color: white;
@@ -103,12 +104,17 @@
 }
 
 .preview__links {
-  display: inline;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  row-gap: 2px;
 }
 
 .preview__link {
   margin: 0 5px;
   padding: 0 20px;
+  height: 24px;
+  line-height: 24px;
   text-decoration: none;
   cursor: pointer;
   font-weight: bold;
@@ -276,7 +282,9 @@ comment-highlight.comment-highlight--focused {
 
 .doc-nav-buttons {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 2px;
 }
 


### PR DESCRIPTION
> [!NOTE]
> Based on `ljh-workspace-nav` (#658). 
> 
> Second of three big PRs to consolidate the document view navigation UI. 
> 
> The final biggie is for branch [ljh-combined-nav](https://github.com/guardian/giant/tree/ljh-combined-view), which builds on this PR.  
> 
> There are some further issues after that (see https://github.com/guardian/giant/issues/668 , https://github.com/guardian/giant/issues/669 , https://github.com/guardian/giant/issues/671 . These are refactor issues rather than features. 

## Shared DocumentFooter and search highlight stepper

Replaces the legacy `StatusBar` in `Viewer` and the inline nav buttons in `PageViewerOrFallback` with a single shared `DocumentFooter` component. Also adds a `SearchStepper` for stepping through search highlights in text views of paged documents, which was previously only available in the non-paged viewer.

## Why

The previous/next navigation for search results lived in the class-based `Viewer` component, with ~60 lines of imperative state management (`setupSearchContext`, `previousResult`, `nextResult`, `hasPreviousResult`, `hasNextResult`). Meanwhile, `PageViewerOrFallback` had its own inline nav buttons for workspace navigation but no search result navigation at all. The two code paths were diverging and becoming harder to maintain.

## Changes

- **`useSearchHighlightStepper`** — hook that extracts the highlight stepping logic (current index, total count, next/previous with wrapping) from the class component into a reusable form, reading from the existing Redux highlight state.
- **`SearchStepper`** — small presentational component showing the current query, match count, and prev/next buttons. Uses CSS modules. Parses the chip-based query format for display.
- **`DocumentFooter`** — shared footer used by both `Viewer` and `PageViewerOrFallback`. Handles the preview switcher, search result document navigation, and workspace sibling navigation. Search results take priority over workspace nav when both are available.
- **`Viewer`** — loses ~140 lines of search result state and navigation methods. Now delegates entirely to `DocumentFooter`.
- **`PageViewerOrFallback`** — gains `SearchStepperOverlay` (extracted to avoid duplication) for keyboard-shortcut-driven highlight stepping in text views, plus scroll-to-highlight behaviour. Uses `DocumentFooter` instead of inline nav buttons.
- **SCSS** — inline styles moved to proper classes (`document__viewer-fallback`, `document--text-content`, additions to `document__page-viewer-wrapper` and `document__status`).

## What this doesn't do

- Doesn't touch the PageViewer's control widget (find-in-document, zoom, rotate). That's consolidated into the footer in the next branch (`ljh-combined-view`).
- Doesn't unify the duplicated find/step logic between `Controls` and `usePageFind` (#668).

### Dependency graph
    main
     └── ljh-workspace-nav        (#658)
          └── ljh-document-footer  ← this PR
               └── ljh-combined-view (find-in-doc, zoom, rotate for combined view)

## Tests

No new test files — this is a refactor of existing UI with no new logic beyond the hook extraction. All 133 existing tests continue to pass.

## Manual tests
- [x] Tested locally
- [ ] Tested on playground