### PR TITLE
Workspaces: fix vertical alignment of text in tree browser rows

### DIFF
--- a/frontend/src/stylesheets/components/_file-browser.scss
+++ b/frontend/src/stylesheets/components/_file-browser.scss
@@ -112,11 +112,11 @@
 }
 
 .file-browser__cell {
-  padding-left: $baseSpacing;
-  padding-right: $baseSpacing;
+  padding: 2px $baseSpacing;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  vertical-align: middle;
 }
 
 .file-browser__cell-flex-container {


### PR DESCRIPTION
Add vertical-align: middle to .file-browser__cell so that text in all columns is vertically centred within each row. Previously the default baseline alignment caused visible misalignment on folder rows, where the name column contains taller elements (chevron, icons).

Also add 2px vertical padding to cells to maintain comfortable row height now that alignment no longer inflates row size implicitly.

### Before
<img width="1325" height="270" alt="Picture 319" src="https://github.com/user-attachments/assets/0f0476f2-a018-4338-becd-63b6aba9099b" />

### After
<img width="1291" height="285" alt="Picture 320" src="https://github.com/user-attachments/assets/79d61630-4faf-4fdb-862a-ee636ae824b0" />



## How has this change been tested?
 - [x] Tested locally on Firefox v148 and Chrome v146 (MacOS)
 - [ ] Tested on playground
