### PR TITLE
Unify search/find highlight stepper logic into shared hook

### DIFF
--- a/frontend/src/js/components/PageViewer/Controls.tsx
+++ b/frontend/src/js/components/PageViewer/Controls.tsx
@@ -1,8 +1,7 @@
-import React, { FC, useCallback, useEffect, useState } from "react";
+import React, { FC, useEffect } from "react";
 import { SearchStepper } from "./SearchStepper";
-import { HighlightForSearchNavigation, HighlightsState } from "./model";
-import { removeLastUnmatchedQuote } from "../../util/stringUtils";
-import authFetch from "../../util/auth/authFetch";
+import { HighlightsState } from "./model";
+import { useHighlightNavigation } from "./useHighlightNavigation";
 
 type ControlsProps = {
   fixedQuery: string;
@@ -15,86 +14,33 @@ export const Controls: FC<ControlsProps> = ({
   uri,
   onHighlightStateChange,
 }) => {
-  const [focusedFindHighlightIndex, setFocusedFindHighlightIndex] = useState<
-    number | null
-  >(null);
-  const [findHighlights, setFindHighlights] = useState<
-    HighlightForSearchNavigation[]
-  >([]);
-  const [isFindPending, setIsFindPending] = useState<boolean>(false);
+  const {
+    highlightsState,
+    isPending,
+    fetchHighlights,
+    jumpToNext,
+    jumpToPrevious,
+  } = useHighlightNavigation(uri, "search");
 
   useEffect(() => {
-    onHighlightStateChange({
-      focusedIndex: focusedFindHighlightIndex,
-      highlights: findHighlights,
-    });
-  }, [focusedFindHighlightIndex, findHighlights, onHighlightStateChange]);
-
-  const performFind = useCallback(
-    (query: string) => {
-      if (!query) {
-        setFocusedFindHighlightIndex(null);
-        setFindHighlights([]);
-        return;
-      }
-
-      const params = new URLSearchParams();
-      params.set("q", removeLastUnmatchedQuote(query));
-      setIsFindPending(true);
-      // TODO: handle error
-      return authFetch(`/api/pages2/${uri}/search?${params.toString()}`)
-        .then((res) => res.json())
-        .then((highlights) => {
-          setIsFindPending(false);
-          setFindHighlights(highlights);
-          if (highlights.length > 0) {
-            setFocusedFindHighlightIndex(0);
-          } else {
-            setFocusedFindHighlightIndex(null);
-          }
-        });
-    },
-    [uri],
-  );
+    onHighlightStateChange(highlightsState);
+  }, [highlightsState, onHighlightStateChange]);
 
   // Auto-trigger the search when mounted with a fixed query
   useEffect(() => {
     if (fixedQuery) {
-      performFind(fixedQuery);
+      fetchHighlights(fixedQuery);
     }
-  }, [fixedQuery, performFind]);
-
-  const jumpToNextFindHit = useCallback(() => {
-    if (findHighlights.length > 0) {
-      const nextHighlightIndex =
-        focusedFindHighlightIndex !== null &&
-        focusedFindHighlightIndex < findHighlights.length - 1
-          ? focusedFindHighlightIndex + 1
-          : 0;
-
-      setFocusedFindHighlightIndex(nextHighlightIndex);
-    }
-  }, [findHighlights, focusedFindHighlightIndex]);
-
-  const jumpToPreviousFindHit = useCallback(() => {
-    if (findHighlights.length > 0) {
-      const previousHighlightIndex =
-        focusedFindHighlightIndex !== null && focusedFindHighlightIndex > 0
-          ? focusedFindHighlightIndex - 1
-          : findHighlights.length - 1;
-
-      setFocusedFindHighlightIndex(previousHighlightIndex);
-    }
-  }, [findHighlights, focusedFindHighlightIndex]);
+  }, [fixedQuery, fetchHighlights]);
 
   return (
     <SearchStepper
       query={fixedQuery}
-      current={focusedFindHighlightIndex ?? undefined}
-      total={findHighlights.length}
-      isPending={isFindPending}
-      onNext={jumpToNextFindHit}
-      onPrevious={jumpToPreviousFindHit}
+      current={highlightsState.focusedIndex ?? undefined}
+      total={highlightsState.highlights.length}
+      isPending={isPending}
+      onNext={jumpToNext}
+      onPrevious={jumpToPrevious}
     />
   );
 };

--- a/frontend/src/js/components/PageViewer/useHighlightNavigation.ts
+++ b/frontend/src/js/components/PageViewer/useHighlightNavigation.ts
@@ -3,6 +3,12 @@ import { HighlightForSearchNavigation, HighlightsState } from "./model";
 import { removeLastUnmatchedQuote } from "../../util/stringUtils";
 import authFetch from "../../util/auth/authFetch";
 
+/**
+ * - "find": on-demand find-in-document queries typed by the user.
+ * - "search": the workspace-level search query, fixed for the lifetime of the
+ *   page viewer. Parses chip syntax and returns highlights with a distinct prefix
+ *   so both sets can coexist without colliding.
+ */
 type HighlightEndpoint = "search" | "find";
 
 export type HighlightNavigationState = {

--- a/frontend/src/js/components/PageViewer/useHighlightNavigation.ts
+++ b/frontend/src/js/components/PageViewer/useHighlightNavigation.ts
@@ -1,0 +1,93 @@
+import { useCallback, useMemo, useState } from "react";
+import { HighlightForSearchNavigation, HighlightsState } from "./model";
+import { removeLastUnmatchedQuote } from "../../util/stringUtils";
+import authFetch from "../../util/auth/authFetch";
+
+type HighlightEndpoint = "search" | "find";
+
+export type HighlightNavigationState = {
+  query: string;
+  highlightsState: HighlightsState;
+  focusedHighlight: HighlightForSearchNavigation | null;
+  isPending: boolean;
+  fetchHighlights: (query: string) => Promise<void> | undefined;
+  jumpToNext: () => void;
+  jumpToPrevious: () => void;
+};
+
+export function useHighlightNavigation(
+  uri: string,
+  endpoint: HighlightEndpoint,
+): HighlightNavigationState {
+  const [query, setQuery] = useState("");
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const [highlights, setHighlights] = useState<HighlightForSearchNavigation[]>(
+    [],
+  );
+  const [isPending, setIsPending] = useState(false);
+
+  const fetchHighlights = useCallback(
+    (q: string) => {
+      if (!q) {
+        setFocusedIndex(null);
+        setHighlights([]);
+        setQuery("");
+        return;
+      }
+
+      const params = new URLSearchParams();
+      // The backend will respect quotes and do an exact search,
+      // but if quotes are unbalanced elasticsearch will error
+      params.set("q", removeLastUnmatchedQuote(q));
+
+      setQuery(q);
+      setIsPending(true);
+      // TODO: handle error
+      return authFetch(`/api/pages2/${uri}/${endpoint}?${params.toString()}`)
+        .then((res) => res.json())
+        .then((results: HighlightForSearchNavigation[]) => {
+          setIsPending(false);
+          setHighlights(results);
+          setFocusedIndex(results.length > 0 ? 0 : null);
+        });
+    },
+    [uri, endpoint],
+  );
+
+  const jumpToNext = useCallback(() => {
+    if (highlights.length > 0) {
+      setFocusedIndex((prev) =>
+        prev !== null && prev < highlights.length - 1 ? prev + 1 : 0,
+      );
+    }
+  }, [highlights.length]);
+
+  const jumpToPrevious = useCallback(() => {
+    if (highlights.length > 0) {
+      setFocusedIndex((prev) =>
+        prev !== null && prev > 0 ? prev - 1 : highlights.length - 1,
+      );
+    }
+  }, [highlights.length]);
+
+  const highlightsState = useMemo<HighlightsState>(
+    () => ({
+      focusedIndex,
+      highlights,
+    }),
+    [focusedIndex, highlights],
+  );
+
+  const focusedHighlight =
+    focusedIndex !== null ? (highlights[focusedIndex] ?? null) : null;
+
+  return {
+    query,
+    highlightsState,
+    focusedHighlight,
+    isPending,
+    fetchHighlights,
+    jumpToNext,
+    jumpToPrevious,
+  };
+}

--- a/frontend/src/js/components/PageViewer/usePageFind.ts
+++ b/frontend/src/js/components/PageViewer/usePageFind.ts
@@ -1,7 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
 import { HighlightForSearchNavigation, HighlightsState } from "./model";
-import { removeLastUnmatchedQuote } from "../../util/stringUtils";
-import authFetch from "../../util/auth/authFetch";
+import {
+  HighlightNavigationState,
+  useHighlightNavigation,
+} from "./useHighlightNavigation";
 
 export type PageFindState = {
   findQuery: string;
@@ -13,76 +14,18 @@ export type PageFindState = {
   jumpToPrevious: () => void;
 };
 
-export function usePageFind(uri: string): PageFindState {
-  const [findQuery, setFindQuery] = useState("");
-  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
-  const [highlights, setHighlights] = useState<HighlightForSearchNavigation[]>(
-    [],
-  );
-  const [isPending, setIsPending] = useState(false);
-
-  const performFind = useCallback(
-    (query: string) => {
-      if (!query) {
-        setFocusedIndex(null);
-        setHighlights([]);
-        setFindQuery("");
-        return;
-      }
-
-      const params = new URLSearchParams();
-      // The backend will respect quotes and do an exact search,
-      // but if quotes are unbalanced elasticsearch will error
-      params.set("q", removeLastUnmatchedQuote(query));
-
-      setFindQuery(query);
-      setIsPending(true);
-      // TODO: handle error
-      return authFetch(`/api/pages2/${uri}/find?${params.toString()}`)
-        .then((res) => res.json())
-        .then((results: HighlightForSearchNavigation[]) => {
-          setIsPending(false);
-          setHighlights(results);
-          setFocusedIndex(results.length > 0 ? 0 : null);
-        });
-    },
-    [uri],
-  );
-
-  const jumpToNext = useCallback(() => {
-    if (highlights.length > 0) {
-      setFocusedIndex((prev) =>
-        prev !== null && prev < highlights.length - 1 ? prev + 1 : 0,
-      );
-    }
-  }, [highlights.length]);
-
-  const jumpToPrevious = useCallback(() => {
-    if (highlights.length > 0) {
-      setFocusedIndex((prev) =>
-        prev !== null && prev > 0 ? prev - 1 : highlights.length - 1,
-      );
-    }
-  }, [highlights.length]);
-
-  const highlightsState = useMemo<HighlightsState>(
-    () => ({
-      focusedIndex,
-      highlights,
-    }),
-    [focusedIndex, highlights],
-  );
-
-  const focusedHighlight =
-    focusedIndex !== null ? (highlights[focusedIndex] ?? null) : null;
-
+function toPageFindState(nav: HighlightNavigationState): PageFindState {
   return {
-    findQuery,
-    highlightsState,
-    focusedHighlight,
-    isPending,
-    performFind,
-    jumpToNext,
-    jumpToPrevious,
+    findQuery: nav.query,
+    highlightsState: nav.highlightsState,
+    focusedHighlight: nav.focusedHighlight,
+    isPending: nav.isPending,
+    performFind: nav.fetchHighlights,
+    jumpToNext: nav.jumpToNext,
+    jumpToPrevious: nav.jumpToPrevious,
   };
+}
+
+export function usePageFind(uri: string): PageFindState {
+  return toPageFindState(useHighlightNavigation(uri, "find"));
 }


### PR DESCRIPTION
See  #668, #669

As suggested by An Actual Engineer, this extracts the duplicated highlight-fetching and step-through navigation logic from `Controls.tsx` and `usePageFind.ts` into a single `useHighlightNavigation` hook parameterised by endpoint (`'search' | 'find'`).

## Changes

- **`useHighlightNavigation.ts`** — new shared hook handling highlight fetching, caching, and prev/next navigation for both search and find
- **`Controls.tsx`** — delegates to `useHighlightNavigation(uri, 'search')` instead of managing its own state
- **`usePageFind.ts`** — thin wrapper around `useHighlightNavigation(uri, 'find')`, preserving the existing `PageFindState` interface

## Motivation

Both `Controls` and `usePageFind` independently implemented the same fetch → store → step-through pattern for page highlights. This consolidation removes ~146 lines of duplication and makes the semantic difference between the two endpoints explicit.
