### PR TITLE
Giant doc viewer: fix page overlap for PDFs with /Rotate metadata

### DIFF
--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -71,12 +71,15 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
       val (pages, _) = (1 to numberOfPages).foldLeft(base) { case ((pages, offsetHeight), pageNumber) =>
         val page = firstDoc.getPage(pageNumber - 1)
         val pageBoundingBox = page.getMediaBox
+        val isRotatedSideways = page.getRotation % 180 != 0
+        val effectiveWidth = if (isRotatedSideways) pageBoundingBox.getHeight else pageBoundingBox.getWidth
+        val effectiveHeight = if (isRotatedSideways) pageBoundingBox.getWidth else pageBoundingBox.getHeight
 
         val dimensions = PageDimensions(
-          width = pageBoundingBox.getWidth,
-          height = pageBoundingBox.getHeight,
+          width = effectiveWidth,
+          height = effectiveHeight,
           top = offsetHeight,
-          bottom = offsetHeight + pageBoundingBox.getHeight
+          bottom = offsetHeight + effectiveHeight
         )
 
         val textByLanguage = pdDocuments.map { case (lang, (_, doc)) =>

--- a/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
+++ b/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
@@ -50,7 +50,11 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
       val totalPages = document.getNumberOfPages
 
       val (pages, _) = (0 until totalPages).foldLeft((List.empty[Page], 0f)) { case ((pages, offsetHeight), pageNumber) =>
-        val pageBoundingBox = document.getPage(pageNumber).getMediaBox
+        val pdfPage = document.getPage(pageNumber)
+        val pageBoundingBox = pdfPage.getMediaBox
+        val isRotatedSideways = pdfPage.getRotation % 180 != 0
+        val effectiveWidth = if (isRotatedSideways) pageBoundingBox.getHeight else pageBoundingBox.getWidth
+        val effectiveHeight = if (isRotatedSideways) pageBoundingBox.getWidth else pageBoundingBox.getHeight
 
         // TODO MRB: does RGB colour help or hinder here?
         val imageFileName = s"${file.getAbsolutePath}-$pageNumber.png"
@@ -58,10 +62,10 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
         ImageIOUtil.writeImage(image, imageFileName, config.dpi)
 
         val dimensions = PageDimensions(
-          width = pageBoundingBox.getWidth,
-          height = pageBoundingBox.getHeight,
+          width = effectiveWidth,
+          height = effectiveHeight,
           top = offsetHeight,
-          bottom = offsetHeight + pageBoundingBox.getHeight
+          bottom = offsetHeight + effectiveHeight
         )
 
         val pageTextByLanguage = params.languages.map { lang =>
@@ -75,7 +79,7 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
 
         Files.delete(Paths.get(imageFileName))
 
-        (pages :+ page, (offsetHeight + pageBoundingBox.getHeight))
+        (pages :+ page, (offsetHeight + effectiveHeight))
       }
 
       pageService.addPageContents(blob.uri, pages)

--- a/frontend/src/js/components/PageViewer/VirtualScroll.module.css
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.module.css
@@ -17,7 +17,6 @@
   margin: 10px;
 
   min-width: 1000px;
-  min-height: 1000px;
   max-width: 10000px;
   max-height: 10000px;
 

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -72,14 +72,23 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   // This must be the same as the margin CSS of .pageContainer
   const MARGIN = 10;
 
+  // Once the first page preview resolves we learn the true page dimensions
+  // from pdfjs (which accounts for the PDF's /Rotate property). This overrides
+  // the backend-supplied firstPageDimensions which may be incorrect for rotated PDFs.
+  const [resolvedDimensions, setResolvedDimensions] = useState<
+    PageDimensions | undefined
+  >(firstPageDimensions);
+
+  const effectiveDimensions = resolvedDimensions ?? firstPageDimensions;
+
   const containerSize = 1000 * scale;
   const pageHeight = pageSlotHeight(
     containerSize,
     MARGIN,
     rotation,
-    firstPageDimensions,
+    effectiveDimensions,
   );
-  const transform = pageTransform(containerSize, rotation, firstPageDimensions);
+  const transform = pageTransform(containerSize, rotation, effectiveDimensions);
 
   const viewport = useRef<HTMLDivElement>(null);
 
@@ -300,6 +309,28 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     getCachedPage,
   ]);
 
+  // Resolve the true page dimensions from the first page's pdfjs viewport.
+  // This corrects for PDFs where the backend-stored dimensions don't account
+  // for the PDF's /Rotate property.
+  const hasResolvedDimensions = useRef(false);
+  useEffect(() => {
+    if (hasResolvedDimensions.current || renderedPages.length === 0) return;
+    const firstPage = renderedPages.find((p) => p.pageNumber === 1);
+    if (!firstPage) return;
+
+    firstPage.getPagePreview.then((preview) => {
+      if (hasResolvedDimensions.current) return;
+      hasResolvedDimensions.current = true;
+      const pdfViewport = preview.pdfPage.getViewport({ scale: 1.0 });
+      setResolvedDimensions({
+        width: pdfViewport.width,
+        height: pdfViewport.height,
+        top: 0,
+        bottom: pdfViewport.height,
+      });
+    });
+  }, [renderedPages]);
+
   useEffect(() => {
     pageNumbersToPreload.forEach((pageNumber) => pageCache.getPage(pageNumber));
   }, [pageNumbersToPreload, pageCache]);
@@ -316,6 +347,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
             key={page.pageNumber}
             style={{
               top: (page.pageNumber - 1) * pageHeight,
+              height: pageHeight - MARGIN * 2,
               transform,
               left: `${scale > 1 ? "0" : ""}`,
             }}


### PR DESCRIPTION
Fixes #720 and, hopefully, #719 (if those are indeed the same problem)

The backend OCR extractors used `PDFBox`'s `getMediaBox()` which returns raw dimensions ignoring the PDF's `/Rotate` property. This caused a mismatch with `pdfjs` (which applies rotation), leading to incorrect slot heights in the virtual scroll layout and overlapping pages.

Backend:
- OcrMyPdfExtractor and TesseractPdfOcrExtractor now account for page rotation when storing dimensions, swapping width/height for 90/270 degree rotations.

Frontend:
- VirtualScroll resolves the true page dimensions from the first `pdfjs` preview (which always respects `/Rotate`) and uses those for layout, fixing overlap for existing indexed documents.
- Removed hardcoded `min-height: 1000px` from page container CSS which was a leftover from before real dimensions were available.
- Set explicit height on page containers based on calculated slot height.

Before:

<img width="576" height="811" alt="Picture 360" src="https://github.com/user-attachments/assets/85177a49-0976-4d84-811f-074d6b871eaf" />

After:

<img width="562" height="875" alt="Picture 359" src="https://github.com/user-attachments/assets/cc7fe437-1d44-4dcd-9953-5ef76f092c01" />
