### PR TITLE
Fix/add document viewer keyboard shortcuts

### DIFF
--- a/frontend/src/js/components/viewer/PreviewSwitcher.js
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.js
@@ -105,8 +105,31 @@ class PreviewSwitcher extends React.Component {
     this.props.setResourceView("text");
   };
 
+  showCombined = () => {
+    if (this.props.totalPages > 0) {
+      this.props.setResourceView("combined");
+    }
+  };
+
   showPreview = () => {
-    if (this.supported()) this.props.setResourceView("preview");
+    if (this.canPreview(this.props.resource?.previewStatus)) {
+      this.props.setResourceView("preview");
+    }
+  };
+
+  showOcr = () => {
+    const resource = this.props.resource;
+    if (resource?.transcript) {
+      const languages = Object.keys(resource.transcript);
+      if (languages.length > 0) {
+        this.props.setResourceView(`transcript.${languages[0]}`);
+      }
+    } else if (resource?.ocr) {
+      const languages = Object.keys(resource.ocr);
+      if (languages.length > 0) {
+        this.props.setResourceView(`ocr.${languages[0]}`);
+      }
+    }
   };
 
   showTable = () => {
@@ -147,8 +170,16 @@ class PreviewSwitcher extends React.Component {
           func={this.showText}
         />
         <KeyboardShortcut
+          shortcut={keyboardShortcuts.showCombined}
+          func={this.showCombined}
+        />
+        <KeyboardShortcut
           shortcut={keyboardShortcuts.showPreview}
           func={this.showPreview}
+        />
+        <KeyboardShortcut
+          shortcut={keyboardShortcuts.showOcr}
+          func={this.showOcr}
         />
         {this.props.totalPages > 0 && (
           <PreviewLink

--- a/frontend/src/js/components/viewer/PreviewSwitcher.js
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.js
@@ -106,6 +106,7 @@ class PreviewSwitcher extends React.Component {
   };
 
   showCombined = () => {
+    // Combined view is only available when the document has been ingested as pages (e.g. PDF).
     if (this.props.totalPages > 0) {
       this.props.setResourceView("combined");
     }

--- a/frontend/src/js/util/keyboardShortcuts.js
+++ b/frontend/src/js/util/keyboardShortcuts.js
@@ -4,6 +4,8 @@ export const keyboardShortcuts = {
   previousHighlight: "shift+n",
   nextHighlight: "n",
   focusSearchBox: "s",
-  showText: "shift+x",
-  showPreview: "shift+c",
+  showText: "shift+t",
+  showCombined: "shift+c",
+  showPreview: "shift+p",
+  showOcr: "shift+o",
 };


### PR DESCRIPTION
We use mousetrap to intercept keyboard events when the user is not in an input field. Our convention is shfift + character, e.g. shift right does "next document in search/worksace". We had shift X and shift C when there were only two document views, but shift C didn't work. This adds shorcuts for all four main view types.

- Shift+T: Switch to Text view (was Shift+X)
- Shift+C: Switch to Combined view (new)
- Shift+P: Switch to Preview/Audio/Video view (was Shift+C, broken)
- Shift+O: Switch to first OCR/Transcript view (new)

If there are multiple OCR or transcript views, the first one is activated. 

Fix: the `showPreview` handler called a non-existent `this.supported()` method, meaning the preview shortcut has never worked. Replaced it with a correct `this.canPreview()` guard.

Add new handlers for Combined and OCR/Transcript views with appropriate availability guards.
