### PR TITLE
Fix double-click required to expand folders in Datasets view

### DIFF
--- a/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
@@ -22,7 +22,7 @@ type Props<T> = {
   selectedEntries: TreeEntry<T>[];
   focusedEntry: TreeEntry<T> | null;
   columnsConfig: ColumnsConfig<T>;
-  expandedNodes: TreeNode<T>[];
+  expandedNodes: TreeEntry<T>[];
 
   focusSibling: (
     i: number,

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
@@ -209,9 +209,7 @@ export default class TreeBrowser<T> extends React.Component<Props<T>, State> {
                 // selectedEntries because these can be nodes or leaves
                 selectedEntries={this.props.selectedEntries}
                 focusedEntry={this.props.focusedEntry}
-                // expandedNodes because leaves can't be expanded but the LazyTreeBrowser does
-                // mark them as expanded in anticipation of them loading and becoming nodes
-                expandedNodes={this.props.expandedEntries.filter(isTreeNode)}
+                expandedNodes={this.props.expandedEntries}
                 onFocus={this.props.onFocus}
                 onSelectLeaf={this.props.onSelectLeaf}
                 onExpandLeaf={this.props.onExpandLeaf}


### PR DESCRIPTION
The LazyTreeBrowser adds leaves to expandedEntries in anticipation of them becoming nodes once the API response returns. However, TreeBrowser was filtering expandedEntries through isTreeNode before passing them down as expandedNodes, which discarded the pre-emptively expanded leaves. This meant the node appeared collapsed after loading, requiring a second click to expand.

Fix by passing expandedEntries directly to Node without filtering, and widening the expandedNodes prop type from TreeNode<T>[] to TreeEntry<T>[]. Node.isExpanded() already matches by ID so the element type is irrelevant.

### Before:
![2026-04-10 18 38 56](https://github.com/user-attachments/assets/1248570d-0c4b-48aa-89eb-3a4ccc759f7d)


### After:
![2026-04-10 18 39 28](https://github.com/user-attachments/assets/3524215c-a18c-4b3b-923f-c848a818d9eb)


## How has this change been tested?
 - [x] Tested locally
 - [ ] Tested on playground

