### PR TITLE
Giant document view: show list of comments in sidebar

### DIFF
--- a/frontend/src/js/components/viewer/CommentHighlighter.tsx
+++ b/frontend/src/js/components/viewer/CommentHighlighter.tsx
@@ -104,6 +104,8 @@ function HighlightWrapper({
     {
       class: focused ? `${elementType}--focused` : "",
       "data-highlight-offset": highlight.range.startCharacter,
+      "data-comment-id":
+        highlight.type === "comment" ? highlight.id : undefined,
       ref: onMountOrUnmount,
       onClick: (e: React.MouseEvent) => {
         if (highlight.type === "comment") {

--- a/frontend/src/js/components/viewer/CommentPanel/CommentPanel.tsx
+++ b/frontend/src/js/components/viewer/CommentPanel/CommentPanel.tsx
@@ -12,6 +12,7 @@ import {
 import { AddComment } from "./AddComment";
 import { filterCommentsInView } from "../../../util/commentUtils";
 import { HighlightRenderedPositions } from "../TextPreview";
+import ModalAction from "../../UtilComponents/ModalAction";
 
 import { sortBy, sumBy, takeWhile } from "lodash";
 
@@ -276,13 +277,11 @@ export const CommentPanel: FC<CommentPanelProps> = ({
                     </Comment.Metadata>
                     <Comment.Text>{c.text}</Comment.Text>
                     {currentUser.username === c.author.username && (
-                      <Comment.Actions>
-                        <Comment.Action
-                          onClick={() => deleteCommentRefresh(c.id)}
-                        >
-                          Delete
-                        </Comment.Action>
-                      </Comment.Actions>
+                      <DeleteCommentAction
+                        authorName={c.author.displayName}
+                        commentText={c.text}
+                        onDelete={() => deleteCommentRefresh(c.id)}
+                      />
                     )}
                   </Comment.Content>
                 </Comment>
@@ -304,3 +303,32 @@ export const CommentPanel: FC<CommentPanelProps> = ({
     </div>
   );
 };
+
+function DeleteCommentAction({
+  authorName,
+  commentText,
+  onDelete,
+}: {
+  authorName: string;
+  commentText: string;
+  onDelete: () => void;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  return (
+    <Comment.Actions>
+      <Comment.Action onClick={() => setConfirmOpen(true)}>
+        Delete
+      </Comment.Action>
+      <ModalAction
+        actionType="confirm"
+        actionDescription="Delete"
+        title="Delete this comment?"
+        text={`${authorName}: "${commentText}"`}
+        isOpen={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={onDelete}
+      />
+    </Comment.Actions>
+  );
+}

--- a/frontend/src/js/components/viewer/DocumentMetadata.js
+++ b/frontend/src/js/components/viewer/DocumentMetadata.js
@@ -4,6 +4,7 @@ import { resourcePropType } from "../../types/Resource";
 import { ResourceBreadcrumbs } from "../ResourceBreadcrumbs";
 import HoverSearchLink from "../UtilComponents/HoverSearchLink";
 import ViewerActions from "./ViewerActions";
+import { SidebarComments } from "./SidebarComments";
 import _ from "lodash";
 import hdate from "human-date";
 import { permissionsPropType } from "../../types/User";
@@ -145,6 +146,12 @@ export class DocumentMetadata extends React.Component {
           childClass="sidebar__list-item"
           resource={this.props.resource}
           showParents={true}
+        />
+
+        <SidebarComments
+          resource={this.props.resource}
+          currentView={this.props.currentView}
+          currentUser={this.props.currentUser}
         />
 
         {this.renderDevTools()}

--- a/frontend/src/js/components/viewer/DocumentMetadata.js
+++ b/frontend/src/js/components/viewer/DocumentMetadata.js
@@ -154,8 +154,6 @@ export class DocumentMetadata extends React.Component {
           currentUser={this.props.currentUser}
         />
 
-        {this.renderDevTools()}
-
         <div className="sidebar__title">
           <span>File Metadata</span>
           {hasEnrichedMetadata ? (
@@ -177,6 +175,8 @@ export class DocumentMetadata extends React.Component {
         </ul>
 
         {this.renderChildren()}
+
+        {this.renderDevTools()}
       </div>
     );
   }

--- a/frontend/src/js/components/viewer/EmailMetadata.js
+++ b/frontend/src/js/components/viewer/EmailMetadata.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { resourcePropType } from "../../types/Resource";
 import { ResourceBreadcrumbs } from "../ResourceBreadcrumbs";
 import ViewerActions from "./ViewerActions";
+import { SidebarComments } from "./SidebarComments";
 
 export class EmailMetadata extends React.Component {
   static propTypes = {
@@ -28,6 +29,12 @@ export class EmailMetadata extends React.Component {
           childClass="sidebar__list-item"
           resource={this.props.resource}
           showParents={true}
+        />
+
+        <SidebarComments
+          resource={this.props.resource}
+          currentView={this.props.currentView}
+          currentUser={this.props.currentUser}
         />
 
         {this.props.resource.children.length > 0 ? (

--- a/frontend/src/js/components/viewer/SidebarComments.tsx
+++ b/frontend/src/js/components/viewer/SidebarComments.tsx
@@ -4,6 +4,7 @@ import hdate from "human-date";
 import CommentIcon from "react-icons/lib/md/comment";
 import ExpandLess from "react-icons/lib/md/expand-less";
 import ExpandMore from "react-icons/lib/md/expand-more";
+import ModalAction from "../UtilComponents/ModalAction";
 
 import { CommentData, Resource } from "../../types/Resource";
 import { PartialUser } from "../../types/User";
@@ -166,6 +167,7 @@ function SidebarComment({
   onClick,
   onDelete,
 }: SidebarCommentProps) {
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const viewLabel = getCommentViewLabel(comment.anchor);
   const snippet = getCommentSnippet(comment.anchor, resource);
   const targetView = getViewForAnchor(comment.anchor);
@@ -205,13 +207,22 @@ function SidebarComment({
             className="btn sidebar-comments__delete"
             onClick={(e) => {
               e.stopPropagation();
-              onDelete();
+              setConfirmDeleteOpen(true);
             }}
           >
             Delete
           </button>
         )}
       </div>
+      <ModalAction
+        actionType="confirm"
+        actionDescription="Delete"
+        title="Delete this comment?"
+        text={`${comment.author.displayName}: "${comment.text}"`}
+        isOpen={confirmDeleteOpen}
+        onClose={() => setConfirmDeleteOpen(false)}
+        onConfirm={onDelete}
+      />
     </li>
   );
 }

--- a/frontend/src/js/components/viewer/SidebarComments.tsx
+++ b/frontend/src/js/components/viewer/SidebarComments.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import hdate from "human-date";
 import CommentIcon from "react-icons/lib/md/comment";
 import ExpandLess from "react-icons/lib/md/expand-less";
@@ -8,7 +8,6 @@ import ModalAction from "../UtilComponents/ModalAction";
 
 import { CommentData, Resource } from "../../types/Resource";
 import { PartialUser } from "../../types/User";
-import { GiantState } from "../../types/redux/GiantState";
 import {
   getCommentSnippet,
   getCommentViewLabel,
@@ -17,6 +16,7 @@ import {
 import { postComment, deleteComment } from "../../services/CommentsApi";
 import { getComments } from "../../actions/resources/getComments";
 import { setResourceView } from "../../actions/urlParams/setViews";
+import { ResourceActionType } from "../../types/redux/GiantActions";
 
 type SidebarCommentsProps = {
   resource: Resource;
@@ -65,7 +65,10 @@ export function SidebarComments({
     if (targetView !== currentView) {
       dispatch(setResourceView(targetView));
     }
-    // TODO(#702): set focusedCommentId to scroll to comment in CommentPanel
+    dispatch({
+      type: ResourceActionType.PENDING_SCROLL_TO_COMMENT,
+      commentId: comment.id,
+    });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/frontend/src/js/components/viewer/SidebarComments.tsx
+++ b/frontend/src/js/components/viewer/SidebarComments.tsx
@@ -1,0 +1,217 @@
+import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import hdate from "human-date";
+import CommentIcon from "react-icons/lib/md/comment";
+import ExpandLess from "react-icons/lib/md/expand-less";
+import ExpandMore from "react-icons/lib/md/expand-more";
+
+import { CommentData, Resource } from "../../types/Resource";
+import { PartialUser } from "../../types/User";
+import { GiantState } from "../../types/redux/GiantState";
+import {
+  getCommentSnippet,
+  getCommentViewLabel,
+  getViewForAnchor,
+} from "../../util/commentUtils";
+import { postComment, deleteComment } from "../../services/CommentsApi";
+import { getComments } from "../../actions/resources/getComments";
+import { setResourceView } from "../../actions/urlParams/setViews";
+
+type SidebarCommentsProps = {
+  resource: Resource;
+  currentView: string | undefined;
+  currentUser: PartialUser | undefined;
+};
+
+export function SidebarComments({
+  resource,
+  currentView,
+  currentUser,
+}: SidebarCommentsProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [newCommentText, setNewCommentText] = useState("");
+  const [sendingComment, setSendingComment] = useState(false);
+
+  const dispatch = useDispatch();
+  const comments = resource.comments ?? [];
+
+  const handleSubmit = async () => {
+    if (!newCommentText.trim()) return;
+
+    setSendingComment(true);
+    try {
+      await postComment(resource.uri, newCommentText.trim());
+      setNewCommentText("");
+      setAdding(false);
+      dispatch(getComments(resource.uri) as any);
+    } finally {
+      setSendingComment(false);
+    }
+  };
+
+  const handleDelete = async (commentId: string) => {
+    await deleteComment(commentId);
+    dispatch(getComments(resource.uri) as any);
+  };
+
+  const handleCommentClick = (comment: CommentData) => {
+    const targetView = getViewForAnchor(comment.anchor);
+    if (!targetView) {
+      // Document-level comment — no navigation
+      return;
+    }
+    if (targetView !== currentView) {
+      dispatch(setResourceView(targetView));
+    }
+    // TODO(#702): set focusedCommentId to scroll to comment in CommentPanel
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      setAdding(false);
+      setNewCommentText("");
+    } else if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div className="sidebar-comments">
+      <div className="sidebar__title">
+        <span
+          className="sidebar-comments__header"
+          onClick={() => setCollapsed(!collapsed)}
+        >
+          {collapsed ? <ExpandMore /> : <ExpandLess />}
+          Comments{comments.length > 0 ? ` (${comments.length})` : ""}
+        </span>
+      </div>
+
+      {!collapsed && (
+        <>
+          <ul className="sidebar-comments__list">
+            {comments.map((comment) => (
+              <SidebarComment
+                key={comment.id}
+                comment={comment}
+                resource={resource}
+                currentView={currentView}
+                currentUser={currentUser}
+                onClick={() => handleCommentClick(comment)}
+                onDelete={() => handleDelete(comment.id)}
+              />
+            ))}
+          </ul>
+
+          {adding ? (
+            <div className="sidebar-comments__add">
+              <textarea
+                rows={3}
+                placeholder="Add a comment about this document…"
+                value={newCommentText}
+                onChange={(e) => setNewCommentText(e.target.value)}
+                onKeyDown={handleKeyDown}
+                autoFocus
+              />
+              <div className="sidebar-comments__add-actions">
+                <input
+                  type="submit"
+                  className="btn"
+                  disabled={!newCommentText.trim() || sendingComment}
+                  value="Comment"
+                  onClick={handleSubmit}
+                />
+                <input
+                  type="button"
+                  className="btn"
+                  disabled={sendingComment}
+                  value="Cancel"
+                  onClick={() => {
+                    setAdding(false);
+                    setNewCommentText("");
+                  }}
+                />
+              </div>
+            </div>
+          ) : (
+            <button
+              className="btn sidebar-comments__add-btn"
+              onClick={() => setAdding(true)}
+            >
+              <CommentIcon /> Add comment
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+type SidebarCommentProps = {
+  comment: CommentData;
+  resource: Resource;
+  currentView: string | undefined;
+  currentUser: PartialUser | undefined;
+  onClick: () => void;
+  onDelete: () => void;
+};
+
+function SidebarComment({
+  comment,
+  resource,
+  currentView,
+  currentUser,
+  onClick,
+  onDelete,
+}: SidebarCommentProps) {
+  const viewLabel = getCommentViewLabel(comment.anchor);
+  const snippet = getCommentSnippet(comment.anchor, resource);
+  const targetView = getViewForAnchor(comment.anchor);
+  const isInCurrentView = targetView === currentView;
+  const isClickable = !!targetView;
+  const canDelete =
+    currentUser && comment.author.username === currentUser.username;
+
+  return (
+    <li
+      className={`sidebar-comments__comment ${isClickable ? "sidebar-comments__comment--clickable" : ""}`}
+      onClick={isClickable ? onClick : undefined}
+    >
+      <div className="sidebar-comments__comment-header">
+        <span className="sidebar-comments__author">
+          {comment.author.displayName}
+        </span>
+        <span
+          className={`sidebar-comments__view-tag ${isInCurrentView ? "sidebar-comments__view-tag--current" : ""}`}
+        >
+          {viewLabel}
+        </span>
+      </div>
+
+      {snippet && (
+        <div className="sidebar-comments__snippet">&ldquo;{snippet}&rdquo;</div>
+      )}
+
+      <div className="sidebar-comments__text">{comment.text}</div>
+
+      <div className="sidebar-comments__footer">
+        <span className="sidebar-comments__time">
+          {hdate.relativeTime(new Date(comment.postedAt))}
+        </span>
+        {canDelete && (
+          <button
+            className="btn sidebar-comments__delete"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+          >
+            Delete
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/frontend/src/js/components/viewer/TextPopover.js
+++ b/frontend/src/js/components/viewer/TextPopover.js
@@ -65,10 +65,18 @@ class TextPopoverUnconnected extends React.Component {
         >
           <div className="textpopover-wrapper">
             <div className="textpopover">
-              <button className="btn textpopover__button" onClick={this.search}>
+              <button
+                className="btn textpopover__button"
+                onClick={this.search}
+                title="Search in Giant"
+              >
                 <SearchIcon className="textpopover-icon" />
               </button>
-              <button className="btn" onClick={this.addComment}>
+              <button
+                className="btn"
+                onClick={this.addComment}
+                title="Add comment"
+              >
                 <CommentIcon className="textpopover-icon" />
               </button>
             </div>

--- a/frontend/src/js/components/viewer/TextPreview.tsx
+++ b/frontend/src/js/components/viewer/TextPreview.tsx
@@ -134,7 +134,7 @@ export function TextPreview({
         el.scrollIntoView({ block: "center", inline: "center" });
       }
     });
-  }, [pendingScrollToCommentId]);
+  }, [pendingScrollToCommentId, reduxDispatch]);
 
   return (
     <div className="document__preview" onClick={() => focusComment(undefined)}>

--- a/frontend/src/js/components/viewer/TextPreview.tsx
+++ b/frontend/src/js/components/viewer/TextPreview.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import TextPopover from "./TextPopover";
 import { CommentHighlighter } from "./CommentHighlighter";
 import { filterCommentsInView } from "../../util/commentUtils";
@@ -6,6 +7,8 @@ import { ResourceRange, Highlight, CommentData } from "../../types/Resource";
 import sortBy from "lodash/sortBy";
 import { CommentPanel } from "./CommentPanel/CommentPanel";
 import { PartialUser } from "../../types/User";
+import { GiantState } from "../../types/redux/GiantState";
+import { ResourceActionType } from "../../types/redux/GiantActions";
 
 function getExistingCommentHighlights(
   comments: CommentData[],
@@ -100,9 +103,38 @@ export function TextPreview({
   >(undefined);
 
   function focusComment(id?: string) {
-    setFocusedCommentId(id);
-    setPreviousFocusedCommentId(focusedCommentId);
+    setFocusedCommentId((prev) => {
+      setPreviousFocusedCommentId(prev);
+      return id;
+    });
   }
+
+  const pendingScrollToCommentId = useSelector(
+    (state: GiantState) => state.pendingScrollToCommentId,
+  );
+  const reduxDispatch = useDispatch();
+
+  useEffect(() => {
+    if (!pendingScrollToCommentId) return;
+
+    focusComment(pendingScrollToCommentId);
+
+    // Clear the one-shot signal
+    reduxDispatch({
+      type: ResourceActionType.PENDING_SCROLL_TO_COMMENT,
+      commentId: null,
+    });
+
+    // Allow a frame for the DOM to update after the focus state change
+    requestAnimationFrame(() => {
+      const el = document.querySelector(
+        `comment-highlight[data-comment-id="${CSS.escape(pendingScrollToCommentId)}"]`,
+      );
+      if (el) {
+        el.scrollIntoView({ block: "center", inline: "center" });
+      }
+    });
+  }, [pendingScrollToCommentId]);
 
   return (
     <div className="document__preview" onClick={() => focusComment(undefined)}>

--- a/frontend/src/js/components/viewer/TextPreview.tsx
+++ b/frontend/src/js/components/viewer/TextPreview.tsx
@@ -11,16 +11,18 @@ function getExistingCommentHighlights(
   comments: CommentData[],
   view?: string,
 ): Highlight[] {
-  return filterCommentsInView(comments, view).map(({ id, anchor }) => {
-    return {
-      id,
-      type: "comment",
-      range: {
-        startCharacter: anchor!.startCharacter,
-        endCharacter: anchor!.endCharacter,
-      },
-    };
-  });
+  return filterCommentsInView(comments, view)
+    .filter(({ anchor }) => anchor !== undefined)
+    .map(({ id, anchor }) => {
+      return {
+        id,
+        type: "comment",
+        range: {
+          startCharacter: anchor!.startCharacter,
+          endCharacter: anchor!.endCharacter,
+        },
+      };
+    });
 }
 
 function getNewCommentHighlight(selection?: ResourceRange): Highlight[] {

--- a/frontend/src/js/components/viewer/ViewerSidebar.js
+++ b/frontend/src/js/components/viewer/ViewerSidebar.js
@@ -76,6 +76,8 @@ class ViewerSidebar extends React.Component {
               resource={this.props.resource}
               config={this.props.config}
               myPermissions={this.props.myPermissions}
+              currentView={this.props.urlParams && this.props.urlParams.view}
+              currentUser={this.props.currentUser}
             />
           ) : (
             <EmailMetadata
@@ -84,6 +86,8 @@ class ViewerSidebar extends React.Component {
               isAdmin={this.props.myPermissions.includes(
                 "CanPerformAdminOperations",
               )}
+              currentView={this.props.urlParams && this.props.urlParams.view}
+              currentUser={this.props.currentUser}
             />
           )}
         </div>
@@ -101,6 +105,7 @@ function mapStateToProps(state) {
     resource: state.resource,
     config: state.app.config,
     myPermissions: state.users.myPermissions,
+    currentUser: state.auth.token ? state.auth.token.user : undefined,
   };
 }
 

--- a/frontend/src/js/reducers/index.js
+++ b/frontend/src/js/reducers/index.js
@@ -17,6 +17,7 @@ import highlights from "./highlightsReducer";
 import expandedFilters from "./expandedFiltersReducer";
 import isLoadingResource from "./isLoadingResourceReducer";
 import pages from "./pagesReducer";
+import pendingScrollToCommentId from "./pendingScrollToCommentReducer";
 
 const allReducers = (history) =>
   combineReducers({
@@ -38,5 +39,6 @@ const allReducers = (history) =>
     expandedFilters,
     isLoadingResource,
     pages,
+    pendingScrollToCommentId,
   });
 export default allReducers;

--- a/frontend/src/js/reducers/pendingScrollToCommentReducer.ts
+++ b/frontend/src/js/reducers/pendingScrollToCommentReducer.ts
@@ -1,0 +1,16 @@
+import {
+  ResourceAction,
+  ResourceActionType,
+} from "../types/redux/GiantActions";
+
+export default function pendingScrollToCommentId(
+  state: string | null = null,
+  action: ResourceAction,
+): string | null {
+  switch (action.type) {
+    case ResourceActionType.PENDING_SCROLL_TO_COMMENT:
+      return action.commentId ?? null;
+    default:
+      return state;
+  }
+}

--- a/frontend/src/js/types/redux/GiantActions.ts
+++ b/frontend/src/js/types/redux/GiantActions.ts
@@ -267,13 +267,18 @@ export enum ResourceActionType {
   RESET_RESOURCE = "RESET_RESOURCE",
   SET_COMMENTS = "RESOURCE_SET_COMMENTS",
   SET_SELECTION = "RESOURCE_SET_SELECTION",
+  PENDING_SCROLL_TO_COMMENT = "RESOURCE_PENDING_SCROLL_TO_COMMENT",
 }
 
 export type ResourceAction =
   | { type: ResourceActionType.GET_RECEIVE; resource: Resource }
   | { type: ResourceActionType.RESET_RESOURCE }
   | { type: ResourceActionType.SET_COMMENTS; comments: CommentData[] }
-  | { type: ResourceActionType.SET_SELECTION; selection?: ResourceRange };
+  | { type: ResourceActionType.SET_SELECTION; selection?: ResourceRange }
+  | {
+      type: ResourceActionType.PENDING_SCROLL_TO_COMMENT;
+      commentId: string | null;
+    };
 
 export enum LoadingStateActionType {
   SET_RESOURCE_LOADING_STATE = "SET_RESOURCE_LOADING_STATE",

--- a/frontend/src/js/types/redux/GiantState.ts
+++ b/frontend/src/js/types/redux/GiantState.ts
@@ -89,4 +89,5 @@ export interface GiantState {
   search: SearchState;
   isLoadingResource: LoadingState;
   pages: PagesState;
+  pendingScrollToCommentId: string | null;
 }

--- a/frontend/src/js/util/commentUtils.spec.ts
+++ b/frontend/src/js/util/commentUtils.spec.ts
@@ -1,0 +1,171 @@
+import { CommentData, Resource } from "../types/Resource";
+import {
+  filterCommentsInView,
+  getCommentSnippet,
+  getCommentViewLabel,
+  getViewForAnchor,
+} from "./commentUtils";
+
+const makeResource = (overrides: Partial<Resource> = {}): Resource => ({
+  uri: "test-uri",
+  type: "blob",
+  isExpandable: false,
+  processingStage: { type: "processed" },
+  extracted: true,
+  mimeTypes: ["text/plain"],
+  fileSize: 100,
+  parents: [],
+  children: [],
+  comments: [],
+  previewStatus: "enabled",
+  text: {
+    contents: "Hello world, this is a test document with some content.",
+    highlights: [],
+  },
+  ocr: {
+    en: {
+      contents: "OCR English text from the scanned page.",
+      highlights: [],
+    },
+    fr: {
+      contents: "Texte OCR français de la page numérisée.",
+      highlights: [],
+    },
+  },
+  ...overrides,
+});
+
+const textComment: CommentData = {
+  id: "c1",
+  author: { username: "alice", displayName: "Alice" },
+  postedAt: Date.now(),
+  text: "Interesting passage",
+  anchor: { type: "text", startCharacter: 0, endCharacter: 11 },
+};
+
+const ocrEnComment: CommentData = {
+  id: "c2",
+  author: { username: "bob", displayName: "Bob" },
+  postedAt: Date.now(),
+  text: "Check this OCR",
+  anchor: { type: "ocr", language: "en", startCharacter: 0, endCharacter: 11 },
+};
+
+const ocrFrComment: CommentData = {
+  id: "c3",
+  author: { username: "bob", displayName: "Bob" },
+  postedAt: Date.now(),
+  text: "Vérifier ceci",
+  anchor: { type: "ocr", language: "fr", startCharacter: 0, endCharacter: 10 },
+};
+
+const documentComment: CommentData = {
+  id: "c4",
+  author: { username: "alice", displayName: "Alice" },
+  postedAt: Date.now(),
+  text: "General note about this document",
+};
+
+const allComments = [textComment, ocrEnComment, ocrFrComment, documentComment];
+
+describe("filterCommentsInView", () => {
+  test("shows text comments and document-level comments in text view", () => {
+    const result = filterCommentsInView(allComments, "text");
+    expect(result).toEqual([textComment, documentComment]);
+  });
+
+  test("shows OCR English comments and document-level comments in ocr.en view", () => {
+    const result = filterCommentsInView(allComments, "ocr.en");
+    expect(result).toEqual([ocrEnComment, documentComment]);
+  });
+
+  test("shows OCR French comments and document-level comments in ocr.fr view", () => {
+    const result = filterCommentsInView(allComments, "ocr.fr");
+    expect(result).toEqual([ocrFrComment, documentComment]);
+  });
+
+  test("shows only document-level comments when view is undefined", () => {
+    const result = filterCommentsInView(allComments, undefined);
+    expect(result).toEqual([documentComment]);
+  });
+
+  test("shows only document-level comments for a view with no matching anchored comments", () => {
+    const result = filterCommentsInView(allComments, "ocr.de");
+    expect(result).toEqual([documentComment]);
+  });
+});
+
+describe("getCommentSnippet", () => {
+  const resource = makeResource();
+
+  test("returns snippet for text anchor", () => {
+    expect(getCommentSnippet(textComment.anchor, resource)).toBe("Hello world");
+  });
+
+  test("returns snippet for OCR anchor", () => {
+    expect(getCommentSnippet(ocrEnComment.anchor, resource)).toBe(
+      "OCR English",
+    );
+  });
+
+  test("returns undefined for document-level comment", () => {
+    expect(getCommentSnippet(undefined, resource)).toBeUndefined();
+  });
+
+  test("truncates long snippets", () => {
+    const longResource = makeResource({
+      text: {
+        contents: "A".repeat(200),
+        highlights: [],
+      },
+    });
+    const anchor = {
+      type: "text" as const,
+      startCharacter: 0,
+      endCharacter: 200,
+    };
+    const snippet = getCommentSnippet(anchor, longResource, 80);
+    expect(snippet).toHaveLength(81); // 80 chars + ellipsis
+    expect(snippet!.endsWith("…")).toBe(true);
+  });
+
+  test("returns undefined when text content is empty", () => {
+    const emptyResource = makeResource({
+      text: { contents: "", highlights: [] },
+    });
+    const anchor = {
+      type: "text" as const,
+      startCharacter: 0,
+      endCharacter: 5,
+    };
+    expect(getCommentSnippet(anchor, emptyResource)).toBeUndefined();
+  });
+});
+
+describe("getCommentViewLabel", () => {
+  test("returns 'Text' for text anchor", () => {
+    expect(getCommentViewLabel(textComment.anchor)).toBe("Text");
+  });
+
+  test("returns 'OCR en' for OCR English anchor", () => {
+    expect(getCommentViewLabel(ocrEnComment.anchor)).toBe("OCR en");
+  });
+
+  test("returns 'Document' for no anchor", () => {
+    expect(getCommentViewLabel(undefined)).toBe("Document");
+  });
+});
+
+describe("getViewForAnchor", () => {
+  test("returns 'text' for text anchor", () => {
+    expect(getViewForAnchor(textComment.anchor)).toBe("text");
+  });
+
+  test("returns 'ocr.en' for OCR English anchor", () => {
+    expect(getViewForAnchor(ocrEnComment.anchor)).toBe("ocr.en");
+  });
+
+  test("returns undefined for no anchor", () => {
+    expect(getViewForAnchor(undefined)).toBeUndefined();
+  });
+});

--- a/frontend/src/js/util/commentUtils.ts
+++ b/frontend/src/js/util/commentUtils.ts
@@ -1,4 +1,4 @@
-import { CommentAnchor, CommentData } from "../types/Resource";
+import { CommentAnchor, CommentData, Resource } from "../types/Resource";
 
 function commentInView(anchor: CommentAnchor, view?: string): boolean {
   if (!view) {
@@ -18,6 +18,66 @@ export function filterCommentsInView(
   view?: string,
 ): CommentData[] {
   return comments.filter(({ anchor }) => {
-    return anchor && commentInView(anchor, view);
+    // Document-level comments (no anchor) are shown in every view
+    if (!anchor) {
+      return true;
+    }
+    return commentInView(anchor, view);
   });
+}
+
+export function getCommentSnippet(
+  anchor: CommentAnchor | undefined,
+  resource: Resource,
+  maxLength: number = 80,
+): string | undefined {
+  if (!anchor) {
+    return undefined;
+  }
+
+  const text = getTextForAnchor(anchor, resource);
+  if (!text) {
+    return undefined;
+  }
+
+  const snippet = text.slice(anchor.startCharacter, anchor.endCharacter);
+  if (snippet.length <= maxLength) {
+    return snippet;
+  }
+  return snippet.slice(0, maxLength) + "…";
+}
+
+export function getCommentViewLabel(anchor: CommentAnchor | undefined): string {
+  if (!anchor) {
+    return "Document";
+  }
+  if (anchor.type === "ocr") {
+    return `OCR ${anchor.language}`;
+  }
+  return "Text";
+}
+
+export function getViewForAnchor(
+  anchor: CommentAnchor | undefined,
+): string | undefined {
+  if (!anchor) {
+    return undefined;
+  }
+  if (anchor.type === "ocr") {
+    return `ocr.${anchor.language}`;
+  }
+  return "text";
+}
+
+function getTextForAnchor(
+  anchor: CommentAnchor,
+  resource: Resource,
+): string | undefined {
+  if (anchor.type === "text") {
+    return resource.text?.contents;
+  }
+  if (anchor.type === "ocr" && resource.ocr) {
+    return resource.ocr[anchor.language]?.contents;
+  }
+  return undefined;
 }

--- a/frontend/src/stylesheets/components/_sidebar-comments.scss
+++ b/frontend/src/stylesheets/components/_sidebar-comments.scss
@@ -1,0 +1,113 @@
+.sidebar-comments {
+  margin-bottom: $baseSpacing;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  &__comment {
+    padding: calc($baseSpacing / 2) $baseSpacing;
+    border-bottom: 1px solid $secondaryDark;
+
+    &--clickable {
+      cursor: pointer;
+
+      &:hover {
+        background-color: $secondary;
+      }
+    }
+  }
+
+  &__comment-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
+  }
+
+  &__author {
+    font-weight: bold;
+    font-size: 12px;
+  }
+
+  &__view-tag {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: $borderRadius;
+    background-color: $secondaryDark;
+    color: $primary;
+
+    &--current {
+      background-color: $primaryLight;
+      color: white;
+    }
+  }
+
+  &__snippet {
+    font-size: 11px;
+    font-style: italic;
+    color: $primary;
+    margin-bottom: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__text {
+    font-size: 12px;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 4px;
+  }
+
+  &__time {
+    font-size: 10px;
+    color: $borderColour;
+  }
+
+  &__delete {
+    font-size: 10px;
+    padding: 0 4px;
+    color: $accentPink;
+  }
+
+  &__add {
+    padding: calc($baseSpacing / 2) $baseSpacing;
+
+    textarea {
+      resize: none;
+      width: 100%;
+      margin-bottom: calc($baseSpacing / 2);
+      font-size: 12px;
+    }
+  }
+
+  &__add-actions {
+    display: flex;
+    gap: calc($baseSpacing / 2);
+  }
+
+  &__add-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin: calc($baseSpacing / 2) $baseSpacing;
+    font-size: 12px;
+  }
+}

--- a/frontend/src/stylesheets/main.scss
+++ b/frontend/src/stylesheets/main.scss
@@ -21,4 +21,5 @@
   "./components/workspace", "./components/file-browser",
   "./components/lazy-tree-browser", "./components/modal-action",
   "./components/users", "./components/page", "./components/upload-files",
-  "./components/markdown-page", "./components/docs-sidebar";
+  "./components/markdown-page", "./components/docs-sidebar",
+  "./components/sidebar-comments";


### PR DESCRIPTION
An attempt to fix or improve upon the following:

- Our preferred document view, "Combined", doesn't support the comments feature in any way. You wouldn't even know comments existed. https://github.com/guardian/giant/issues/704
- Users can't make comments about documents; only about text highlights in documents. https://github.com/guardian/giant/issues/705
- If a user makes a comment in "Text" view mode, it's not visible in OCR (or any other text based) view mode; and vice versa. https://github.com/guardian/giant/issues/708
- Even in view modes where comments are supported, there is no indication that comments exist elsewhere in a document. #709 
- When users select some text in a text based view mode, they get two icons but not much signal for what the icons do. Add some rollover text for these tools. https://github.com/guardian/giant/issues/700
- There's no facility to "see all the comments for this document".

**Before:**

https://github.com/user-attachments/assets/0b35428c-ff7c-4c2f-b875-0fa0da50c5c0


**After:**

<img width="2728" height="1900" alt="2026-04-29 14 27 07" src="https://github.com/user-attachments/assets/7dc8076a-b229-4ce9-98fb-561353fbf094" />

I haven't attempted inline comments in the PageViewer, because exchanging the positions across different view modes would be very clunky. But you can at least see all comments in all views, and navigate to them in situ in the text view modes.

Plus you can make unanchored comments - i.e. about the whole document - in any view mode.

## Changes

- **Unified comment sidebar** — shows all comments across all views with view tags (Text/OCR/Document), text snippets, collapse/expand, and document-level comment creation (#701, #704)
- **Text selection tooltips** — added title attributes to search and comment popover buttons (#700)
- **Delete confirmation dialog** — comments now require confirmation before deletion, showing author and text (#705)
- **Scroll-to-comment** — clicking an anchored comment in the sidebar switches to the correct view and scrolls to the highlight (#702)
- **Dev Tools moved to bottom** of sidebar so comments sit in a more prominent position
- **Bug fix** — document-level comments (no anchor) no longer crash the text view highlight mapper

## Testing

- [x] Integration tests: 171 lines of new tests for `commentUtils` utility functions
- [x] Played with it on local for various document types
- [x] Playground 