### PR TITLE
Datasets view: add to workspace context menu

### DIFF
--- a/frontend/src/js/components/viewer/AddToWorkspaceModal.tsx
+++ b/frontend/src/js/components/viewer/AddToWorkspaceModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Resource } from "../../types/Resource";
+import { BasicResource, Resource } from "../../types/Resource";
 import Modal from "../UtilComponents/Modal";
 import Select from "react-select";
 import TreeBrowser from "../UtilComponents/TreeBrowser";
@@ -20,7 +20,7 @@ import { ValueType } from "react-select/src/types";
 import { getWorkspace } from "../../actions/workspaces/getWorkspace";
 
 interface PropsFromParent {
-  resource: Resource;
+  resource: Resource | BasicResource;
   isOpen: boolean;
   dismissModal: () => void;
 }
@@ -54,6 +54,7 @@ class AddToWorkspaceModalUnconnected extends React.Component<Props, State> {
   componentDidMountOrUpdate(prevProps?: Props, prevState?: State) {
     if (
       (!prevProps || this.props.resource.uri !== prevProps.resource.uri) &&
+      this.props.resource.parents &&
       this.props.resource.parents.length > 0
     ) {
       const parentUriParts = this.props.resource.parents[0].uri.split("/");
@@ -91,13 +92,18 @@ class AddToWorkspaceModalUnconnected extends React.Component<Props, State> {
       };
     } else if (this.props.resource.type === "blob") {
       icon = "document";
+      const resource = this.props.resource as Resource;
+      params = {
+        uri: resource.uri,
+        mimeType:
+          resource.mimeTypes && resource.mimeTypes.length > 1
+            ? "multiple types detected"
+            : resource.mimeTypes?.[0],
+        size: resource.fileSize,
+      };
+    } else {
       params = {
         uri: this.props.resource.uri,
-        mimeType:
-          this.props.resource.mimeTypes.length > 1
-            ? "multiple types detected"
-            : this.props.resource.mimeTypes[0],
-        size: this.props.resource.fileSize,
       };
     }
 

--- a/frontend/src/js/components/viewer/LazyTreeBrowser.tsx
+++ b/frontend/src/js/components/viewer/LazyTreeBrowser.tsx
@@ -9,6 +9,7 @@ import { ResourceBreadcrumbs } from "../ResourceBreadcrumbs";
 import DetectClickOutside from "../UtilComponents/DetectClickOutside";
 import AddToWorkspaceModal from "./AddToWorkspaceModal";
 import { fetchResource } from "../../services/ResourceApi";
+import { hasSingleBlobChild } from "../../util/resourceUtils";
 import sortBy from "lodash/sortBy";
 import {
   Tree,
@@ -120,7 +121,7 @@ export default function LazyTreeBrowser({
 
   const [addToWorkspaceModal, setAddToWorkspaceModal] = useState<{
     isOpen: boolean;
-    resource: Resource | null;
+    resource: Resource | BasicResource | null;
   }>({ isOpen: false, resource: null });
 
   function onExpandNode(node: TreeNode<BasicResource>) {
@@ -165,7 +166,15 @@ export default function LazyTreeBrowser({
 
   function onAddToWorkspace(entry: TreeEntry<BasicResource>) {
     closeContextMenu();
-    fetchResource(entry.data.uri, false).then((resource) => {
+    // Fetch the resource, then resolve file → blob if needed.
+    // Workspaces store references to blobs, not their parent file nodes.
+    fetchResource(entry.data.uri, true).then((resource) => {
+      if (hasSingleBlobChild(resource)) {
+        const blobUri = resource.children[0].uri;
+        return fetchResource(blobUri, false).then((blobResource) => {
+          setAddToWorkspaceModal({ isOpen: true, resource: blobResource });
+        });
+      }
       setAddToWorkspaceModal({ isOpen: true, resource });
     });
   }

--- a/frontend/src/js/components/viewer/LazyTreeBrowser.tsx
+++ b/frontend/src/js/components/viewer/LazyTreeBrowser.tsx
@@ -1,12 +1,22 @@
 import React, { useState } from "react";
+import { Menu } from "semantic-ui-react";
 import { Resource, BasicResource } from "../../types/Resource";
 import { getLastPart } from "../../util/stringUtils";
 import DocumentIcon from "react-icons/lib/ti/document";
 import EmailIcon from "react-icons/lib/md/email";
 import TreeBrowser from "../UtilComponents/TreeBrowser";
 import { ResourceBreadcrumbs } from "../ResourceBreadcrumbs";
+import DetectClickOutside from "../UtilComponents/DetectClickOutside";
+import AddToWorkspaceModal from "./AddToWorkspaceModal";
+import { fetchResource } from "../../services/ResourceApi";
 import sortBy from "lodash/sortBy";
-import { Tree, TreeEntry, TreeLeaf, TreeNode } from "../../types/Tree";
+import {
+  Tree,
+  TreeEntry,
+  TreeLeaf,
+  TreeNode,
+  isTreeLeaf,
+} from "../../types/Tree";
 import { getChildResource } from "../../actions/resources/getResource";
 
 type PropTypes = {
@@ -101,6 +111,18 @@ export default function LazyTreeBrowser({
     TreeEntry<BasicResource>[]
   >([]);
 
+  const [contextMenu, setContextMenu] = useState<{
+    isOpen: boolean;
+    entry: TreeEntry<BasicResource> | null;
+    positionX: number;
+    positionY: number;
+  }>({ isOpen: false, entry: null, positionX: 0, positionY: 0 });
+
+  const [addToWorkspaceModal, setAddToWorkspaceModal] = useState<{
+    isOpen: boolean;
+    resource: Resource | null;
+  }>({ isOpen: false, resource: null });
+
   function onExpandNode(node: TreeNode<BasicResource>) {
     setExpandedEntries([...expandedEntries, node]);
   }
@@ -115,6 +137,41 @@ export default function LazyTreeBrowser({
     // once its resource has been fetched, since it will have children.
     // We want to make sure that node appears expanded.
     setExpandedEntries([...expandedEntries, leaf]);
+  }
+
+  function onContextMenu(e: React.MouseEvent, entry: TreeEntry<BasicResource>) {
+    if (e.metaKey && e.shiftKey) {
+      // override for devs to do "inspect element"
+      return;
+    }
+    e.preventDefault();
+
+    // Only show context menu for files, not expandable folders
+    if (isTreeLeaf(entry) && !entry.isExpandable) {
+      setSelectedEntries([entry]);
+      setFocusedEntry(entry);
+      setContextMenu({
+        isOpen: true,
+        entry,
+        positionX: e.pageX,
+        positionY: e.pageY,
+      });
+    }
+  }
+
+  function closeContextMenu() {
+    setContextMenu({ isOpen: false, entry: null, positionX: 0, positionY: 0 });
+  }
+
+  function onAddToWorkspace(entry: TreeEntry<BasicResource>) {
+    closeContextMenu();
+    fetchResource(entry.data.uri, false).then((resource) => {
+      setAddToWorkspaceModal({ isOpen: true, resource });
+    });
+  }
+
+  function dismissAddToWorkspaceModal() {
+    setAddToWorkspaceModal({ isOpen: false, resource: null });
   }
 
   return (
@@ -183,9 +240,40 @@ export default function LazyTreeBrowser({
         onExpandLeaf={onExpandLeaf}
         onExpandNode={onExpandNode}
         onCollapseNode={onCollapseNode}
-        onContextMenu={() => {}}
+        onContextMenu={onContextMenu}
         showColumnHeaders={false}
       />
+      {contextMenu.isOpen && contextMenu.entry && (
+        <DetectClickOutside onClickOutside={closeContextMenu}>
+          <Menu
+            style={{
+              position: "absolute",
+              left: contextMenu.positionX,
+              top: contextMenu.positionY,
+            }}
+            items={[
+              {
+                key: "addToWorkspace",
+                content: "Add to workspace",
+                icon: "plus",
+              },
+            ]}
+            vertical
+            onItemClick={() => {
+              if (contextMenu.entry) {
+                onAddToWorkspace(contextMenu.entry);
+              }
+            }}
+          />
+        </DetectClickOutside>
+      )}
+      {addToWorkspaceModal.isOpen && addToWorkspaceModal.resource && (
+        <AddToWorkspaceModal
+          resource={addToWorkspaceModal.resource}
+          isOpen={true}
+          dismissModal={dismissAddToWorkspaceModal}
+        />
+      )}
     </React.Fragment>
   );
 }


### PR DESCRIPTION
> [!NOTE]
> Depends on #677 

This is an initial step towards https://github.com/guardian/giant/issues/346

Previously, adding a file from the Datasets view to a workspace required opening the file first, then using the "Add to Workspace" button in the document viewer sidebar. 

This PR adds a shortcut directly from the file browser in the Datasets view (and anywhere else `LazyTreeBrowser` is used — Collections, document viewer child trees). Right-clicking a file shows an "Add to workspace" option that opens the existing workspace picker dialog.

What I really want to do is let people add selections of multiple files (including folders, with some warnings) to a workspace. But the lazy-loading dataset file browser doesn't know what's in a ingestion or folder until it's opened, so that's a much more involved change. This at least speeds up the process a bit. The multiselect can come later perhaps.  

![2026-04-10 19 18 51](https://github.com/user-attachments/assets/0b0aab53-86f9-4f33-b3fd-7504da0ae3cc)


## How

- Added context menu state and handlers to `LazyTreeBrowser`, following the same UI pattern as the Workspaces file browser (Semantic UI `Menu`, absolute positioning, `DetectClickOutside` for dismissal).
- On "Add to workspace", the file resource is fetched and resolved to its blob child (matching the normal viewer flow), then passed to the existing `AddToWorkspaceModal`.
- Widened `AddToWorkspaceModal`'s `resource` prop to accept `BasicResource | Resource` so it can handle non-blob resources (e.g. emails) without crashing on missing `mimeTypes`/`fileSize` fields.

## Scope & limitations

- Context menu only appears on non-expandable files (leaves), not folders — adding folders recursively would need backend support.
- Single file only — multi-select add is a possible future enhancement.
- Meta+Shift+right-click still opens the browser's native context menu (for inspect element).

## How has this change been tested?
 - [x] Tested locally
 - [x] Tested on playground
