### PR TITLE
Post outstandingFromIngestStore metric to cloudwatch

### DIFF
--- a/backend/app/services/MetricsService.scala
+++ b/backend/app/services/MetricsService.scala
@@ -22,6 +22,7 @@ object Metrics {
   val searchInFolderEvents = "SearchInFolderEvents"
   val extractorWorkInProgress = "ExtractorWorkInProgress"
   val extractorWorkOutstanding = "ExtractorWorkOutstanding"
+  val ingestStoreOutstanding = "IngestStoreOutstanding"
 
 
   def metricDatum(name: String, dimensions: List[Dimension], value: Double): MetricDatum = {

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -68,6 +68,7 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
   private def publishStateMetrics (state: AWSWorkerControl.State): Unit = {
     metrics.updateMetric(Metrics.extractorWorkInProgress, state.inProgress)
     metrics.updateMetric(Metrics.extractorWorkOutstanding, state.outstandingFromTodos)
+    metrics.updateMetric(Metrics.ingestStoreOutstanding, state.outstandingFromIngestStore)
   }
 
   override def start(scheduler: Scheduler)(implicit ec: ExecutionContext): Unit = {


### PR DESCRIPTION
## What does this change?
It often looks like giant's not really doing anything when in fact it is frantically cranking through files from the ingest S3 bucket and adding them to giant/moving them to the dead letter bucket.

Having this metric in cloudwatch will mean we can see how far through the first part of a CLI ingestion we are.

## How has this change been tested?
 - [ ] Tested locally
 - [x] Tested on playground
