### PR TITLE
fix the cleanup of scratch/temp files (during email parsing)

### DIFF
--- a/backend/app/extraction/email/eml/EmlParser.scala
+++ b/backend/app/extraction/email/eml/EmlParser.scala
@@ -103,7 +103,7 @@ class EmlParser(val scratch: ScratchSpace, val ingestionServices: IngestionServi
 
   def ingestAttachment(context: IngestionContextBuilder, email: Email, attachment: MimeBodyPart): Unit = {
     val attachmentStream = attachment.getInputStream
-    val attachmentRoot = scratch.createWorkingDir(s"emails/${email.uri.value}/")
+    val attachmentRoot = new ScratchSpace(scratch.createWorkingDir(s"emails/${email.uri.value}/"))
 
     try {
       val name = getFilename(attachment).getOrElse(throw new IllegalArgumentException(s"Missing Content-Disposition for attachment in ${email.uri}"))
@@ -112,7 +112,7 @@ class EmlParser(val scratch: ScratchSpace, val ingestionServices: IngestionServi
       val mimeType = if (semicolonIndex > 0) rawContentType.substring(0, semicolonIndex) else rawContentType
 
       // Create Blob URI
-      val attachmentFile = scratch.copyToScratchSpace(attachmentStream)
+      val attachmentFile = attachmentRoot.copyToScratchSpace(attachmentStream)
       val blobUri = Uri(FingerprintServices.createFingerprintFromFile(attachmentFile))
 
       // Ingest
@@ -127,7 +127,7 @@ class EmlParser(val scratch: ScratchSpace, val ingestionServices: IngestionServi
       ingestionServices.ingestFile(attachmentContext, blob.uri, attachmentFile.toPath)
     } finally {
       attachmentStream.close()
-      FileUtils.deleteDirectory(attachmentRoot.toFile)
+      FileUtils.deleteDirectory(attachmentRoot.pathFor("/").toFile)
     }
   }
 

--- a/backend/app/extraction/email/olm/OlmEmailExtractor.scala
+++ b/backend/app/extraction/email/olm/OlmEmailExtractor.scala
@@ -136,10 +136,10 @@ class OlmEmailExtractor(scratch: ScratchSpace, ingestion: IngestionServices) ext
     // Create Blob URI
     val stream = zipFile.getInputStream(entry)
 
-    try {
-      val emailFile = scratch.copyToScratchSpace(stream)
-      logger.info(s"Copying $name to scratch ${emailFile.toString}")
+    val emailFile = scratch.copyToScratchSpace(stream)
+    logger.info(s"Copying $name to scratch ${emailFile.toString}")
 
+    try {
       val blobUri = Uri(FingerprintServices.createFingerprintFromFile(emailFile))
       val fileContext = buildFileContext(name, emailFile.toPath, emailUri, entry, context)
 
@@ -150,6 +150,7 @@ class OlmEmailExtractor(scratch: ScratchSpace, ingestion: IngestionServices) ext
       }
     } finally {
       stream.close()
+      Files.deleteIfExists(emailFile.toPath)
     }
   }
 

--- a/backend/app/services/ScratchSpace.scala
+++ b/backend/app/services/ScratchSpace.scala
@@ -15,7 +15,7 @@ class ScratchSpace(rootFolder: Path) extends Logging {
     ensureRootFolderExists()
   }
 
-  def ensureRootFolderExists(): Unit = {
+  private def ensureRootFolderExists(): Unit = {
     try {
       Files.createDirectories(rootFolder)
     } catch {


### PR DESCRIPTION
We've recently observed disk space errors when ingesting thousands of emails over the course of a few days, looking at disk usage pattern for an example worker...
<img width="1224" height="440" alt="image" src="https://github.com/user-attachments/assets/7413c718-b8de-422b-b79e-b826d4249d18" />
... it was clear that something wasn't being cleaned-up.

This PR fixes that.
