### PR TITLE
Add extra logging to WorkerControl

### DIFF
--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -72,7 +72,11 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
         scheduler.scheduleWithFixedDelay(config.controlInterval, config.controlInterval)(() => {
           // Only run the check on the oldest instance to get as close as we running the checks as a "singleton"
           if(runningOnOldestInstance()) {
-            val state = getCurrentState(workerAutoScalingGroupName, spotWorkerAutoscalingGroupName)
+            val state = getCurrentState(workerAutoScalingGroupName, spotWorkerAutoscalingGroupName).recoverWith {
+              case failure =>
+                logger.error(s"Failed to get state for  auto-scaling groups $workerAutoScalingGroupName, $spotWorkerAutoscalingGroupName", failure.toThrowable)
+                Attempt.Left(failure)
+            }
             // reuse the state needed for worker control to report cloudwatch metrics on work remaining
             state.foreach(publishStateMetrics)
             if(AwsDiscovery.isRiffRaffDeployRunning(discoveryConfig.stack, discoveryConfig.stage, ec2)) {
@@ -175,10 +179,6 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
     Attempt.catchNonFatalBlasé {
       val request = DescribeAutoScalingGroupsRequest.builder().autoScalingGroupNames(workerAutoScalingGroupName).build()
       autoscaling.describeAutoScalingGroups(request)
-    }.recoverWith {
-      case failure =>
-        logger.error(s"Failed to describe auto-scaling group $workerAutoScalingGroupName", failure.toThrowable)
-        Attempt.Left(failure)
     }.flatMap { response =>
       response.autoScalingGroups().asScala.headOption match {
         case Some(asg) =>

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -175,6 +175,10 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
     Attempt.catchNonFatalBlasé {
       val request = DescribeAutoScalingGroupsRequest.builder().autoScalingGroupNames(workerAutoScalingGroupName).build()
       autoscaling.describeAutoScalingGroups(request)
+    }.recoverWith {
+      case failure =>
+        logger.error(s"Failed to describe auto-scaling group $workerAutoScalingGroupName", failure.toThrowable)
+        Attempt.Left(failure)
     }.flatMap { response =>
       response.autoScalingGroups().asScala.headOption match {
         case Some(asg) =>
@@ -253,7 +257,7 @@ object AWSWorkerControl {
   case object AddNewWorker extends Operation
   case object RemoveWorker extends Operation
 
-  def decideOperation(state: State, now: Long, cooldown: Long): Option[Operation] = {
+  private def decideOperation(state: State, now: Long, cooldown: Long): Option[Operation] = {
     val inCooldown = state.workerAsg.lastEventTime > (now - cooldown) || state.spotWorkerAsg.lastEventTime > (now - cooldown)
     val manuallyScaledDown = state.workerAsg.desiredNumberOfWorkers == 0
 


### PR DESCRIPTION
## What does this change?
In WorkerControl I am wondering if we are being _too_ blasé about the call to describe the ASG and are ending up swallowing any errors that come back. This PR attempts to get a bit more visibility if that call throws an error. Tested on PROD whilst debugging an issue.

## How has this change been tested?
 - [ ] Tested locally
 - [ ] Tested on playground

## Old PR context
WorkerControl is not, err, working, on PROD following the merge of https://github.com/guardian/giant/pull/654. 

I am fairly confident this is because giant is failing to fetch the state of the worker/spot worker asgs here https://github.com/guardian/giant/blob/f058c8cade982aff37c851b3a204ac52b085e3bd/backend/app/utils/WorkerControl.scala#L75 - we know this because neither publishStateMetrics nor scaleUpOrDownIfNeeded are happening
