### PR TITLE
fix for `ColorConversionNeededError`

### DIFF
--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -181,9 +181,30 @@ object Ocr extends Logging {
       }
     }
 
+    def calculateColorConversionStrategyFlag(path: Path): String = {
+      val startTime = System.currentTimeMillis()
+      var colorConversionStrategyFlag = ""
+      Process(
+        s"ocrmypdf --skip-text --output-type pdfa --pages 1 --tesseract-timeout 0 ${path.toAbsolutePath} /dev/null"
+      ) ! ProcessLogger ( log =>
+        if (log.contains("ColorConversionNeededError:")) {
+          colorConversionStrategyFlag = "--color-conversion-strategy=RGB"
+        }
+      )
+      val duration = System.currentTimeMillis() - startTime
+      logger.info(s"Checked if color conversion strategy flag is needed. Took ${duration}ms. Result: $colorConversionStrategyFlag")
+      colorConversionStrategyFlag
+    }
+
     def ocrWithOcrMyPdf(flag: OcrMyPdfFlag, overrideFile: Option[Path] = None): Int = {
-      val sourceFilePath = overrideFile.getOrElse(inputFilePath)
-      val cmd = s"ocrmypdf ${flag.flag} -l $lang ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")} ${sourceFilePath.toAbsolutePath} ${tempFile.toAbsolutePath}"
+      val sourceFilePath = overrideFile.getOrElse(inputFilePath).toAbsolutePath
+      val cmd = s"""ocrmypdf ${flag.flag}
+                   | ${calculateColorConversionStrategyFlag(sourceFilePath)}
+                   | -l $lang
+                   | ${dpi.map(dpi => s"--image-dpi $dpi").getOrElse("")}
+                   | $sourceFilePath
+                   | ${tempFile.toAbsolutePath}"""
+        .stripMargin.replaceAll("\n", "")
       val process = Process(cmd, cwd = None, extraEnv = "TMPDIR" -> tmpDir.toAbsolutePath.toString)
       runProcessWithTimeout(process)
     }


### PR DESCRIPTION
Paired with @philmcmahon 

Typically large/complex PDFs often have a mix of colour spaces e.g. CMYK and RGB in the same PDF and then after the worker has done all the hard/long work of OCRing it fails at the final step of converting to PDF-A since it requires a consistent colour space. 

Fixes #679 

## What does this change?
Run a lightweight pre-run of `ocrmypdf` to detect `ColorConversionNeededError` and if detected then pass `--color-conversion-strategy=RGB` to the actual main run of `ocrmypdf` to avoid it failing at the very end of OCRing

## How has this change been tested?
 - [ ] Tested locally
 - [x] Tested on playground

## Things to think about
This will add a few seconds to every OCR, but still more efficient than a % of all PDFs failing after a lot of wasted work.
