### PR TITLE
Add admin-only option to reprocess folder contents in workspace

### DIFF
--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -6,6 +6,7 @@ import model.Uri
 import model.annotations.{ProcessingStage, Workspace, WorkspaceEntry, WorkspaceLeaf}
 import model.frontend.{TreeEntry, TreeLeaf, TreeNode}
 import model.ingestion.{ RemoteIngest, RemoteIngestStatus}
+import model.user.UserPermission.CanPerformAdminOperations
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.append
 import org.joda.time.DateTime
@@ -142,6 +143,25 @@ class Workspaces(
       _ <- reprocessBlobs(blobIds, rerunSuccessful, rerunFailed)
     } yield {
       Ok(Json.toJson(blobIds))
+    }
+  }
+
+  def reprocessFolder(workspaceId: String, folderId: String, rerunSuccessfulParam: Option[Boolean], rerunFailedParam: Option[Boolean]) = ApiAction.attempt { req: UserIdentityRequest[_] =>
+    checkPermission(CanPerformAdminOperations, req) {
+      val rerunSuccessful = rerunSuccessfulParam.getOrElse(false)
+      val rerunFailed = rerunFailedParam.getOrElse(true)
+
+      for {
+        contents <- annotation.getWorkspaceContents(req.user.username, workspaceId)
+        folderNode <- Attempt.fromOption(
+          TreeEntry.findNodeById(contents, folderId),
+          Attempt.Left[TreeEntry[WorkspaceEntry]](NotFoundFailure(s"Folder $folderId not found in workspace $workspaceId"))
+        )
+        blobIds = if (rerunSuccessful) TreeEntry.workspaceTreeToBlobIds(folderNode) else TreeEntry.workspaceTreeToFailedBlobIds(folderNode)
+        _ <- reprocessBlobs(blobIds, rerunSuccesful = rerunSuccessful, rerunFailed = rerunFailed)
+      } yield {
+        Ok(Json.toJson(blobIds))
+      }
     }
   }
 

--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -157,7 +157,7 @@ class Workspaces(
           TreeEntry.findNodeById(contents, folderId),
           Attempt.Left[TreeEntry[WorkspaceEntry]](NotFoundFailure(s"Folder $folderId not found in workspace $workspaceId"))
         )
-        blobIds = if (rerunSuccessful) TreeEntry.workspaceTreeToBlobIds(folderNode) else TreeEntry.workspaceTreeToFailedBlobIds(folderNode)
+        blobIds = if (rerunSuccessful) TreeEntry.workspaceTreeToBlobIds(folderNode) else TreeEntry.getFailedBlobUris(folderNode)
         _ <- reprocessBlobs(blobIds, rerunSuccesful = rerunSuccessful, rerunFailed = rerunFailed)
       } yield {
         Ok(Json.toJson(blobIds))

--- a/backend/app/model/frontend/TreeEntry.scala
+++ b/backend/app/model/frontend/TreeEntry.scala
@@ -1,7 +1,7 @@
 package model.frontend
 
 import model.Uri
-import model.annotations.{WorkspaceEntry, WorkspaceLeaf}
+import model.annotations.{ProcessingStage, WorkspaceEntry, WorkspaceLeaf}
 
 sealed trait TreeEntry[+T] {
   def id: String
@@ -63,6 +63,15 @@ object TreeEntry {
       case _ => throw new AssertionError(s"WorkspaceNode inside TreeLeaf with id ${treeLeaf.id} is crazy and should not happen")
     }
     case treeNode: TreeNode[WorkspaceEntry] => treeNode.children.flatMap(workspaceTreeToBlobIds)
+  }
+
+  def workspaceTreeToFailedBlobIds(tree: TreeEntry[WorkspaceEntry]): List[Uri] = tree match {
+    case treeLeaf: TreeLeaf[WorkspaceEntry] => treeLeaf.data match {
+      case workspaceLeaf: WorkspaceLeaf if workspaceLeaf.processingStage == ProcessingStage.Failed =>
+        List(Uri(workspaceLeaf.uri))
+      case _ => List.empty
+    }
+    case treeNode: TreeNode[WorkspaceEntry] => treeNode.children.flatMap(workspaceTreeToFailedBlobIds)
   }
 }
 

--- a/backend/app/model/frontend/TreeEntry.scala
+++ b/backend/app/model/frontend/TreeEntry.scala
@@ -65,13 +65,13 @@ object TreeEntry {
     case treeNode: TreeNode[WorkspaceEntry] => treeNode.children.flatMap(workspaceTreeToBlobIds)
   }
 
-  def workspaceTreeToFailedBlobIds(tree: TreeEntry[WorkspaceEntry]): List[Uri] = tree match {
+  def getFailedBlobUris(tree: TreeEntry[WorkspaceEntry]): List[Uri] = tree match {
     case treeLeaf: TreeLeaf[WorkspaceEntry] => treeLeaf.data match {
       case workspaceLeaf: WorkspaceLeaf if workspaceLeaf.processingStage == ProcessingStage.Failed =>
         List(Uri(workspaceLeaf.uri))
       case _ => List.empty
     }
-    case treeNode: TreeNode[WorkspaceEntry] => treeNode.children.flatMap(workspaceTreeToFailedBlobIds)
+    case treeNode: TreeNode[WorkspaceEntry] => treeNode.children.flatMap(getFailedBlobUris)
   }
 }
 

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -68,6 +68,7 @@ GET           /api/workspaces/:workspaceId/totalWordCount                   cont
 POST          /api/workspaces/:workspaceId/text                             controllers.api.Workspaces.getText(workspaceId: String)
 PUT           /api/workspaces/:workspaceId/owner                            controllers.api.Workspaces.updateWorkspaceOwner(workspaceId: String)
 POST          /api/workspaces/:workspaceId/reprocess                        controllers.api.Workspaces.reprocess(workspaceId: String, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])
+POST          /api/workspaces/:workspaceId/folders/:folderId/reprocess     controllers.api.Workspaces.reprocessFolder(workspaceId: String, folderId: String, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])
 POST          /api/workspaces/:workspaceId/nodes                            controllers.api.Workspaces.addItemToWorkspace(workspaceId: String)
 GET           /api/workspaces/:workspaceId/remoteJobs                       controllers.api.Workspaces.getRelevantRemoteJobs(workspaceId: String)
 POST          /api/workspaces/:workspaceId/remoteUrl                        controllers.api.Workspaces.addRemoteUrlToWorkspace(workspaceId: String)

--- a/backend/test/model/frontend/TreeEntryTest.scala
+++ b/backend/test/model/frontend/TreeEntryTest.scala
@@ -1,5 +1,8 @@
 package model.frontend
 
+import model.Uri
+import model.annotations.{ProcessingStage, WorkspaceEntry, WorkspaceLeaf, WorkspaceNode}
+import model.frontend.user.PartialUser
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 
@@ -42,6 +45,79 @@ class TreeEntryTest extends AnyFreeSpec with Matchers {
 
       TreeEntry.findNodeById(test, folderId = "bottom") must contain(bottomLeaf)
       TreeEntry.findNodeById(test, folderId = "middleLeaf") must contain(middleLeaf)
+    }
+  }
+
+  val testUser: PartialUser = PartialUser("testUser", "Test User")
+
+  def makeLeaf(id: String, uri: String, stage: ProcessingStage): TreeLeaf[WorkspaceLeaf] =
+    TreeLeaf(
+      id = id,
+      name = id,
+      data = WorkspaceLeaf(
+        addedBy = testUser,
+        addedOn = None,
+        maybeParentId = None,
+        processingStage = stage,
+        uri = uri,
+        mimeType = "application/pdf",
+        size = Some(100L)
+      ),
+      isExpandable = false
+    )
+
+  def makeNode(id: String, children: List[TreeEntry[WorkspaceEntry]]): TreeNode[WorkspaceEntry] =
+    TreeNode[WorkspaceEntry](
+      id = id,
+      name = id,
+      data = WorkspaceNode(
+        addedBy = testUser,
+        addedOn = None,
+        maybeParentId = None,
+        descendantsLeafCount = 0,
+        descendantsNodeCount = 0,
+        descendantsProcessingTaskCount = 0,
+        descendantsFailedCount = 0
+      ),
+      children = children
+    )
+
+  "workspaceTreeToFailedBlobIds" - {
+    "return empty list for a processed leaf" in {
+      val leaf = makeLeaf("f1", "uri1", ProcessingStage.Processed)
+      TreeEntry.workspaceTreeToFailedBlobIds(leaf) must be(List.empty)
+    }
+
+    "return empty list for a processing leaf" in {
+      val leaf = makeLeaf("f1", "uri1", ProcessingStage.Processing(3, None))
+      TreeEntry.workspaceTreeToFailedBlobIds(leaf) must be(List.empty)
+    }
+
+    "return the uri for a failed leaf" in {
+      val leaf = makeLeaf("f1", "uri1", ProcessingStage.Failed)
+      TreeEntry.workspaceTreeToFailedBlobIds(leaf) must be(List(Uri("uri1")))
+    }
+
+    "return only failed uris from a folder tree" in {
+      val tree = makeNode("root", List(
+        makeLeaf("f1", "uri1", ProcessingStage.Failed),
+        makeLeaf("f2", "uri2", ProcessingStage.Processed),
+        makeNode("subfolder", List(
+          makeLeaf("f3", "uri3", ProcessingStage.Failed),
+          makeLeaf("f4", "uri4", ProcessingStage.Processing(1, None)),
+        ))
+      ))
+
+      TreeEntry.workspaceTreeToFailedBlobIds(tree) must be(List(Uri("uri1"), Uri("uri3")))
+    }
+
+    "return empty list for a folder with no failed files" in {
+      val tree = makeNode("root", List(
+        makeLeaf("f1", "uri1", ProcessingStage.Processed),
+        makeLeaf("f2", "uri2", ProcessingStage.Processing(2, None)),
+      ))
+
+      TreeEntry.workspaceTreeToFailedBlobIds(tree) must be(List.empty)
     }
   }
 }

--- a/backend/test/model/frontend/TreeEntryTest.scala
+++ b/backend/test/model/frontend/TreeEntryTest.scala
@@ -82,20 +82,20 @@ class TreeEntryTest extends AnyFreeSpec with Matchers {
       children = children
     )
 
-  "workspaceTreeToFailedBlobIds" - {
+  "getFailedBlobUris" - {
     "return empty list for a processed leaf" in {
       val leaf = makeLeaf("f1", "uri1", ProcessingStage.Processed)
-      TreeEntry.workspaceTreeToFailedBlobIds(leaf) must be(List.empty)
+      TreeEntry.getFailedBlobUris(leaf) must be(List.empty)
     }
 
     "return empty list for a processing leaf" in {
       val leaf = makeLeaf("f1", "uri1", ProcessingStage.Processing(3, None))
-      TreeEntry.workspaceTreeToFailedBlobIds(leaf) must be(List.empty)
+      TreeEntry.getFailedBlobUris(leaf) must be(List.empty)
     }
 
     "return the uri for a failed leaf" in {
       val leaf = makeLeaf("f1", "uri1", ProcessingStage.Failed)
-      TreeEntry.workspaceTreeToFailedBlobIds(leaf) must be(List(Uri("uri1")))
+      TreeEntry.getFailedBlobUris(leaf) must be(List(Uri("uri1")))
     }
 
     "return only failed uris from a folder tree" in {
@@ -108,7 +108,7 @@ class TreeEntryTest extends AnyFreeSpec with Matchers {
         ))
       ))
 
-      TreeEntry.workspaceTreeToFailedBlobIds(tree) must be(List(Uri("uri1"), Uri("uri3")))
+      TreeEntry.getFailedBlobUris(tree) must be(List(Uri("uri1"), Uri("uri3")))
     }
 
     "return empty list for a folder with no failed files" in {
@@ -117,7 +117,7 @@ class TreeEntryTest extends AnyFreeSpec with Matchers {
         makeLeaf("f2", "uri2", ProcessingStage.Processing(2, None)),
       ))
 
-      TreeEntry.workspaceTreeToFailedBlobIds(tree) must be(List.empty)
+      TreeEntry.getFailedBlobUris(tree) must be(List.empty)
     }
   }
 }

--- a/frontend/src/js/actions/workspaces/reprocessFailedInFolder.ts
+++ b/frontend/src/js/actions/workspaces/reprocessFailedInFolder.ts
@@ -1,0 +1,27 @@
+import { reprocessFolder as reprocessFolderApi } from "../../services/WorkspaceApi";
+import { ThunkAction } from "redux-thunk";
+import { GiantState } from "../../types/redux/GiantState";
+import {
+  AppAction,
+  AppActionType,
+  WorkspacesAction,
+} from "../../types/redux/GiantActions";
+import { getWorkspace } from "./getWorkspace";
+
+export function reprocessFolder(
+  workspaceId: string,
+  folderId: string,
+  mode: "all" | "errored",
+): ThunkAction<void, GiantState, null, WorkspacesAction | AppAction> {
+  return (dispatch) => {
+    return reprocessFolderApi(workspaceId, folderId, mode)
+      .then(() => dispatch(getWorkspace(workspaceId)))
+      .catch((error) =>
+        dispatch({
+          type: AppActionType.APP_SHOW_ERROR,
+          message: "Failed to reprocess folder contents",
+          error,
+        }),
+      );
+  };
+}

--- a/frontend/src/js/components/workspace/ReprocessFolderModal.tsx
+++ b/frontend/src/js/components/workspace/ReprocessFolderModal.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import Modal from "../UtilComponents/Modal";
+import { WorkspaceNode } from "../../types/Workspaces";
+
+type ReprocessFolderModalProps = {
+  isOpen: boolean;
+  folderName: string;
+  folderData: WorkspaceNode;
+  onReprocessErrored: () => void;
+  onReprocessAll: () => void;
+  onCancel: () => void;
+};
+
+export function ReprocessFolderModal({
+  isOpen,
+  folderName,
+  folderData,
+  onReprocessErrored,
+  onReprocessAll,
+  onCancel,
+}: ReprocessFolderModalProps) {
+  const totalFiles = folderData.descendantsLeafCount;
+  const failedFiles = folderData.descendantsFailedCount;
+
+  return (
+    <Modal isOpen={isOpen} isDismissable={true} dismiss={onCancel}>
+      <div className="form form-full-width">
+        <h2 className="modal__title">Reprocess folder contents</h2>
+        <div className="form__row">
+          <p>
+            The folder <strong>{folderName}</strong> contains{" "}
+            <strong>{totalFiles}</strong> file{totalFiles !== 1 ? "s" : ""}
+            {failedFiles > 0 && (
+              <>
+                , of which <strong>{failedFiles}</strong>{" "}
+                {failedFiles === 1 ? "has" : "have"} errors
+              </>
+            )}
+            .
+          </p>
+          <p>How would you like to proceed?</p>
+        </div>
+        <div className="form__row btn-group btn-group--left">
+          <button className="btn" onClick={onCancel}>
+            Cancel
+          </button>
+          {failedFiles > 0 && (
+            <button className="btn" onClick={onReprocessErrored}>
+              Reprocess Errored
+            </button>
+          )}
+          <button className="btn" onClick={onReprocessAll}>
+            Reprocess All
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -61,11 +61,13 @@ import {
 import { setWorkspaceIsPublic } from "../../actions/workspaces/setWorkspaceIsPublic";
 import { RouteComponentProps } from "react-router-dom";
 import { reprocessBlob } from "../../actions/workspaces/reprocessBlob";
+import { reprocessFolder } from "../../actions/workspaces/reprocessFailedInFolder";
 import {
   DeleteModal,
   ModalStatus,
   RemoveFromWorkspaceModal,
 } from "./ConfirmModal";
+import { ReprocessFolderModal } from "./ReprocessFolderModal";
 import { PartialUser } from "../../types/User";
 import { getMyPermissions } from "../../actions/users/getMyPermissions";
 import buildLink from "../../util/buildLink";
@@ -110,6 +112,7 @@ type State = {
     entry: null | TreeEntry<WorkspaceEntry>;
     status: ModalStatus;
   };
+  reprocessFolderModalEntry: null | TreeEntry<WorkspaceEntry>;
   itemsBeingMoved: number;
   itemsWithMoveSettled: number;
 };
@@ -418,6 +421,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
       entry: null,
       status: "unconfirmed",
     },
+    reprocessFolderModalEntry: null,
     itemsBeingMoved: 0,
     itemsWithMoveSettled: 0,
   };
@@ -895,6 +899,18 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
       });
     }
 
+    const isAdmin = this.props.myPermissions.includes(
+      "CanPerformAdminOperations",
+    );
+
+    if (isAdmin && isWorkspaceFolder && !isRemoteIngest) {
+      items.push({
+        key: "reprocessFolder",
+        content: "Reprocess folder contents\u2026",
+        icon: "redo",
+      });
+    }
+
     if (isWorkspaceFolder && !isRemoteIngest) {
       items.push({
         key: "search",
@@ -990,6 +1006,13 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
               workspaceLeaf
             ) {
               this.props.reprocessBlob(workspaceId, workspaceLeaf.uri);
+            }
+
+            if (
+              menuItemProps.content === "Reprocess folder contents\u2026" &&
+              isWorkspaceFolder
+            ) {
+              this.setState({ reprocessFolderModalEntry: entry });
             }
 
             if (menuItemProps.content === "Search in folder") {
@@ -1257,6 +1280,39 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
           removeStatus={this.state.removeFromWorkspaceModalContext.status}
           entry={this.state.removeFromWorkspaceModalContext.entry}
         />
+        {this.state.reprocessFolderModalEntry &&
+          isWorkspaceNode(this.state.reprocessFolderModalEntry.data) && (
+            <ReprocessFolderModal
+              isOpen={true}
+              folderName={this.state.reprocessFolderModalEntry.name}
+              folderData={this.state.reprocessFolderModalEntry.data}
+              onReprocessErrored={() => {
+                const entry = this.state.reprocessFolderModalEntry;
+                if (entry) {
+                  this.props.reprocessFolder(
+                    this.props.match.params.id,
+                    entry.id,
+                    "errored",
+                  );
+                }
+                this.setState({ reprocessFolderModalEntry: null });
+              }}
+              onReprocessAll={() => {
+                const entry = this.state.reprocessFolderModalEntry;
+                if (entry) {
+                  this.props.reprocessFolder(
+                    this.props.match.params.id,
+                    entry.id,
+                    "all",
+                  );
+                }
+                this.setState({ reprocessFolderModalEntry: null });
+              }}
+              onCancel={() =>
+                this.setState({ reprocessFolderModalEntry: null })
+              }
+            />
+          )}
       </div>
     );
   }
@@ -1286,6 +1342,7 @@ function mapDispatchToProps(dispatch: GiantDispatch) {
     renameItem: bindActionCreators(renameItem, dispatch),
     deleteItem: bindActionCreators(deleteItem, dispatch),
     reprocessBlob: bindActionCreators(reprocessBlob, dispatch),
+    reprocessFolder: bindActionCreators(reprocessFolder, dispatch),
     deleteResourceFromWorkspace: bindActionCreators(
       deleteResourceFromWorkspace,
       dispatch,

--- a/frontend/src/js/services/WorkspaceApi.ts
+++ b/frontend/src/js/services/WorkspaceApi.ts
@@ -224,3 +224,18 @@ function addItemToWorkspace(
     }),
   }).then((res) => res.json());
 }
+
+export function reprocessFolder(
+  workspaceId: string,
+  folderId: string,
+  mode: "all" | "errored",
+): Promise<boolean> {
+  const params =
+    mode === "all"
+      ? "?rerunSuccessful=true&rerunFailed=true"
+      : "?rerunSuccessful=false&rerunFailed=true";
+  return authFetch(
+    `/api/workspaces/${workspaceId}/folders/${folderId}/reprocess${params}`,
+    { method: "POST" },
+  ).then((res) => res.ok);
+}


### PR DESCRIPTION
Add a new context menu item 'Reprocess folder contents…' for workspace folders, visible only to users with CanPerformAdminOperations permission. 


<img width="389" height="359" alt="Picture 364" src="https://github.com/user-attachments/assets/78c0b62d-6e53-4497-80fc-fe73029aafec" />
 ____

Shows a confirmation dialog indicating the total file count; the number with errors; and providing three options: Reprocess Errored (only shown when there are errors), Reprocess All, and Cancel.

<img width="619" height="217" alt="Picture 365" src="https://github.com/user-attachments/assets/8039eea3-4102-4bc4-bd32-b538b326c521" />


### Backend:
- Add `workspaceTreeToFailedBlobIds` to `TreeEntry` to collect only failed blob URIs from a workspace tree
- Add `reprocessFolder` endpoint on Workspaces controller, gated behind `CanPerformAdminOperations`, supporting both all and errored-only modes via rerunSuccessful/rerunFailed query params
- Add route: POST /api/workspaces/:id/folders/:folderId/reprocess
- Add tests for `workspaceTreeToFailedBlobIds`

### Frontend:
- Add `reprocessFolder` API function in WorkspaceApi with mode parameter
- Add `reprocessFolder` Redux action supporting 'all' and 'errored' modes
- Add `ReprocessFolderModal` confirmation dialog component
- Add 'Reprocess folder contents…' context menu item for folders, visible only to admins.

## How has this change been tested?
 - [x] Tested locally
 - [x] Tested on playground

## Things to think about
 - Does this change impact the external transcription service integration? If so, how has this been tested?
 - For UI changes: have you thought about accessibility? See https://github.com/guardian/accessibility/
