### PR TITLE
add new (admin only) option to download all the text of a workspace

### DIFF
--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -160,14 +160,19 @@ class Workspaces(
       .map(workspace => Ok(Json.toJson(workspace)))
   }
 
+  def getTotalWordCount(workspaceId: String) = ApiAction.attempt { req =>
+    for {
+      _ <- annotation.getWorkspaceMetadata(req.user.username, workspaceId) // check workspace exists and user has access
+      totalWordCount <- index.getTotalWordCountForWorkspace(workspaceId)
+    } yield Ok(Json.toJson(totalWordCount))
+  }
+
   def getText(workspaceId: String) = ApiAction.attempt(parse.json) { req =>
     for {
       _ <- annotation.getWorkspaceMetadata(req.user.username, workspaceId) // check workspace exists and user has access
       blobUris <- req.body.validate[List[String]].toAttempt
-      result <-
-        if (blobUris.isEmpty) index.getTotalWordCountForWorkspace(workspaceId).map(Json.toJson(_))
-        else index.getTextForBlobs(blobUris).map(Json.toJson(_))
-    } yield Ok(result)
+      result <- index.getTextForBlobs(workspaceId, blobUris)
+    } yield Ok(Json.toJson(result))
   }
 
   def updateWorkspaceFollowers(workspaceId: String) = ApiAction.attempt(parse.json) { req =>

--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -160,6 +160,16 @@ class Workspaces(
       .map(workspace => Ok(Json.toJson(workspace)))
   }
 
+  def getText(workspaceId: String) = ApiAction.attempt(parse.json) { req =>
+    for {
+      _ <- annotation.getWorkspaceMetadata(req.user.username, workspaceId) // check workspace exists and user has access
+      blobUris <- req.body.validate[List[String]].toAttempt
+      result <-
+        if (blobUris.isEmpty) index.getTotalWordCountForWorkspace(workspaceId).map(Json.toJson(_))
+        else index.getTextForBlobs(blobUris).map(Json.toJson(_))
+    } yield Ok(result)
+  }
+
   def updateWorkspaceFollowers(workspaceId: String) = ApiAction.attempt(parse.json) { req =>
     for {
       data <- req.body.validate[UpdateWorkspaceFollowers].toAttempt

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -513,21 +513,28 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     }
   }
 
+  private def buildWorkspaceIdFilter(workspaceId: String) = {
+    nestedQuery(IndexFields.workspacesField,
+      termQuery(s"${IndexFields.workspacesField}.${IndexFields.workspaces.workspaceId}", workspaceId)
+    )
+  }
+
   override def getTotalWordCountForWorkspace(workspaceId: String): Attempt[Long] = {
     val query = search(indexName)
       .query(
-        nestedQuery(IndexFields.workspacesField,
-          termQuery(s"${IndexFields.workspacesField}.${IndexFields.workspaces.workspaceId}", workspaceId)
-        )
+        buildWorkspaceIdFilter(workspaceId)
       )
       .aggregations(
         scriptedMetricAggregation("workspaceWordCount")
           .initScript(Script("state.total = 0L").lang("painless"))
           .mapScript(Script("""
-                              |if (params._source != null && params._source.text != null) {
-                              |  for (entry in params._source.text.entrySet()) {
-                              |    if (entry.getValue() != null && entry.getValue().length() > 0) {
-                              |      state.total += /\s+/.split(entry.getValue()).length;
+                              |if (params._source != null) {
+                              |  Map text = params._source.ocr != null ? params._source.ocr : params._source.text;
+                              |  if (text != null) {
+                              |    for (entry in text.entrySet()) {
+                              |      if (entry.getValue() != null && entry.getValue().length() > 0) {
+                              |        state.total += /\s+/.split(entry.getValue()).length;
+                              |      }
                               |    }
                               |  }
                               |}
@@ -535,26 +542,32 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
           .combineScript(Script("return state.total").lang("painless"))
           .reduceScript(Script("long total = 0; for (s in states) { total += s } return total").lang("painless"))
       )
+      .size(0)
 
     execute(query).map { response =>
-      response.aggregations.data("workspaceWordCount").asInstanceOf[Map[String, Any]]("value") match {
-        case n: Number => n.longValue()
-        case other => other.toString.toLong
-      }
+      response.aggregations.data("workspaceWordCount").asInstanceOf[Map[String, Number]]("value").longValue()
     }
   }
 
-  override def getTextForBlobs(blobUris: List[String]): Attempt[Map[String, Map[String, String]]] = {
+  override def getTextForBlobs(workspaceId: String, blobUris: List[String]): Attempt[Map[String, Map[String, String]]] = {
     val query = search(indexName)
       .query(
-        idsQuery(blobUris)
+        must(
+          idsQuery(blobUris),
+          // extra security, such that if someone tries to fetch text for blobs they don't have access to,
+          // they will just get an empty result (instead of an error, which could be used to probe for blob existence)
+          buildWorkspaceIdFilter(workspaceId)
+        )
       )
-      .sourceInclude("text.*")
+      .sourceInclude(
+        "text.*",
+        "ocr.*"
+      )
       .size(blobUris.size)
 
     execute(query).map { response =>
       response.hits.hits.flatMap { hit =>
-        hit.sourceAsMap.get(IndexFields.text).map(text => hit.id -> text.asInstanceOf[Map[String, String]])
+        hit.sourceAsMap.get(IndexFields.ocr).orElse(hit.sourceAsMap.get(IndexFields.text)).map(text => hit.id -> text.asInstanceOf[Map[String, String]])
       }.toMap
     }
   }

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -513,6 +513,52 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     }
   }
 
+  override def getTotalWordCountForWorkspace(workspaceId: String): Attempt[Long] = {
+    val query = search(indexName)
+      .query(
+        nestedQuery(IndexFields.workspacesField,
+          termQuery(s"${IndexFields.workspacesField}.${IndexFields.workspaces.workspaceId}", workspaceId)
+        )
+      )
+      .aggregations(
+        scriptedMetricAggregation("workspaceWordCount")
+          .initScript(Script("state.total = 0L").lang("painless"))
+          .mapScript(Script("""
+                              |if (params._source != null && params._source.text != null) {
+                              |  for (entry in params._source.text.entrySet()) {
+                              |    if (entry.getValue() != null && entry.getValue().length() > 0) {
+                              |      state.total += /\s+/.split(entry.getValue()).length;
+                              |    }
+                              |  }
+                              |}
+          """.stripMargin.trim).lang("painless"))
+          .combineScript(Script("return state.total").lang("painless"))
+          .reduceScript(Script("long total = 0; for (s in states) { total += s } return total").lang("painless"))
+      )
+
+    execute(query).map { response =>
+      response.aggregations.data("workspaceWordCount").asInstanceOf[Map[String, Any]]("value") match {
+        case n: Number => n.longValue()
+        case other => other.toString.toLong
+      }
+    }
+  }
+
+  override def getTextForBlobs(blobUris: List[String]): Attempt[Map[String, Map[String, String]]] = {
+    val query = search(indexName)
+      .query(
+        idsQuery(blobUris)
+      )
+      .sourceInclude("text.*")
+      .size(blobUris.size)
+
+    execute(query).map { response =>
+      response.hits.hits.flatMap { hit =>
+        hit.sourceAsMap.get(IndexFields.text).map(text => hit.id -> text.asInstanceOf[Map[String, String]])
+      }.toMap
+    }
+  }
+
   def delete(id: String): Attempt[Unit] = {
     executeNoReturn {
       deleteById(indexName, id)

--- a/backend/app/services/index/Index.scala
+++ b/backend/app/services/index/Index.scala
@@ -46,5 +46,5 @@ trait Index {
   def updateIngestionPath(oldIngestionPath: String, newIngestionPath: String): Attempt[Unit]
 
   def getTotalWordCountForWorkspace(workspaceId: String): Attempt[Long]
-  def getTextForBlobs(blobUris: List[String]): Attempt[Map[String, Map[String, String]]] = ???
+  def getTextForBlobs(workspaceId: String, blobUris: List[String]): Attempt[Map[String, Map[String, String]]]
 }

--- a/backend/app/services/index/Index.scala
+++ b/backend/app/services/index/Index.scala
@@ -44,4 +44,7 @@ trait Index {
   def deleteWorkspace(workspaceId: String): Attempt[Unit]
 
   def updateIngestionPath(oldIngestionPath: String, newIngestionPath: String): Attempt[Unit]
+
+  def getTotalWordCountForWorkspace(workspaceId: String): Attempt[Long]
+  def getTextForBlobs(blobUris: List[String]): Attempt[Map[String, Map[String, String]]] = ???
 }

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -64,6 +64,7 @@ PUT           /api/workspaces/:workspaceId/isPublic                         cont
 PUT           /api/workspaces/:workspaceId/name                             controllers.api.Workspaces.updateWorkspaceName(workspaceId: String)
 GET           /api/workspaces/:workspaceId                                  controllers.api.Workspaces.get(workspaceId: String)
 GET           /api/workspaces/:workspaceId/nodes                            controllers.api.Workspaces.getContents(workspaceId: String)
+POST          /api/workspaces/:workspaceId/text                             controllers.api.Workspaces.getText(workspaceId: String)
 PUT           /api/workspaces/:workspaceId/owner                            controllers.api.Workspaces.updateWorkspaceOwner(workspaceId: String)
 POST          /api/workspaces/:workspaceId/reprocess                        controllers.api.Workspaces.reprocess(workspaceId: String, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])
 POST          /api/workspaces/:workspaceId/nodes                            controllers.api.Workspaces.addItemToWorkspace(workspaceId: String)

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -64,6 +64,7 @@ PUT           /api/workspaces/:workspaceId/isPublic                         cont
 PUT           /api/workspaces/:workspaceId/name                             controllers.api.Workspaces.updateWorkspaceName(workspaceId: String)
 GET           /api/workspaces/:workspaceId                                  controllers.api.Workspaces.get(workspaceId: String)
 GET           /api/workspaces/:workspaceId/nodes                            controllers.api.Workspaces.getContents(workspaceId: String)
+GET           /api/workspaces/:workspaceId/totalWordCount                   controllers.api.Workspaces.getTotalWordCount(workspaceId: String)
 POST          /api/workspaces/:workspaceId/text                             controllers.api.Workspaces.getText(workspaceId: String)
 PUT           /api/workspaces/:workspaceId/owner                            controllers.api.Workspaces.updateWorkspaceOwner(workspaceId: String)
 POST          /api/workspaces/:workspaceId/reprocess                        controllers.api.Workspaces.reprocess(workspaceId: String, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])

--- a/frontend/src/js/components/workspace/DownloadTextModal.tsx
+++ b/frontend/src/js/components/workspace/DownloadTextModal.tsx
@@ -1,0 +1,245 @@
+import {
+  isWorkspaceLeaf,
+  Workspace,
+  WorkspaceEntry,
+} from "../../types/Workspaces";
+import Modal from "../UtilComponents/Modal";
+import { isTreeNode, TreeEntry } from "../../types/Tree";
+import { getWorkspaceText } from "../../services/WorkspaceApi";
+import { useEffect, useMemo, useState } from "react";
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiLoadingSpinner,
+  EuiProgress,
+} from "@elastic/eui";
+
+interface DownloadTextModalProps {
+  isOpen: boolean;
+  dismiss: () => void;
+  workspace: Workspace;
+}
+
+const getFileBlobUriMap = (
+  entry: TreeEntry<WorkspaceEntry>,
+  pathSoFar: string = "",
+): { [blobUri: string]: string } => {
+  if (isWorkspaceLeaf(entry.data)) {
+    return { [entry.data.uri]: `${pathSoFar}/${entry.name}` };
+  } else if (isTreeNode(entry)) {
+    return entry.children.reduce(
+      (blobUriMap, child) => ({
+        ...blobUriMap,
+        ...getFileBlobUriMap(
+          child,
+          // don't include the workspace name again (as that is the 'name' of the root node)
+          pathSoFar ? `${pathSoFar}/${entry.name}` : "",
+        ),
+      }),
+      {},
+    );
+  }
+  return {};
+};
+
+export const DownloadTextModal = ({
+  isOpen,
+  dismiss,
+  workspace,
+}: DownloadTextModalProps) => {
+  const [workspaceWordCount, setWorkspaceWordCount] = useState<number | null>(
+    null,
+  );
+  useEffect(() => {
+    getWorkspaceText(workspace.id).then(setWorkspaceWordCount);
+  }, [workspace.id]);
+
+  const blobUriToWorkspacePath = useMemo(
+    () => getFileBlobUriMap(workspace.rootNode),
+    [workspace.rootNode],
+  );
+
+  const allBlobUris = useMemo(
+    () => Object.keys(blobUriToWorkspacePath),
+    [blobUriToWorkspacePath],
+  );
+
+  const [targetNumOfResultFiles, setTargetNumOfResultFiles] = useState(
+    Math.min(allBlobUris.length, 250),
+  );
+
+  const [progress, setProgress] = useState<number | null>(null);
+
+  const downloadAllText = async () => {
+    setProgress(0);
+
+    let buffer: {
+      [blobUri: string]: {
+        [lang: string]: string;
+      };
+    } = {};
+
+    let fetchedCounter = 0;
+    let currentOutputFile = {
+      number: 0,
+      text: "",
+    };
+
+    const dumpToFile = () => {
+      const filename = `${workspace.name} (${workspace.id}).${currentOutputFile.number}.txt`;
+      const myBlob = new Blob([currentOutputFile.text.trim()], {
+        type: "text/plain",
+      });
+      const blobURL = URL.createObjectURL(myBlob);
+      const a = document.createElement("a");
+      a.setAttribute("href", blobURL);
+      a.setAttribute("download", filename);
+      a.style.display = "none";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(blobURL);
+
+      currentOutputFile.number++;
+      currentOutputFile.text = "";
+      setProgress(
+        Math.min(0.95, currentOutputFile.number / targetNumOfResultFiles),
+      );
+    };
+
+    while (
+      fetchedCounter < allBlobUris.length ||
+      Object.keys(buffer).length > 0
+    ) {
+      let bufferEntries = Object.entries(buffer);
+      if (
+        bufferEntries.length <
+        Math.min(100, allBlobUris.length - fetchedCounter)
+      ) {
+        const blobUrisForThisBatch = allBlobUris.slice(
+          fetchedCounter,
+          Math.min(fetchedCounter + 100, allBlobUris.length),
+        );
+        const textForBatch: {
+          [blobUri: string]: {
+            [lang: string]: string;
+          };
+        } = await getWorkspaceText(workspace.id, blobUrisForThisBatch);
+        fetchedCounter += blobUrisForThisBatch.length;
+        buffer = {
+          ...buffer,
+          ...textForBatch,
+        };
+        bufferEntries = Object.entries(buffer);
+      }
+      for (const [blobUri, langTextMap] of bufferEntries) {
+        for (const [lang, text] of Object.entries(langTextMap)) {
+          const file = `${blobUriToWorkspacePath[blobUri]} (${lang})`;
+          const wrappedText = `----- START OF ${file} -----\n\n${text}\n\n----- END OF ${file} -----\n\n\n`;
+          const wordCount = wrappedText.split(/\s+/).length;
+          const runningTotalWordCount =
+            currentOutputFile.text.split(/\s+/).length;
+          // TODO need to handle the writing of the final file
+          if (
+            currentOutputFile.text.length > 0 &&
+            runningTotalWordCount + wordCount > wordsPerFile!
+          ) {
+            dumpToFile();
+          }
+          currentOutputFile.text += wrappedText;
+          delete buffer[blobUri];
+        }
+      }
+    }
+
+    if (currentOutputFile.text.length > 0) {
+      dumpToFile();
+    }
+
+    setProgress(1);
+  };
+
+  const wordsPerFile =
+    workspaceWordCount &&
+    Math.ceil(workspaceWordCount / targetNumOfResultFiles);
+
+  return (
+    <Modal isOpen={isOpen} dismiss={dismiss}>
+      <div style={{ padding: "10px" }}>
+        <h2>Download Workspace as Text</h2>
+        <p>
+          {workspaceWordCount === null ? (
+            <span>
+              <EuiLoadingSpinner size="s" /> Calculating total word count for
+              workspace...
+            </span>
+          ) : (
+            `This workspace has a total of ${workspaceWordCount.toLocaleString()} words across all files and languages.`
+          )}
+        </p>
+        <p>
+          This will download the text for all the{" "}
+          <strong>{allBlobUris.length.toLocaleString()}</strong> files in this
+          workspace, with each file's text separated by a header indicating the
+          file path and language.
+        </p>
+        <p>
+          <label>
+            Split into roughly{" "}
+            <input
+              type="number"
+              value={targetNumOfResultFiles}
+              min={1}
+              max={allBlobUris.length}
+              disabled={progress !== null}
+              onChange={(e) =>
+                setTargetNumOfResultFiles(parseInt(e.target.value))
+              }
+            />{" "}
+            files (so approximately{" "}
+            {wordsPerFile ? (
+              wordsPerFile.toLocaleString()
+            ) : (
+              <EuiLoadingSpinner size="s" />
+            )}{" "}
+            words per file).
+          </label>
+        </p>
+        {progress ? (
+          <div>
+            <EuiProgress value={progress} max={1.0} />
+            <div>
+              {progress === 1 ? (
+                "Done!"
+              ) : (
+                <span>
+                  Generating{" "}
+                  <code>
+                    {
+                      Object.entries(progress).find(
+                        ([_, isComplete]) => !isComplete,
+                      )?.[0]
+                    }
+                  </code>
+                </span>
+              )}
+            </div>
+          </div>
+        ) : (
+          <EuiButton
+            onClick={downloadAllText}
+            disabled={!workspaceWordCount || allBlobUris.length === 0}
+          >
+            Start Download
+          </EuiButton>
+        )}
+        <br />
+        <br />
+        <EuiCallOut color={"warning"} title="Note">
+          If prompted for permission to download <strong>multiple</strong>{" "}
+          files, you must accept in order to use this functionality.
+        </EuiCallOut>
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/src/js/components/workspace/DownloadTextModal.tsx
+++ b/frontend/src/js/components/workspace/DownloadTextModal.tsx
@@ -5,7 +5,10 @@ import {
 } from "../../types/Workspaces";
 import Modal from "../UtilComponents/Modal";
 import { isTreeNode, TreeEntry } from "../../types/Tree";
-import { getWorkspaceText } from "../../services/WorkspaceApi";
+import {
+  getWorkspaceText,
+  getWorkspaceTotalWordCount,
+} from "../../services/WorkspaceApi";
 import { useEffect, useMemo, useState } from "react";
 import {
   EuiButton,
@@ -51,7 +54,7 @@ export const DownloadTextModal = ({
     null,
   );
   useEffect(() => {
-    getWorkspaceText(workspace.id).then(setWorkspaceWordCount);
+    getWorkspaceTotalWordCount(workspace.id).then(setWorkspaceWordCount);
   }, [workspace.id]);
 
   const blobUriToWorkspacePath = useMemo(
@@ -71,7 +74,9 @@ export const DownloadTextModal = ({
   const [progress, setProgress] = useState<number | null>(null);
 
   const downloadAllText = async () => {
-    setProgress(0);
+    setProgress(0.01);
+
+    const fetchTextBatchSize = Math.min(1000, workspaceWordCount! / 15_000);
 
     let buffer: {
       [blobUri: string]: {
@@ -114,17 +119,16 @@ export const DownloadTextModal = ({
       let bufferEntries = Object.entries(buffer);
       if (
         bufferEntries.length <
-        Math.min(100, allBlobUris.length - fetchedCounter)
+        Math.min(fetchTextBatchSize, allBlobUris.length - fetchedCounter)
       ) {
         const blobUrisForThisBatch = allBlobUris.slice(
           fetchedCounter,
-          Math.min(fetchedCounter + 100, allBlobUris.length),
+          Math.min(fetchedCounter + fetchTextBatchSize, allBlobUris.length),
         );
-        const textForBatch: {
-          [blobUri: string]: {
-            [lang: string]: string;
-          };
-        } = await getWorkspaceText(workspace.id, blobUrisForThisBatch);
+        const textForBatch = await getWorkspaceText(
+          workspace.id,
+          blobUrisForThisBatch,
+        );
         fetchedCounter += blobUrisForThisBatch.length;
         buffer = {
           ...buffer,
@@ -139,7 +143,6 @@ export const DownloadTextModal = ({
           const wordCount = wrappedText.split(/\s+/).length;
           const runningTotalWordCount =
             currentOutputFile.text.split(/\s+/).length;
-          // TODO need to handle the writing of the final file
           if (
             currentOutputFile.text.length > 0 &&
             runningTotalWordCount + wordCount > wordsPerFile!

--- a/frontend/src/js/components/workspace/WorkspaceSummary.tsx
+++ b/frontend/src/js/components/workspace/WorkspaceSummary.tsx
@@ -26,6 +26,7 @@ import { FileAndFolderCounts } from "../UtilComponents/TreeBrowser/FileAndFolder
 import buildLink from "../../util/buildLink";
 import history from "../../util/history";
 import { workspaceEntryPath } from "../../util/workspaceUtils";
+import { DownloadTextModal } from "./DownloadTextModal";
 
 type Props = {
   workspace: Workspace;
@@ -62,6 +63,7 @@ export default function WorkspaceSummary({
   isAdmin,
   clearFocus,
 }: Props) {
+  const [downloadTextModalOpen, setDownloadTextModalOpen] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [takeOwnershipModalOpen, setTakeOwnershipModalOpen] = useState(false);
   const [renameModalOpen, setRenameModalOpen] = useState(false);
@@ -184,6 +186,12 @@ export default function WorkspaceSummary({
             disabled={!canDelete}
             onClick={() => setDeleteModalOpen(true)}
           />
+          <Dropdown.Divider />
+          <Dropdown.Item
+            icon="file alternate outline"
+            text="Download all text"
+            onClick={() => setDownloadTextModalOpen(true)}
+          />
         </Dropdown.Menu>
       </Dropdown>
       <TakeOwnershipOfWorkspaceModal
@@ -194,6 +202,13 @@ export default function WorkspaceSummary({
         isOpen={takeOwnershipModalOpen}
         onClose={() => setTakeOwnershipModalOpen(false)}
       />
+      {isAdmin && downloadTextModalOpen && (
+        <DownloadTextModal
+          isOpen={downloadTextModalOpen}
+          dismiss={() => setDownloadTextModalOpen(false)}
+          workspace={workspace}
+        />
+      )}
       <ShareWorkspaceModal
         workspace={workspace}
         workspaceUsers={workspaceUsers}

--- a/frontend/src/js/services/WorkspaceApi.ts
+++ b/frontend/src/js/services/WorkspaceApi.ts
@@ -59,11 +59,24 @@ export function getWorkspace(id: string) {
   return authFetch(`/api/workspaces/${id}`).then((res) => res.json());
 }
 
-export function getWorkspaceText(id: string, maybeBlobUris?: string[]) {
+export function getWorkspaceTotalWordCount(id: string): Promise<number> {
+  return authFetch(`/api/workspaces/${id}/totalWordCount`).then((res) =>
+    res.json(),
+  );
+}
+
+export function getWorkspaceText(
+  id: string,
+  blobUris: string[],
+): Promise<{
+  [blobUri: string]: {
+    [lang: string]: string;
+  };
+}> {
   return authFetch(`/api/workspaces/${id}/text`, {
     method: "POST",
     headers: new Headers({ "Content-Type": "application/json" }),
-    body: JSON.stringify(maybeBlobUris ?? []), // returns word count for whole workspace if no blobs specified
+    body: JSON.stringify(blobUris),
   }).then((res) => res.json());
 }
 

--- a/frontend/src/js/services/WorkspaceApi.ts
+++ b/frontend/src/js/services/WorkspaceApi.ts
@@ -59,6 +59,14 @@ export function getWorkspace(id: string) {
   return authFetch(`/api/workspaces/${id}`).then((res) => res.json());
 }
 
+export function getWorkspaceText(id: string, maybeBlobUris?: string[]) {
+  return authFetch(`/api/workspaces/${id}/text`, {
+    method: "POST",
+    headers: new Headers({ "Content-Type": "application/json" }),
+    body: JSON.stringify(maybeBlobUris ?? []), // returns word count for whole workspace if no blobs specified
+  }).then((res) => res.json());
+}
+
 export function moveItem(
   workspaceId: string,
   itemId: string,


### PR DESCRIPTION
Sometimes it's useful to be able to extract all the text for a workspace to use in other tools (notable example being NotebookLM), fortunately we have all the text (original text plus OCRed text) available in ElasticSearch (originally/primarily for the purposes of search/highlighting).

## What does this change?
Adds a new POST endpoint `/api/workspaces/:workspaceId/text` which if passed an array of blobUris will returns the text (for each language, typically `english`) preferring the OCR text if available. If passed an empty list then it returns a word count for the entire workspace.

Added a new menu option for the workspace, which launches a new modal, fetching/displaying the total word count and then presents a number field (min 1, max number of unique blobUris in the workspace) of approximately how many files to distribute the text across (approximate number of files, since the different files will have different word counts and so won't fit perfectly evenly between the files, so might end up with a few more or a few less than the target).

The text content of each original file will be wrapped as follows...
```----- START OF ${file} -----\n\n${text}\n\n----- END OF ${file} -----\n\n\n```
... where `file` is `${blobUriToWorkspacePath[blobUri]} (${lang})`.

Once the user clicks Start Download they're presented with a progress bar, and then a series of files will start downloading named after the workspace (and workspace ID) followed by the file number with the extension `.txt`.

We distribute the text across a configurable number of files, so they're easy to upload to tools like NotebookLM (which has limits on the number of files [based on licence tier] as well as hard limit of 500k words per file - and anecdotally we've found it performs better with smaller files, i.e. dividing the total words into as many files as possible under the file limits).

NOTE: this feature is implemented such that most of the hard work is done in the browser, to keep load on the server to a minimum.

## How has this change been tested?
 - [x] Tested locally
 - [x] Tested on playground

## Things to think about
 - Does this change impact the external transcription service integration? If so, how has this been tested?
 - For UI changes: have you thought about accessibility? See https://github.com/guardian/accessibility/

## Images
<img width="234" height="248" alt="image" src="https://github.com/user-attachments/assets/a6408bfe-cf98-45f4-aef9-b88e3c2e8cdc" />
<img width="615" height="351" alt="image" src="https://github.com/user-attachments/assets/e0f1ef56-4b75-41f8-9c4c-b4010fd8ab14" />
<img width="617" height="360" alt="image" src="https://github.com/user-attachments/assets/2b9ae048-5518-4594-b984-43e11bfb0894" />
<img width="815" height="221" alt="image" src="https://github.com/user-attachments/assets/f931dc67-26c7-4e73-bc78-a5e0d6afbe82" />