### PR TITLE
Process 500 rows of Excel sheet at a time (rather than 1000)

### DIFF
--- a/backend/app/extraction/tables/ExcelTableExtractor.scala
+++ b/backend/app/extraction/tables/ExcelTableExtractor.scala
@@ -49,7 +49,7 @@ class ExcelTableExtractor(scratch: ScratchSpace, tableOps: Tables)(implicit ec: 
 
       breakable {
         while (xmlReader.hasNext) {
-          result :+= readRows(1000, xmlReader, stringsTable, stylesTable, sheetName, blob)
+          result :+= readRows(500, xmlReader, stringsTable, stylesTable, sheetName, blob)
           if (xmlReader.isStartElement && xmlReader.getLocalName.equals("sheetData")) break()
         }
       }


### PR DESCRIPTION
## What does this change?
We are seeing a lot of 'out of memory' errors when giant attempts to extract data from certain excel sheets. 

This is a very dumb fix, but also a cheap one - just reducing how many rows we process by 50%. If we keep seeing the problem a better fix  (suggested by @twrichards) would be:

 - extract the number of rows from the file (this is a bit akward as at this point it is just XML, no easy metadata available so we'd have to do something like the below)
 - we can assume rows are likely to be roughly the same size
 - look at the size of the file, divide into e.g. 100MB chunks, and set the number of rows read/written at a time appropriately

## Example exception
```
java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Arrays.java:3541)
	at java.base/java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:242)
	at java.base/java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:587)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:179)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:173)
	at scala.collection.IterableOnceOps.addString(IterableOnce.scala:1249)
	at scala.collection.IterableOnceOps.addString$(IterableOnce.scala:1241)
	at scala.collection.AbstractIterator.addString(Iterator.scala:1300)
	at com.sksamuel.elastic4s.handlers.bulk.BulkHandlers.buildBulkHttpBody(BulkHandlers.scala:32)
	at com.sksamuel.elastic4s.handlers.bulk.BulkHandlers.buildBulkHttpBody$(BulkHandlers.scala:29)
	at com.sksamuel.elastic4s.ElasticDsl$.buildBulkHttpBody(ElasticDsl.scala:81)
	at com.sksamuel.elastic4s.handlers.bulk.BulkHandlers$BulkHandler$.build(BulkHandlers.scala:14)
	at com.sksamuel.elastic4s.handlers.bulk.BulkHandlers$BulkHandler$.build(BulkHandlers.scala:11)
	at com.sksamuel.elastic4s.ElasticClient.execute(ElasticClient.scala:38)
	at services.ElasticsearchSyntax.execute(ElasticsearchSyntax.scala:87)
	at services.ElasticsearchSyntax.execute$(ElasticsearchSyntax.scala:86)
	at services.table.ElasticsearchTable.execute(Table.scala:19)
	at services.ElasticsearchSyntax.executeBulk(ElasticsearchSyntax.scala:114)
	at services.ElasticsearchSyntax.executeBulk$(ElasticsearchSyntax.scala:113)
	at services.table.ElasticsearchTable.executeBulk(Table.scala:19)
	at services.table.ElasticsearchTable.addDocumentRows(Table.scala:48)
	at extraction.tables.ExcelTableExtractor.readRows(ExcelTableExtractor.scala:77)
	at extraction.tables.ExcelTableExtractor.$anonfun$extract$1(ExcelTableExtractor.scala:52)
	at extraction.tables.ExcelTableExtractor$$Lambda/0x000000d001f8cd48.apply$mcV$sp(Unknown Source)
	at scala.util.control.Breaks.breakable(Breaks.scala:77)
	at extraction.tables.ExcelTableExtractor.extract(ExcelTableExtractor.scala:51)
	at extraction.FileExtractor.extract(FileExtractor.scala:22)
	at extraction.Worker.safeInvokeExtractor(Worker.scala:150)
	at extraction.Worker.$anonfun$executeBatch$3(Worker.scala:94)
	at extraction.Worker$$Lambda/0x000000d001dd6250.apply(Unknown Source)
	at scala.util.Either.flatMap(Either.scala:352)
	at extraction.Worker.$anonfun$executeBatch$2(Worker.scala:92)
```


## How has this change been tested?
 - [ ] Tested locally
 - [ ] Tested on playground
