### PR TITLE
Remove logging every time something isn't an MBOX file

### DIFF
--- a/backend/app/extraction/email/mbox/MBoxEmailDetector.scala
+++ b/backend/app/extraction/email/mbox/MBoxEmailDetector.scala
@@ -25,9 +25,9 @@ object MBoxEmailDetector extends CustomTikaDetector {
       try {
         val messageCount = mbox.getMessageCount()
         if(messageCount >= 2) {
+          logger.info(s"Mbox file had $messageCount messages.")
           Some(MediaType.parse(MBOX_MIME_TYPE))
         } else {
-          logger.error(s"Mbox file had ${messageCount} messages - this could be because JakartaMail failed to properly open the MBOX file. ")
           None
         }
       } catch  {


### PR DESCRIPTION
## What does this change?
Remove logging introduced in https://github.com/guardian/giant/pull/131 which triggers every single time we run the type detection on a file that is not a valid MBOX - making this the most common error in giant!

We only want to log when a file is an MBOX file but also has 0 messages, which is impossible to know at the `detectType` stage, so I've removed the error logging and added info logging instead to the success path. We don't get many MBOX files so I think this makes sense