### PR TITLE
Check all pages in a pdf when deciding whether to downscale it to A1.

### DIFF
--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -54,7 +54,7 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
     try {
       pdDocuments = params.languages.map { lang =>
         val pages = Using(PDDocument.load(file))(_.getNumberOfPages).toOption
-        val biggerThanA1 = Ocr.isBiggerThanA1(file.toPath, stdErrLogger)
+        val biggerThanA1 = Ocr.hasPagesBiggerThanA1(file.toPath, stdErrLogger)
         val preProcessPdf = Ocr.preProcessPdf(file.toPath, tmpDir, stdErrLogger, biggerThanA1)
         val pdfPath = Ocr.invokeOcrMyPdf(lang.ocr, preProcessPdf.getOrElse(file.toPath), None, stdErrLogger, tmpDir, pages, ocrMyPdfFlag)
         val pdfDoc = PDDocument.load(pdfPath.toFile)
@@ -113,6 +113,7 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
       }
 
       OcrMyPdfExtractor.insertFullText(blob.uri, pages, index)
+
     } finally {
       pdDocuments.foreach { case(_, (path, doc)) =>
         doc.close()

--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -117,32 +117,25 @@ object Ocr extends Logging {
     }
   }
 
-  // Uses pdfinfo to get the page size of the first page of the PDF, true if it's bigger than A1
-  def isBiggerThanA1(inputFilePath: Path, stderrLogger: OcrStderrLogger): Boolean = {
+  // Uses pdfinfo to get the page sizes, return true if any of them are bigger than A1
+  def hasPagesBiggerThanA1(inputFilePath: Path, stderrLogger: OcrStderrLogger): Boolean = {
     val a1PageSizePtArea = 4014656 // https://www.a1-size.com/a1-size-in-point/
-    val cmd = s"pdfinfo ${inputFilePath.toAbsolutePath}"
+    val cmd = s"pdfinfo -f 1 -l -1 ${inputFilePath.toAbsolutePath}"
     val stdout = mutable.Buffer.empty[String]
     val exitCode = Process(cmd).!(ProcessLogger(stdout.append(_), stderrLogger.append))
     exitCode match {
       case 0 =>
-        val biggerThanA1 = stdout.find(_.startsWith("Page size:")).map { line =>
-          val sizePattern = """Page size:\s+([\d.]+) x ([\d.]+) pts.*""".r
-          line match {
-            case sizePattern(width, height) =>
-              val w = width.toDouble
-              val h = height.toDouble
-              val area = w * h
-              val bigger = area > a1PageSizePtArea
-              if (bigger) {
-                logger.info(s"Page size of ${inputFilePath.getFileName} is bigger than A1 - will be downsized to A1")
-              }
-              bigger
-          }
+        val sizePattern = """Page\s+(\d+) size:\s+([\d.]+) x ([\d.]+) pts""".r
+        stdout.exists {
+          case sizePattern(pageNum, width, height) =>
+            val area = width.toDouble * height.toDouble
+            val bigger = area > a1PageSizePtArea
+            if (bigger) {
+              logger.info(s"Page $pageNum of ${inputFilePath.getFileName} is bigger than A1 - will be downsized to A1")
+            }
+            bigger
+          case _ => false
         }
-        biggerThanA1.getOrElse({
-          logger.warn(s"Failed to calculate page size for ${inputFilePath.getFileName}, assuming it's not too big")
-          false
-        })
       case _ =>
         logger.warn(s"Failed to get pdf info for ${inputFilePath.getFileName}. exit code ${exitCode} .")
         false


### PR DESCRIPTION
## What does this change?
Last year we added this https://github.com/guardian/giant/pull/289 to downsize PDFs where the page size was too big. 

In that change I assumed that every page of the PDF would be the same size. That's not true for PDFs such as this one https://giant.pfi.gutools.co.uk/viewer/iDhF4htxvCwp-TuUNchm6jc84plsMu8bFTZvvgi1SEiDjcms_N83Ea08WAlp1la-9ATxlks6r7yC4KnGnObwyQ?view=preview where the pages vary between big and enormous

This change gets giant to check the size of every page in the PDF and to downsize the entire PDF if any page is bigger than A1.

This is still a bit of a blunt instrument as if we have a 500 page PDF where 1 page is bigger than A1 and the rest are A4 then we will end up upsizing 499 pages. However, I think the alternative is to split up the PDF to allow us to upsize/downsize each page correctly. Given that a large majority of the stuff in giant is A4 based, I think this is a reasonably pragmatic approach, and in any case a bit better than what we were doing before.

Comparison before/after the downsizing  is below - the main change is that we go from 6878268 kb (6.7GB) of memory usage to 2138252kb (2GB).

Before
```
$ /usr/bin/time -v ocrmypdf /tmp/test.pdf out.pdf --redo-ocr
Scanning contents    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 7/7 0:00:00
Start processing 2 pages concurrently                                                                                                              ocr.py:96
    1 redoing OCR                                                                                                                           _pipeline.py:340
    4 /usr/local/lib/python3.10/dist-packages/PIL/Image.py:3574: DecompressionBombWarning: Image size (450494892 pixels) exceeds limit of    warnings.py:109
250000000 pixels, could be decompression bomb DOS attack.
  warnings.warn(

    5 /usr/local/lib/python3.10/dist-packages/PIL/Image.py:3574: DecompressionBombWarning: Image size (409822537 pixels) exceeds limit of    warnings.py:109
250000000 pixels, could be decompression bomb DOS attack.
  warnings.warn(

OCR                  ━━━━━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━  43% 3/7 0:00:23Command terminated by signal 9
	Command being timed: "ocrmypdf /tmp/test.pdf out.pdf --redo-ocr"
	User time (seconds): 105.28
	System time (seconds): 4.34
	Percent of CPU this job got: 150%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:13.03
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 6878268
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 127
	Minor (reclaiming a frame) page faults: 3414378
	Voluntary context switches: 6182
	Involuntary context switches: 22073
	Swaps: 0
	File system inputs: 26096
	File system outputs: 457928
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```


```
$ /usr/bin/time -v ocrmypdf small.pdf out.pdf --redo-ocr
Scanning contents    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 7/7 0:00:00
Start processing 2 pages concurrently                                                                                                              ocr.py:96
    1 redoing OCR                                                                                                                           _pipeline.py:340
OCR                  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 7/7 0:00:00
Postprocessing...                                                                                                                                 ocr.py:144
PDF/A conversion     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 7/7 0:00:00
Linearizing          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 100/100 0:00:00
Recompressing JPEGs  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0/0 -:--:--
Deflating JPEGs      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 6/6 0:00:00
JBIG2                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0/0 -:--:--
Image optimization ratio: 1.37 savings: 27.2%                                                                                              _pipeline.py:1002
Total file size ratio: 1.37 savings: 27.0%                                                                                                 _pipeline.py:1005
Output file is a PDF/A-2b (as expected)                                                                                                       _common.py:474
	Command being timed: "ocrmypdf small.pdf out.pdf --redo-ocr"
	User time (seconds): 175.31
	System time (seconds): 7.22
	Percent of CPU this job got: 179%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:41.78
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 2138252
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 65
	Minor (reclaiming a frame) page faults: 6070936
	Voluntary context switches: 4938
	Involuntary context switches: 48002
	Swaps: 0
	File system inputs: 22640
	File system outputs: 865264
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

## How has this change been tested?
 - [x] Tested locally
 - [ ] Tested on playground

## Things to think about
