### PR TITLE
Fix minio docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,14 +53,14 @@ services:
       MINIO_ROOT_USER: minio-user
       MINIO_ROOT_PASSWORD: reallyverysecret
     volumes:
-      - minio:/export
+      - minio:/data
     ports:
       - 9090:9000
       - 9091:9001
     entrypoint:
       sh
     command:
-      -c 'mkdir -p /export/ingest-data && mkdir -p /export/remote-ingest-data && mkdir -p /export/transcription-output-data && mkdir -p /export/ingest-data-dead-letter && mkdir -p /export/data && mkdir -p /export/preview && minio server /export --console-address ":9001"'
+      -c 'mkdir -p /data/ingest-data && mkdir -p /data/remote-ingest-data && mkdir -p /data/transcription-output-data && mkdir -p /data/ingest-data-dead-letter && mkdir -p /data/data && mkdir -p /data/preview && minio server /data --console-address ":9001"'
 
   postgres:
     image: postgres:15.3


### PR DESCRIPTION
## What does this change?
I think we missed a bit when upgrading minio here https://github.com/guardian/giant/pull/564/changes#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3

Recent Minio versions (2025+) no longer accept /export as a valid drive path. Using /data fixes this.

To get this working locally you may need to:

`docker compose down`
`docker volume rm giant_minio`
`docker pull`
`docker compose up -d`

To check minio is happily starting you can run `docker ps`

or, if you want to wipe everything in giant locally:

`docker compose down -v` which will delete all volumes

## How has this change been tested?
 - [x] Tested locally
 - [ ] Tested on playground
