### PR TITLE
Allow anyone to reprocess a file in a public workspace

### DIFF
--- a/backend/app/controllers/api/Blobs.scala
+++ b/backend/app/controllers/api/Blobs.scala
@@ -136,7 +136,7 @@ class Blobs(override val controllerComponents: AuthControllerComponents, manifes
       }
       else {
         manifest.getWorkspacesForBlob(id).map { workspaces =>
-          workspaces.exists(w => w.followers.exists(u => u.username == username))
+          workspaces.exists(w => w.followers.exists(u => u.username == username) || w.isPublic)
         }
       }
     }


### PR DESCRIPTION
## What does this change?
Currently only people shared on a workspace or the original file uploader can send items in a workspace for reprocessing. This means that for public workspace e.g. https://giant.pfi.gutools.co.uk/workspaces/4e0aa1d3-40c7-46fb-8473-c6ad62b722ff/798ae20b-9bc4-4b95-ba2b-cd7fb5405a6d you get the option in the context menu to reprocess a file but it errors 100% of the time if you're not the original uploader

This resolves that by allowing anyone to reprocess files in a public workspace. This seems reasonable since they could always download the file and reupload it with the same name to get the same effect anyway.


## How has this change been tested?
 - [ ] Tested locally
 - [ ] Tested on playground
