### PR TITLE
Add language detection functionality to giant

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -1,6 +1,7 @@
 import org.apache.pekko.actor.{ActorSystem, CoordinatedShutdown}
 import org.apache.pekko.actor.CoordinatedShutdown.Reason
 import cats.syntax.either._
+
 import java.net.URI
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sqs.SqsClient
@@ -34,6 +35,7 @@ import services.annotations.Neo4jAnnotations
 import services.events.ElasticsearchEvents
 import services.index.{ElasticsearchPages, ElasticsearchResources, Pages2}
 import ingestion.{IngestionServices, Neo4jRemoteIngestStore, RemoteIngestWorker}
+import org.apache.tika.language.detect.LanguageDetector
 import play.filters.gzip.{GzipFilter, GzipFilterConfig}
 import services.manifest.Neo4jManifest
 import services.observability.{PostgresClientDoNothing, PostgresClientImpl}
@@ -150,14 +152,23 @@ class AppComponents(context: Context, config: Config)
     // processing services
     val tika = Tika.createInstance
     val mimeTypeMapper = new MimeTypeMapper()
-    val ingestionServices = IngestionServices(manifest, esResources, blobStorage, tika, mimeTypeMapper, postgresClient)
+    // language detection
+    val languageDetector: ThreadLocal[LanguageDetector] =
+      // This might be overkill but https://stackoverflow.com/questions/75781081/are-apache-tikas-languagedetectors-thread-safe
+      // suggests that the LanguageDetector is not thread safe, so wrap in ThreadLocal
+      ThreadLocal.withInitial { () =>
+        LanguageDetector.getDefaultLanguageDetector.loadModels()
+      }
+    val ingestionServices = IngestionServices(manifest, esResources, blobStorage, tika, mimeTypeMapper, postgresClient, languageDetector)
 
     // Preview
     val previewStorage = S3ObjectStorage(s3Client, s3Presigner, config.s3.buckets.preview).valueOr(failure => throw new Exception(failure.msg))
     val previewService = PreviewService(config.preview, esResources, blobStorage, previewStorage)
 
+
+
     // extractors
-    val documentBodyExtractor = new DocumentBodyExtractor(tika, esResources)
+    val documentBodyExtractor = new DocumentBodyExtractor(tika, esResources, ingestionServices)
 
     val zipExtractor = new ZipExtractor(scratchSpace, ingestionServices)
     val rarExtractor = new RarExtractor(scratchSpace, ingestionServices)

--- a/backend/app/extraction/DocumentBodyExtractor.scala
+++ b/backend/app/extraction/DocumentBodyExtractor.scala
@@ -1,17 +1,18 @@
 package extraction
 
 import java.io.InputStream
-
 import model.manifest.Blob
+import org.apache.tika.language.detect.LanguageDetector
 import services.Tika
 import services.index.Index
+import services.ingestion.IngestionServices
 import utils.Logging
 import utils.attempt.AttemptAwait._
 import utils.attempt.{Failure, UnsupportedOperationFailure}
 
 import scala.concurrent.ExecutionContext
 
-class DocumentBodyExtractor(tika: Tika, index: Index)(implicit ec: ExecutionContext) extends Extractor with Logging {
+class DocumentBodyExtractor(tika: Tika, index: Index, ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends Extractor with Logging {
   val mimeTypes: Set[String] = Set(
     "application/html",
     "application/json",
@@ -50,7 +51,8 @@ class DocumentBodyExtractor(tika: Tika, index: Index)(implicit ec: ExecutionCont
     if(passesSafetyCheck(mimeType, blob.size)) {
       tika.parse(stream, mimeType).flatMap { case (metadata, body) =>
         val rawMetadata = metadata.names().map(name => name -> metadata.getValues(name).toSeq).toMap
-        val enrichedMetadata = MetadataEnrichment.enrich(rawMetadata)
+        val detectedLanguage = ingestionServices.detectLanguage(blob.uri.value, body.trim())
+        val enrichedMetadata = MetadataEnrichment.enrich(rawMetadata, detectedLanguage)
         // Optionally having a body will allow documents without text to default to preview, useful for un-OCR'd documents
         val optionalBody = if (body.trim().isEmpty) None else Some(body)
 

--- a/backend/app/extraction/DocumentBodyExtractor.scala
+++ b/backend/app/extraction/DocumentBodyExtractor.scala
@@ -52,7 +52,6 @@ class DocumentBodyExtractor(tika: Tika, index: Index, ingestionServices: Ingesti
       tika.parse(stream, mimeType).flatMap { case (metadata, body) =>
         val rawMetadata = metadata.names().map(name => name -> metadata.getValues(name).toSeq).toMap
         val documentBodyDetectedLanguage = ingestionServices.detectLanguage(blob.uri.value, body.trim())
-        println("DETECTED LANGUAGE: " + documentBodyDetectedLanguage)
         val enrichedMetadata = MetadataEnrichment.enrich(rawMetadata)
         // Optionally having a body will allow documents without text to default to preview, useful for un-OCR'd documents
         val optionalBody = if (body.trim().isEmpty) None else Some(body)

--- a/backend/app/extraction/DocumentBodyExtractor.scala
+++ b/backend/app/extraction/DocumentBodyExtractor.scala
@@ -51,12 +51,13 @@ class DocumentBodyExtractor(tika: Tika, index: Index, ingestionServices: Ingesti
     if(passesSafetyCheck(mimeType, blob.size)) {
       tika.parse(stream, mimeType).flatMap { case (metadata, body) =>
         val rawMetadata = metadata.names().map(name => name -> metadata.getValues(name).toSeq).toMap
-        val detectedLanguage = ingestionServices.detectLanguage(blob.uri.value, body.trim())
-        val enrichedMetadata = MetadataEnrichment.enrich(rawMetadata, detectedLanguage)
+        val documentBodyDetectedLanguage = ingestionServices.detectLanguage(blob.uri.value, body.trim())
+        println("DETECTED LANGUAGE: " + documentBodyDetectedLanguage)
+        val enrichedMetadata = MetadataEnrichment.enrich(rawMetadata)
         // Optionally having a body will allow documents without text to default to preview, useful for un-OCR'd documents
         val optionalBody = if (body.trim().isEmpty) None else Some(body)
 
-        index.addDocumentDetails(blob.uri, optionalBody, rawMetadata, enrichedMetadata, params.languages).awaitEither()
+        index.addDocumentDetails(blob.uri, optionalBody, rawMetadata, enrichedMetadata, params.languages, documentBodyDetectedLanguage).awaitEither()
       }
     } else {
       Left(UnsupportedOperationFailure("Failed safety check"))

--- a/backend/app/extraction/MetadataEnrichment.scala
+++ b/backend/app/extraction/MetadataEnrichment.scala
@@ -12,8 +12,7 @@ case class EnrichedMetadata(title: Option[String],
                             lastModified: Option[Long],
                             createdWith: Option[String],
                             pageCount: Option[Int],
-                            wordCount: Option[Int],
-                            detectedLanguageCode: Option[String]) {
+                            wordCount: Option[Int]) {
   def toMap: Map[String, AnyRef] = {
     val t = this.title.map(IndexFields.metadata.enrichedMetadata.title -> _)
     val a = this.author.map(IndexFields.metadata.enrichedMetadata.author -> _)
@@ -22,9 +21,8 @@ case class EnrichedMetadata(title: Option[String],
     val cw = this.createdWith.map(IndexFields.metadata.enrichedMetadata.createdWith -> _)
     val p =  this.pageCount.map(IndexFields.metadata.enrichedMetadata.pageCount -> Int.box(_))
     val wc = this.wordCount.map(IndexFields.metadata.enrichedMetadata.wordCount -> Int.box(_))
-    val dlc = this.detectedLanguageCode.map(IndexFields.metadata.enrichedMetadata.detectedLanguageCode -> _)
 
-    Map() ++ t ++ a ++ c ++ l ++ cw ++ p ++ wc ++ dlc
+    Map() ++ t ++ a ++ c ++ l ++ cw ++ p ++ wc
   }
 }
 
@@ -37,15 +35,14 @@ object MetadataEnrichment {
   def someIdentity[T](v: T): Option[T] = Some(v)
   def safeIntParse(c: String): Option[Int] = Try(c.toInt).toOption
 
-  def enrich(metadata: Map[String, Seq[String]], detectedLanguage: Option[String]): EnrichedMetadata = EnrichedMetadata(
+  def enrich(metadata: Map[String, Seq[String]]): EnrichedMetadata = EnrichedMetadata(
     extractFields(metadata, titleKeys)(someIdentity),
     extractFields(metadata, authorKeys)(someIdentity),
     extractFields(metadata, createdAtKeys)(isoDateToLong),
     extractFields(metadata, lastModifiedKeys)(isoDateToLong),
     extractFields(metadata, createdWithKeys)(someIdentity),
     extractFields(metadata, pageCountKeys)(safeIntParse),
-    extractFields(metadata, wordCountKeys)(safeIntParse),
-    detectedLanguage
+    extractFields(metadata, wordCountKeys)(safeIntParse)
   )
 
   // Probably these lists of keys could be simplified now we're on Tika v2.

--- a/backend/app/extraction/MetadataEnrichment.scala
+++ b/backend/app/extraction/MetadataEnrichment.scala
@@ -12,7 +12,8 @@ case class EnrichedMetadata(title: Option[String],
                             lastModified: Option[Long],
                             createdWith: Option[String],
                             pageCount: Option[Int],
-                           wordCount: Option[Int]) {
+                            wordCount: Option[Int],
+                            detectedLanguageCode: Option[String]) {
   def toMap: Map[String, AnyRef] = {
     val t = this.title.map(IndexFields.metadata.enrichedMetadata.title -> _)
     val a = this.author.map(IndexFields.metadata.enrichedMetadata.author -> _)
@@ -21,8 +22,9 @@ case class EnrichedMetadata(title: Option[String],
     val cw = this.createdWith.map(IndexFields.metadata.enrichedMetadata.createdWith -> _)
     val p =  this.pageCount.map(IndexFields.metadata.enrichedMetadata.pageCount -> Int.box(_))
     val wc = this.wordCount.map(IndexFields.metadata.enrichedMetadata.wordCount -> Int.box(_))
+    val dlc = this.detectedLanguageCode.map(IndexFields.metadata.enrichedMetadata.detectedLanguageCode -> _)
 
-    Map() ++ t ++ a ++ c ++ l ++ cw ++ p ++ wc
+    Map() ++ t ++ a ++ c ++ l ++ cw ++ p ++ wc ++ dlc
   }
 }
 
@@ -35,14 +37,15 @@ object MetadataEnrichment {
   def someIdentity[T](v: T): Option[T] = Some(v)
   def safeIntParse(c: String): Option[Int] = Try(c.toInt).toOption
 
-  def enrich(metadata: Map[String, Seq[String]]): EnrichedMetadata = EnrichedMetadata(
+  def enrich(metadata: Map[String, Seq[String]], detectedLanguage: Option[String]): EnrichedMetadata = EnrichedMetadata(
     extractFields(metadata, titleKeys)(someIdentity),
     extractFields(metadata, authorKeys)(someIdentity),
     extractFields(metadata, createdAtKeys)(isoDateToLong),
     extractFields(metadata, lastModifiedKeys)(isoDateToLong),
     extractFields(metadata, createdWithKeys)(someIdentity),
     extractFields(metadata, pageCountKeys)(safeIntParse),
-    extractFields(metadata, wordCountKeys)(safeIntParse)
+    extractFields(metadata, wordCountKeys)(safeIntParse),
+    detectedLanguage
   )
 
   // Probably these lists of keys could be simplified now we're on Tika v2.

--- a/backend/app/extraction/ocr/BaseOcrExtractor.scala
+++ b/backend/app/extraction/ocr/BaseOcrExtractor.scala
@@ -1,28 +1,41 @@
 package extraction.ocr
 
 import extraction.{ExtractionParams, FileExtractor}
+import model.Languages
 import model.manifest.Blob
+import org.apache.tika.language.detect.LanguageDetector
 import services.ScratchSpace
+import services.index.Index
 import utils.Ocr.{OcrMyPdfTimeout, OcrSubprocessInterruptedException}
 import utils.OcrStderrLogger
 import utils.attempt.{Failure, OcrTimeout, SubprocessInterruptedFailure}
 
 import java.io.File
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext}
 import scala.util.control.NonFatal
 
-abstract class BaseOcrExtractor(scratchSpace: ScratchSpace) extends FileExtractor(scratchSpace) {
+abstract class BaseOcrExtractor(scratchSpace: ScratchSpace, index:Index)  (implicit ec: ExecutionContext)  extends FileExtractor(scratchSpace) {
   def extractOcr(blob: Blob, file: File, params: ExtractionParams, stdErrLogger: OcrStderrLogger): Unit
   def buildStdErrLogger(blob: Blob): OcrStderrLogger
 
   final override def extract(blob: Blob, file: File, params: ExtractionParams): Either[Failure, Unit] = {
-    if (params.languages.isEmpty) {
+    // extractors are synchronous so we have to await here
+    val detectedLanguageCode = Await.result(index.getDetectedLanguage(blob.uri).asFuture, 3.seconds).toOption
+
+    if (params.languages.isEmpty && detectedLanguageCode.isDefined) {
       throw new IllegalStateException(s"${this.name} requires a language")
     }
+
+    // if we have detected a supported language code, use that, otherwise OCR in every language set for the ingestion
+    val ocrLanguages = detectedLanguageCode.map(code => Languages.getByIso6391Code(code).toList).getOrElse(params.languages)
+
+    val updatedParams = params.copy(languages = ocrLanguages)
 
     val stdErrLogger = buildStdErrLogger(blob)
 
     try {
-      extractOcr(blob, file, params, stdErrLogger)
+      extractOcr(blob, file, updatedParams, stdErrLogger)
       Right(())
     } catch {
       case OcrSubprocessInterruptedException =>

--- a/backend/app/extraction/ocr/BaseOcrExtractor.scala
+++ b/backend/app/extraction/ocr/BaseOcrExtractor.scala
@@ -21,7 +21,7 @@ abstract class BaseOcrExtractor(scratchSpace: ScratchSpace, index:Index)  (impli
 
   final override def extract(blob: Blob, file: File, params: ExtractionParams): Either[Failure, Unit] = {
     // extractors are synchronous so we have to await here
-    val detectedLanguageCode = Await.result(index.getDetectedLanguage(blob.uri).asFuture, 3.seconds).toOption
+    val detectedLanguageCode = Await.result(index.getTextDetectedLanguage(blob.uri).asFuture, 3.seconds).toOption
 
     if (params.languages.isEmpty && detectedLanguageCode.isDefined) {
       throw new IllegalStateException(s"${this.name} requires a language")

--- a/backend/app/extraction/ocr/ImageOcrExtractor.scala
+++ b/backend/app/extraction/ocr/ImageOcrExtractor.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 // I've avoided renaming this for compatibility reasons (the extractor name is stored in the Manifest).
 // It should now be called TesseractImageOcrExtractor
 class ImageOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, ingestionServices: IngestionServices)
-  (implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
+  (implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch, index) with Logging {
 
   val mimeTypes = Set(
     "image/png",
@@ -40,7 +40,8 @@ class ImageOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, 
     params.languages.foreach { lang =>
       val text = Ocr.invokeTesseractDirectly(lang.ocr, file.getAbsolutePath, config.tesseract, stdErrLogger)
       val optionalText = if (text.trim().isEmpty) None else Some(text)
-      index.addDocumentOcr(blob.uri, optionalText, lang).awaitEither(10.second)
+      val detectedLanguageCode = ingestionServices.detectLanguage(blob.uri.value, text)
+      index.addDocumentOcr(blob.uri, optionalText, lang, detectedLanguageCode).awaitEither(10.second)
     }
   }
 }

--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration._
 import scala.util.{Try, Using}
 
 class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages, previewStorage: ObjectStorage,
-  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
+  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch, index) with Logging {
 
   val mimeTypes = Set(
     "application/pdf"
@@ -112,8 +112,7 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
         previewStorage.create(blob.uri.toStoragePath, path, Some("application/pdf"))
       }
 
-      OcrMyPdfExtractor.insertFullText(blob.uri, pages, index)
-
+      OcrMyPdfExtractor.insertFullText(blob.uri, pages, index, ingestionServices.detectLanguage)
     } finally {
       pdDocuments.foreach { case(_, (path, doc)) =>
         doc.close()
@@ -142,7 +141,7 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
 }
 
 object OcrMyPdfExtractor {
-  def insertFullText(uri: Uri, pages: List[Page], index: Index)(implicit ec: ExecutionContext): Unit = {
+  def insertFullText(uri: Uri, pages: List[Page], index: Index, detectLanguage: (String, String) => Option[String])(implicit ec: ExecutionContext): Unit = {
     val textByLanguage = pages.foldLeft(Map.empty[Language, String]) { (acc, page) =>
       page.value.foldLeft(acc) { case (acc, (lang, value)) =>
         acc + (lang -> (acc.getOrElse(lang, "") + value))
@@ -151,7 +150,8 @@ object OcrMyPdfExtractor {
 
     textByLanguage.foreach { case (lang, value) =>
       val optionalText = if (value.trim().isEmpty) None else Some(value)
-      index.addDocumentOcr(uri, optionalText, lang).awaitEither(10.second)
+      val detectedLanguageCode = detectLanguage(uri.value, value)
+      index.addDocumentOcr(uri, optionalText, lang, detectedLanguageCode).awaitEither(10.second)
     }
   }
 }

--- a/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfImageExtractor.scala
@@ -22,7 +22,7 @@ import scala.sys.process.{Process, ProcessLogger}
 import scala.util.{Try, Using}
 
 class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, previewStorage: ObjectStorage,
-  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
+  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch, index) with Logging {
   val mimeTypes = Set(
     "image/png",
     "image/jpeg",
@@ -68,7 +68,8 @@ class OcrMyPdfImageExtractor(config: OcrConfig, scratch: ScratchSpace, index: In
       params.languages.foreach { lang =>
         val text = invokeOcrMyPdf(blob.uri, lang, fileToOCR, config, stdErrLogger, tmpDir)
         val optionalText = if (text.trim().isEmpty) None else Some(text)
-        index.addDocumentOcr(blob.uri, optionalText, lang).awaitEither(10.second)
+        val detectedLanguage = ingestionServices.detectLanguage(blob.uri.value, text.trim())
+        index.addDocumentOcr(blob.uri, optionalText, lang, detectedLanguage).awaitEither(10.second)
       }
     } finally {
       FileUtils.deleteDirectory(tmpDir.toFile)

--- a/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
+++ b/backend/app/extraction/ocr/TesseractPdfOcrExtractor.scala
@@ -18,7 +18,7 @@ import scala.concurrent.ExecutionContext
 // We could also use this as a possible fallback option after the primary OcrMyPdfExtractor, which
 // doesn't ocr as many docs (e.g. it respects encryption of PDFs)
 class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: Index, pageService: Pages,
-  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch) with Logging {
+  ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch, index) with Logging {
   val mimeTypes = Set(
     "application/pdf"
   )
@@ -83,7 +83,7 @@ class TesseractPdfOcrExtractor(config: OcrConfig, scratch: ScratchSpace, index: 
       }
 
       pageService.addPageContents(blob.uri, pages)
-      OcrMyPdfExtractor.insertFullText(blob.uri, pages, index)
+      OcrMyPdfExtractor.insertFullText(blob.uri, pages, index, ingestionServices.detectLanguage)
     } finally {
       Option(document).foreach(_.close())
       cleanup(file)

--- a/backend/app/model/index/Document.scala
+++ b/backend/app/model/index/Document.scala
@@ -16,7 +16,8 @@ case class Document(uri: Uri,
                     metadata: Map[String, Seq[String]],
                     enrichedMetadata: Option[EnrichedMetadata],
                     flag: Option[String],
-                    fileSize: Long) extends IndexedResource
+                    fileSize: Long,
+                    languageData: Option[LanguageData]) extends IndexedResource
 
 object Document {
   implicit val documentFormat: Format[Document] = Json.format[Document]

--- a/backend/app/model/index/LanguageData.scala
+++ b/backend/app/model/index/LanguageData.scala
@@ -1,0 +1,16 @@
+package model.index
+
+import play.api.libs.json._
+
+case class LanguageDataField(detectedLanguageCode: Option[String], translation: Option[String])
+case class OcrLanguageData(detectedLanguageCode: Map[String, String], translation: Map[String, String])
+case class LanguageData(text: Option[LanguageDataField],
+                        emailSubject: Option[LanguageDataField],
+                        emailBody: Option[LanguageDataField],
+                        ocr: Option[OcrLanguageData])
+
+object LanguageData {
+  implicit val languageDataFieldFormat: Format[LanguageDataField] = Json.format[LanguageDataField]
+  implicit val ocrLanguageDataFormat: Format[OcrLanguageData] = Json.format[OcrLanguageData]
+  implicit val languageDataFormat: Format[LanguageData] = Json.format[LanguageData]
+}

--- a/backend/app/services/ElasticsearchSyntax.scala
+++ b/backend/app/services/ElasticsearchSyntax.scala
@@ -9,12 +9,13 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.indexes.CreateIndexResponse
 import com.sksamuel.elastic4s.requests.indexes.admin.IndexExistsResponse
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
-import com.sksamuel.elastic4s.requests.mappings.{MappingDefinition}
+import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import com.sksamuel.elastic4s.requests.update.{UpdateByQueryRequest, UpdateRequest}
 import model.Language
 import org.apache.http.{ContentTooLongException, HttpHost}
 import org.elasticsearch.client.RestClient
 import org.elasticsearch.client.sniff.Sniffer
+import services.index.IndexFields
 import utils.Logging
 import utils.attempt.{Attempt, ContentTooLongFailure, ElasticSearchQueryFailure, MultipleFailures, UnknownFailure}
 
@@ -47,6 +48,13 @@ trait ElasticsearchSyntax { this: Logging =>
 
   // Each entry is added by a call to multiLanguageField
   def emptyMultiLanguageField(name: String): ObjectField = objectField(name)
+
+  def emptyLanguageDataField(name: String): ObjectField = {
+    ObjectField(name, properties = Seq(
+      textField(IndexFields.languageData.translatableFieldData.detectedLanguageCode),
+      textField(IndexFields.languageData.translatableFieldData.translation)
+    ))
+  }
 
   def multiLanguageField(name: String, language: Language): ObjectField = {
     ObjectField(name, properties = Seq(

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -68,7 +68,7 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
           )),
           // ocr documents only
           ObjectField(IndexFields.metadata.ocrMetadataField, properties = Seq(
-            emptyMultiLanguageField(IndexFields.metadata.ocr.languagesField)
+            ObjectField(IndexFields.metadata.ocr.languagesField, dynamic = Some("true"))
           )),
           // Emails Only
           ObjectField(IndexFields.metadata.fromField, properties = Seq(

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -1,6 +1,6 @@
 package services.index
 
-import com.sksamuel.elastic4s.ElasticClient
+import com.sksamuel.elastic4s.{ArrayFieldValue, ElasticClient}
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.fields.ObjectField
 import com.sksamuel.elastic4s.requests.common.FetchSourceContext
@@ -64,11 +64,16 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
             textKeywordField(IndexFields.metadata.enrichedMetadata.createdWith),
             intField(IndexFields.metadata.enrichedMetadata.pageCount),
             intField(IndexFields.metadata.enrichedMetadata.wordCount),
-            textKeywordField(IndexFields.metadata.enrichedMetadata.detectedLanguageCode),
           )),
-          // ocr documents only
-          ObjectField(IndexFields.metadata.ocrMetadataField, properties = Seq(
-            ObjectField(IndexFields.metadata.ocr.languagesField, dynamic = Some("true"))
+          ObjectField(IndexFields.languageDataField, properties = Seq(
+           emptyLanguageDataField(IndexFields.languageData.textField),
+           emptyLanguageDataField(IndexFields.languageData.emailBodyField),
+           emptyLanguageDataField(IndexFields.languageData.emailSubjectField),
+            // at the moment OCR can be an arbitrary number of languages, so this is a bit more complicated
+            ObjectField(IndexFields.languageData.ocr, properties = Seq(
+              emptyMultiLanguageField(IndexFields.languageData.translatableFieldData.translation),
+              emptyMultiLanguageField(IndexFields.languageData.translatableFieldData.detectedLanguageCode),
+            )),
           )),
           // Emails Only
           ObjectField(IndexFields.metadata.fromField, properties = Seq(
@@ -102,6 +107,12 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
         multiLanguageField(IndexFields.ocr, language),
         multiLanguageField(IndexFields.transcript, language),
         multiLanguageField(IndexFields.vttTranscript, language),
+        ObjectField(IndexFields.languageDataField, properties = Seq(
+          ObjectField(IndexFields.languageData.ocr, properties = Seq(
+            multiLanguageField(IndexFields.languageData.translatableFieldData.detectedLanguageCode, language),
+            multiLanguageField(IndexFields.languageData.translatableFieldData.translation, language),
+          ))
+        )),
         ObjectField(IndexFields.metadataField, properties = Seq(
           multiLanguageField(IndexFields.metadata.fileUris, language),
           ObjectField(IndexFields.metadata.fromField, properties = Seq(
@@ -225,15 +236,15 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     }
   }
 
-  override def getDetectedLanguage(uri:Uri): Attempt[String] = {
+  override def getTextDetectedLanguage(uri:Uri): Attempt[String] = {
     execute {
       get(indexName, uri.value)
-        .fetchSourceInclude(s"${IndexFields.metadataField}.${IndexFields.metadata.enrichedMetadataField}.${IndexFields.metadata.enrichedMetadata.detectedLanguageCode}")
+        .fetchSourceInclude(s"${IndexFields.languageDataField}.${IndexFields.languageData.textField}.${IndexFields.languageData.translatableFieldData.detectedLanguageCode}")
     }.flatMap { resp =>
       if(resp.exists) {
-        val maybeLanguageCode = resp.source.optField[FieldMap](IndexFields.metadataField)
-          .flatMap(_.optField[FieldMap](IndexFields.metadata.enrichedMetadataField))
-          .flatMap(_.optField[String](IndexFields.metadata.enrichedMetadata.detectedLanguageCode))
+        val maybeLanguageCode = resp.source.optField[FieldMap](IndexFields.languageDataField)
+          .flatMap(_.optField[FieldMap](IndexFields.languageData.textField))
+          .flatMap(_.optField[String](IndexFields.languageData.translatableFieldData.detectedLanguageCode))
 
         maybeLanguageCode.toAttempt(Attempt.Left(NotFoundFailure(s"Detected language code not found for resource: ${uri.value}")))
       } else {
@@ -242,7 +253,7 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     }
   }
 
-  override def addDocumentDetails(uri: Uri, text: Option[String], metadata: Map[String, Seq[String]], enrichedMetadata: EnrichedMetadata, languages: List[Language]): Attempt[Unit] = {
+  override def addDocumentDetails(uri: Uri, text: Option[String], metadata: Map[String, Seq[String]], enrichedMetadata: EnrichedMetadata, languages: List[Language], documentBodyDetectedLanguage: Option[String]): Attempt[Unit] = {
     logger.info(s"Adding text to ${uri.value} in index")
 
     val metadataList = metadata.map { case(key, values) =>
@@ -256,13 +267,21 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
       Map(IndexFields.text -> multiLanguageValue(languages, textContent))
     }.getOrElse(Map.empty)
 
+    val updatedLanguageData = documentBodyDetectedLanguage.map { code =>
+      IndexFields.languageDataField -> Map(
+        IndexFields.languageData.textField -> Map(
+          IndexFields.languageData.translatableFieldData.detectedLanguageCode -> code
+        )
+      )
+    }
+
     val fieldMap: Map[String, Any] = Map(
       IndexFields.extracted -> true,
       IndexFields.metadataField -> Map(
         IndexFields.metadata.extractedMetadataField -> metadataList,
         IndexFields.metadata.enrichedMetadataField -> enrichedMetadata.toMap
       )
-    ) ++ textField ++ enrichedMetadata.createdAt.map(IndexFields.createdAt -> _) ++ enrichedMetadata.lastModified.map(IndexFields.lastModifiedAt -> _)
+    ) ++ updatedLanguageData ++ textField ++ enrichedMetadata.createdAt.map(IndexFields.createdAt -> _) ++ enrichedMetadata.lastModified.map(IndexFields.lastModifiedAt -> _)
 
     executeUpdate {
       updateById(indexName, uri.value).doc(
@@ -274,21 +293,17 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
   override def addDocumentOcr(uri: Uri, ocr: Option[String], language: Language, detectedLanguageCode: Option[String]): Attempt[Unit] = {
     logger.info(s"Adding OCR to ${uri.value} in index")
 
-    val updatedMetadata = detectedLanguageCode.map { code =>
-      IndexFields.metadataField -> Map(
-        IndexFields.metadata.ocrMetadataField -> Map(
-          IndexFields.metadata.ocr.languagesField -> Map(
-            language.key -> Map(
-              IndexFields.metadata.ocr.languages.detectedLanguageCode -> code
-            )
-          )
+    val updatedLanguageData = detectedLanguageCode.map { code =>
+      IndexFields.languageDataField -> Map(
+        IndexFields.languageData.ocr -> Map(
+          IndexFields.languageData.translatableFieldData.detectedLanguageCode -> Map(language.key -> code)
         )
       )
     }
 
     val fieldMap = Map(
       IndexFields.ocrExtracted -> true,
-    ) ++ updatedMetadata ++ ocr.map(ocrText =>
+    ) ++ updatedLanguageData ++ ocr.map(ocrText =>
       IndexFields.ocr -> Map(
         language.key -> ocrText
       )
@@ -331,7 +346,7 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     }
   }
 
-  override def ingestEmail(email: Email, ingestion: String, sourceMimeType: String, parentBlobs: List[Uri], workspace: Option[WorkspaceItemContext], languages: List[Language]): Attempt[Unit] = {
+  override def ingestEmail(email: Email, ingestion: String, sourceMimeType: String, parentBlobs: List[Uri], workspace: Option[WorkspaceItemContext], languages: List[Language], subjectDetectedLanguage: Option[String], bodyDetectedLanguage: Option[String]): Attempt[Unit] = {
     val collection = ingestion.split("/").headOption.getOrElse("unknown")
     val recipients = email.recipients.map { r => recipientToMap(languages, Some(r)) }
 
@@ -343,6 +358,20 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
         NestedField.values -> values
       )
     }
+
+    val bodyDetectedLanguageField = bodyDetectedLanguage.map { code =>
+        IndexFields.languageData.emailBodyField -> Map(
+          IndexFields.languageData.translatableFieldData.detectedLanguageCode -> code
+        )
+    }
+    val subjectDetectedLanguageField = subjectDetectedLanguage.map { code =>
+      IndexFields.languageData.emailSubjectField -> Map(
+        IndexFields.languageData.translatableFieldData.detectedLanguageCode -> code
+      )
+    }
+    val updatedLanguageData = Map(
+        IndexFields.languageDataField -> (Map() ++ bodyDetectedLanguageField ++ subjectDetectedLanguageField)
+    )
 
     val defaultFields = Map(
       IndexFields.`type` -> "email",
@@ -369,7 +398,7 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
 
     val createdAtField: Option[(String, Long)] = email.sentAtMillis().map(IndexFields.createdAt -> _)
 
-    val upsertFields = defaultFields ++ createdAtField
+    val upsertFields = defaultFields ++ createdAtField ++ updatedLanguageData
 
     executeUpdate {
       updateById(indexName, email.uri.value)
@@ -925,7 +954,6 @@ object IndexFields {
       val createdWith = "createdWith"
       val pageCount = "pageCount"
       val wordCount = "wordCount"
-      val detectedLanguageCode = "detectedLanguageCode"
     }
 
     val fromField = "from"
@@ -947,15 +975,18 @@ object IndexFields {
     val subject = "subject"
     val html = "html"
     val attachmentCount = "attachmentCount"
+  }
+  // languageData object to support translation for various fields - detected language and translated text
+  val languageDataField = "languageData"
+  object languageData {
+    val textField = "text"
+    val emailSubjectField = "emailSubject"
+    val emailBodyField = "emailBody"
+    val ocr = "ocr"
 
-    // ideally this would live in the top level 'ocr' field, but that has the structure {ocr: {[lang]:text}} so there's
-    // no space to squeeze in metadata without reindexing everything (we'd like to have {ocr: {[lang]: {text:..., metadata:{...}}}})
-    val ocrMetadataField = "ocrMetadata"
-    object ocr {
-      val languagesField = "languages"
-      object languages {
-        val detectedLanguageCode = "detectedLanguageCode"
-      }
+    object translatableFieldData {
+      val detectedLanguageCode = "detectedLanguageCode"
+      val translation = "translation"
     }
   }
 

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -63,9 +63,13 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
             longField(IndexFields.metadata.enrichedMetadata.lastModified),
             textKeywordField(IndexFields.metadata.enrichedMetadata.createdWith),
             intField(IndexFields.metadata.enrichedMetadata.pageCount),
-            intField(IndexFields.metadata.enrichedMetadata.wordCount)
+            intField(IndexFields.metadata.enrichedMetadata.wordCount),
+            textKeywordField(IndexFields.metadata.enrichedMetadata.detectedLanguageCode),
           )),
-
+          // ocr documents only
+          ObjectField(IndexFields.metadata.ocrMetadataField, properties = Seq(
+            emptyMultiLanguageField(IndexFields.metadata.ocr.languagesField)
+          )),
           // Emails Only
           ObjectField(IndexFields.metadata.fromField, properties = Seq(
             emptyMultiLanguageField(IndexFields.metadata.from.name),
@@ -221,6 +225,23 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     }
   }
 
+  override def getDetectedLanguage(uri:Uri): Attempt[String] = {
+    execute {
+      get(indexName, uri.value)
+        .fetchSourceInclude(s"${IndexFields.metadataField}.${IndexFields.metadata.enrichedMetadataField}.${IndexFields.metadata.enrichedMetadata.detectedLanguageCode}")
+    }.flatMap { resp =>
+      if(resp.exists) {
+        val maybeLanguageCode = resp.source.optField[FieldMap](IndexFields.metadataField)
+          .flatMap(_.optField[FieldMap](IndexFields.metadata.enrichedMetadataField))
+          .flatMap(_.optField[String](IndexFields.metadata.enrichedMetadata.detectedLanguageCode))
+
+        maybeLanguageCode.toAttempt(Attempt.Left(NotFoundFailure(s"Detected language code not found for resource: ${uri.value}")))
+      } else {
+        Attempt.Left(NotFoundFailure(s"Resource not found in index: ${uri.value}"))
+      }
+    }
+  }
+
   override def addDocumentDetails(uri: Uri, text: Option[String], metadata: Map[String, Seq[String]], enrichedMetadata: EnrichedMetadata, languages: List[Language]): Attempt[Unit] = {
     logger.info(s"Adding text to ${uri.value} in index")
 
@@ -230,6 +251,8 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
         NestedField.values -> values
       )
     }
+
+    println(s"DLC ${enrichedMetadata.detectedLanguageCode}")
 
     val textField: Map[String, Any] = text.map { textContent =>
       Map(IndexFields.text -> multiLanguageValue(languages, textContent))
@@ -250,21 +273,42 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     }
   }
 
-  override def addDocumentOcr(uri: Uri, ocr: Option[String], language: Language): Attempt[Unit] = {
+  override def addDocumentOcr(uri: Uri, ocr: Option[String], language: Language, detectedLanguageCode: Option[String]): Attempt[Unit] = {
     logger.info(s"Adding OCR to ${uri.value} in index")
 
+    println(s"DLC in OCR ${detectedLanguageCode}")
+
+    val updatedMetadata = detectedLanguageCode.map { code =>
+      IndexFields.metadataField -> Map(
+        IndexFields.metadata.ocrMetadataField -> Map(
+          IndexFields.metadata.ocr.languagesField -> Map(
+            language.key -> Map(
+              IndexFields.metadata.ocr.languages.detectedLanguageCode -> code
+            )
+          )
+        )
+      )
+    }
+
     val fieldMap = Map(
-      IndexFields.ocrExtracted -> true
-    )  ++ ocr.map(ocrText =>
+      IndexFields.ocrExtracted -> true,
+    ) ++ updatedMetadata ++ ocr.map(ocrText =>
       IndexFields.ocr -> Map(
         language.key -> ocrText
       )
     )
 
-    executeUpdate {
+    println(s"new fieldmap ${fieldMap}")
+
+    val result = executeUpdate {
       updateById(indexName, uri.value).doc(
         fieldMap
       )
+    }
+
+    result.recoverWith { case error =>
+      logger.error(s"Failed to update OCR for ${uri.value}: ${error.msg}", error.toThrowable)
+      Attempt.Left(error)
     }
   }
 
@@ -887,6 +931,7 @@ object IndexFields {
       val createdWith = "createdWith"
       val pageCount = "pageCount"
       val wordCount = "wordCount"
+      val detectedLanguageCode = "detectedLanguageCode"
     }
 
     val fromField = "from"
@@ -908,6 +953,16 @@ object IndexFields {
     val subject = "subject"
     val html = "html"
     val attachmentCount = "attachmentCount"
+
+    // ideally this would live in the top level 'ocr' field, but that has the structure {ocr: {[lang]:text}} so there's
+    // no space to squeeze in metadata without reindexing everything (we'd like to have {ocr: {[lang]: {text:..., metadata:{...}}}})
+    val ocrMetadataField = "ocrMetadata"
+    object ocr {
+      val languagesField = "languages"
+      object languages {
+        val detectedLanguageCode = "detectedLanguageCode"
+      }
+    }
   }
 
   // These should be in order of importance

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -65,16 +65,6 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
             intField(IndexFields.metadata.enrichedMetadata.pageCount),
             intField(IndexFields.metadata.enrichedMetadata.wordCount),
           )),
-          ObjectField(IndexFields.languageDataField, properties = Seq(
-           emptyLanguageDataField(IndexFields.languageData.textField),
-           emptyLanguageDataField(IndexFields.languageData.emailBodyField),
-           emptyLanguageDataField(IndexFields.languageData.emailSubjectField),
-            // at the moment OCR can be an arbitrary number of languages, so this is a bit more complicated
-            ObjectField(IndexFields.languageData.ocr, properties = Seq(
-              emptyMultiLanguageField(IndexFields.languageData.translatableFieldData.translation),
-              emptyMultiLanguageField(IndexFields.languageData.translatableFieldData.detectedLanguageCode),
-            )),
-          )),
           // Emails Only
           ObjectField(IndexFields.metadata.fromField, properties = Seq(
             emptyMultiLanguageField(IndexFields.metadata.from.name),
@@ -92,8 +82,18 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
           textKeywordField(IndexFields.metadata.inReplyTo),
           emptyMultiLanguageField(IndexFields.metadata.html),
           intField(IndexFields.metadata.attachmentCount)
-        )
-    ))).flatMap { _ =>
+        )),
+        ObjectField(IndexFields.languageDataField, properties = Seq(
+          emptyLanguageDataField(IndexFields.languageData.textField),
+          emptyLanguageDataField(IndexFields.languageData.emailBodyField),
+          emptyLanguageDataField(IndexFields.languageData.emailSubjectField),
+          // at the moment OCR can be an arbitrary number of languages, so this is a bit more complicated
+          ObjectField(IndexFields.languageData.ocr, properties = Seq(
+            emptyMultiLanguageField(IndexFields.languageData.translatableFieldData.translation),
+            emptyMultiLanguageField(IndexFields.languageData.translatableFieldData.detectedLanguageCode),
+          )),
+        ))
+    )).flatMap { _ =>
       Attempt.sequence(Languages.all.map(addLanguage))
     }.map { _ =>
       this

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -252,8 +252,6 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
       )
     }
 
-    println(s"DLC ${enrichedMetadata.detectedLanguageCode}")
-
     val textField: Map[String, Any] = text.map { textContent =>
       Map(IndexFields.text -> multiLanguageValue(languages, textContent))
     }.getOrElse(Map.empty)
@@ -276,8 +274,6 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
   override def addDocumentOcr(uri: Uri, ocr: Option[String], language: Language, detectedLanguageCode: Option[String]): Attempt[Unit] = {
     logger.info(s"Adding OCR to ${uri.value} in index")
 
-    println(s"DLC in OCR ${detectedLanguageCode}")
-
     val updatedMetadata = detectedLanguageCode.map { code =>
       IndexFields.metadataField -> Map(
         IndexFields.metadata.ocrMetadataField -> Map(
@@ -297,8 +293,6 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
         language.key -> ocrText
       )
     )
-
-    println(s"new fieldmap ${fieldMap}")
 
     val result = executeUpdate {
       updateById(indexName, uri.value).doc(

--- a/backend/app/services/index/HitReaders.scala
+++ b/backend/app/services/index/HitReaders.scala
@@ -247,7 +247,8 @@ object HitReaders {
       mimeTypes = metadataMap.setField[String](metadata.mimeTypes),
       fileUris  = readFileUris(metadataMap).toSet,
       fileSize  = metadataMap.optLongField(metadata.fileSize).getOrElse(0L),
-      metadata = readMetadata(fields)
+      metadata = readMetadata(fields),
+      languageData = readLanguageData(fields)
     )
   }
 
@@ -272,6 +273,35 @@ object HitReaders {
     }
   }
 
+  private def readLanguageData(fields: FieldMap): Option[LanguageData] = {
+    fields.optField[FieldMap](languageDataField).map { ld =>
+      def readField(name: String): Option[LanguageDataField] = {
+        ld.optField[FieldMap](name).map { f =>
+          LanguageDataField(
+            detectedLanguageCode = f.optField[String](languageData.translatableFieldData.detectedLanguageCode),
+            translation = f.optField[String](languageData.translatableFieldData.translation)
+          )
+        }
+      }
+
+      val ocrData = ld.optField[FieldMap](languageData.ocr).map { o =>
+        OcrLanguageData(
+          detectedLanguageCode = o.optField[FieldMap](languageData.translatableFieldData.detectedLanguageCode)
+            .map(_.view.mapValues(_.asInstanceOf[String]).toMap).getOrElse(Map.empty),
+          translation = o.optField[FieldMap](languageData.translatableFieldData.translation)
+            .map(_.view.mapValues(_.asInstanceOf[String]).toMap).getOrElse(Map.empty)
+        )
+      }
+
+      LanguageData(
+        text = readField(languageData.textField),
+        emailSubject = readField(languageData.emailSubjectField),
+        emailBody = readField(languageData.emailBodyField),
+        ocr = ocrData
+      )
+    }
+  }
+
   private def readVttTranscript(fields: FieldMap): Option[Map[String, String]] = {
     fields.optField[FieldMap](vttTranscript).map { languages =>
       languages.view.mapValues(_.asInstanceOf[String]).toMap
@@ -290,9 +320,7 @@ object HitReaders {
         map.optField[Long](metadata.enrichedMetadata.lastModified),
         map.optField[String](metadata.enrichedMetadata.createdWith),
         map.optField[Int](metadata.enrichedMetadata.pageCount),
-        map.optField[Int](metadata.enrichedMetadata.wordCount),
-        map.optField[String](metadata.enrichedMetadata.detectedLanguageCode)
-
+        map.optField[Int](metadata.enrichedMetadata.wordCount)
       )
     }
   }

--- a/backend/app/services/index/HitReaders.scala
+++ b/backend/app/services/index/HitReaders.scala
@@ -290,7 +290,9 @@ object HitReaders {
         map.optField[Long](metadata.enrichedMetadata.lastModified),
         map.optField[String](metadata.enrichedMetadata.createdWith),
         map.optField[Int](metadata.enrichedMetadata.pageCount),
-        map.optField[Int](metadata.enrichedMetadata.wordCount)
+        map.optField[Int](metadata.enrichedMetadata.wordCount),
+        map.optField[String](metadata.enrichedMetadata.detectedLanguageCode)
+
       )
     }
   }

--- a/backend/app/services/index/Index.scala
+++ b/backend/app/services/index/Index.scala
@@ -13,13 +13,13 @@ trait Index {
 
   def ingestDocument(uri: Uri, size: Long, document: IngestionData, languages: List[Language]): Attempt[Unit]
 
-  def addDocumentDetails(uri: Uri, text: Option[String], metadata: Map[String, Seq[String]], enrichedMetadata: EnrichedMetadata, languages: List[Language]): Attempt[Unit]
+  def addDocumentDetails(uri: Uri, text: Option[String], metadata: Map[String, Seq[String]], enrichedMetadata: EnrichedMetadata, languages: List[Language], documentBodyDetectedLanguage: Option[String]): Attempt[Unit]
   def addDocumentOcr(uri: Uri, ocr: Option[String], language: Language, detectedLanguageCode: Option[String]): Attempt[Unit]
   def addDocumentTranscription(uri: Uri, transcription: TranscriptionResult): Attempt[Unit]
 
-  def getDetectedLanguage(uri:Uri): Attempt[String]
+  def getTextDetectedLanguage(uri:Uri): Attempt[String]
 
-  def ingestEmail(email: Email, ingestion: String, sourceMimeType: String, parentBlobs: List[Uri], workspace: Option[WorkspaceItemContext], languages: List[Language]): Attempt[Unit]
+  def ingestEmail(email: Email, ingestion: String, sourceMimeType: String, parentBlobs: List[Uri], workspace: Option[WorkspaceItemContext], languages: List[Language], subjectDetectedLanguage: Option[String], bodyDetectedLanguage: Option[String]): Attempt[Unit]
 
   def query(parameters: SearchParameters, context: SearchContext): Attempt[SearchResults]
 

--- a/backend/app/services/index/Index.scala
+++ b/backend/app/services/index/Index.scala
@@ -14,8 +14,10 @@ trait Index {
   def ingestDocument(uri: Uri, size: Long, document: IngestionData, languages: List[Language]): Attempt[Unit]
 
   def addDocumentDetails(uri: Uri, text: Option[String], metadata: Map[String, Seq[String]], enrichedMetadata: EnrichedMetadata, languages: List[Language]): Attempt[Unit]
-  def addDocumentOcr(uri: Uri, ocr: Option[String], language: Language): Attempt[Unit]
+  def addDocumentOcr(uri: Uri, ocr: Option[String], language: Language, detectedLanguageCode: Option[String]): Attempt[Unit]
   def addDocumentTranscription(uri: Uri, transcription: TranscriptionResult): Attempt[Unit]
+
+  def getDetectedLanguage(uri:Uri): Attempt[String]
 
   def ingestEmail(email: Email, ingestion: String, sourceMimeType: String, parentBlobs: List[Uri], workspace: Option[WorkspaceItemContext], languages: List[Language]): Attempt[Unit]
 

--- a/backend/app/services/ingestion/IngestionServices.scala
+++ b/backend/app/services/ingestion/IngestionServices.scala
@@ -6,6 +6,7 @@ import extraction.{Extractor, MimeTypeMapper}
 import model.{Language, Uri}
 import model.ingestion.{EmailContext, FileContext, WorkspaceItemContext}
 import model.manifest.{Blob, MimeType}
+import org.apache.tika.language.detect.LanguageDetector
 import services.index.{Index, IngestionData}
 import services.manifest.Manifest
 import services.{ObjectStorage, Tika, TypeDetector}
@@ -15,7 +16,7 @@ import utils.attempt.{Attempt, Failure, NotFoundFailure}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import services.observability.{BlobMetadata, EventDetails, IngestionEvent, IngestionEventType, EventMetadata, PostgresClient, EventStatus}
+import services.observability.{BlobMetadata, EventDetails, EventMetadata, EventStatus, IngestionEvent, IngestionEventType, PostgresClient}
 
 sealed trait UriParent {
   def parent: Uri
@@ -45,11 +46,30 @@ trait IngestionServices {
   def ingestEmail(context: EmailContext, sourceMimeType: String): Either[Failure, Unit]
   def ingestFile(context: FileContext, blobUri: Uri, path: Path, isFastLane: Boolean = false): Either[Failure, Blob]
   def setProgressNote(blobUri: Uri, extractor: Extractor, note: String): Either[Failure, Unit]
+  def detectLanguage(blobUri: String, text: String): Option[String]
 }
 
 object IngestionServices extends Logging {
-  def apply(manifest: Manifest, index: Index, objectStorage: ObjectStorage, typeDetector: TypeDetector, mimeTypeMapper: MimeTypeMapper, postgresClient: PostgresClient)(implicit ec: ExecutionContext): IngestionServices = new IngestionServices {
+  def apply(manifest: Manifest, index: Index, objectStorage: ObjectStorage, typeDetector: TypeDetector, mimeTypeMapper: MimeTypeMapper, postgresClient: PostgresClient, languageDetector: ThreadLocal[LanguageDetector])(implicit ec: ExecutionContext): IngestionServices = new IngestionServices {
     override def recordIngestionEvent(event: IngestionEvent) = postgresClient.insertEvent(event)
+
+    /***
+      * Uses tika to return the iso639-1 language code for the given text. We only store codes where tikka has a high
+      * confidence in the result to try and maintain index quality
+      * See https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes for a list of codes
+      * @param text
+      * @return
+      */
+    def detectLanguage(blobUri: String, text: String): Option[String] = {
+      val result = languageDetector.get().detect(text.take(10000))
+      println(s"lang: ${result.getLanguage} confidence: ${result.getRawScore} reasonably certain: ${result.isReasonablyCertain}")
+      if (result.isReasonablyCertain) {
+        Some(result.getLanguage)
+      } else {
+        logger.info(s"Unable to detect language for text in blob $blobUri. Tika result: ${result.getLanguage} with confidence ${result.getRawScore}")
+        None
+      }
+    }
 
     override def ingestEmail(context: EmailContext, sourceMimeType: String): Either[Failure, Unit] = {
 

--- a/backend/app/services/ingestion/IngestionServices.scala
+++ b/backend/app/services/ingestion/IngestionServices.scala
@@ -53,16 +53,16 @@ object IngestionServices extends Logging {
 
   private def cleanTextForLanguageDetection(text: String): String = {
     text
-      .replaceAll("""https?://\S+""", "")                // URLs
-      .replaceAll("""www\.\S+""", "")                     // www URLs without scheme
-      .replaceAll("""[\w.+-]+@[\w.-]+\.\w+""", "")        // email addresses
-      .replaceAll("""[A-Za-z]:\\[\\\w.\-]+""", "")        // Windows paths
-      .replaceAll("""/[\w./\-]+""", "")                   // Unix paths (conservative)
-      .replaceAll("""<[^>]+>""", "")                      // HTML/XML tags
-      .replaceAll("""[0-9a-fA-F]{16,}""", "")             // long hex strings
-      .replaceAll("""[A-Za-z0-9+/=]{40,}""", "")          // base64-like strings
-      .replaceAll("""\b\d+\b""", "")                      // standalone numbers
-      .replaceAll("""\s{2,}""", " ")                      // collapse whitespace
+      .replaceAll("""https?://\S+""", "")                // removes URLs starting with http:// or https:// followed by non-whitespace
+      .replaceAll("""www\.\S+""", "")                     // removes URLs starting with www. that have no scheme
+      .replaceAll("""[\w.+-]+@[\w.-]+\.\w+""", "")        // removes email addresses (e.g. user.name+tag@domain.co.uk)
+      .replaceAll("""[A-Za-z]:\\[\\\w.\-]+""", "")        // removes Windows file paths (e.g. C:\Users\file.txt)
+      .replaceAll("""/[\w./\-]+""", "")                   // removes Unix file paths starting with / (e.g. /usr/local/bin)
+      .replaceAll("""<[^>]+>""", "")                      // removes HTML/XML tags (e.g. <div class="foo">)
+      .replaceAll("""[0-9a-fA-F]{16,}""", "")             // removes hex strings of 16+ characters (e.g. SHA hashes, UUIDs without dashes)
+      .replaceAll("""[A-Za-z0-9+/=]{40,}""", "")          // removes base64-like strings of 40+ alphanumeric/+/=/characters
+      .replaceAll("""\b\d+\b""", "")                      // removes standalone numbers (digits not attached to words)
+      .replaceAll("""\s{2,}""", " ")                      // collapses runs of 2+ whitespace characters into a single space
       .trim
   }
 

--- a/backend/app/services/ingestion/IngestionServices.scala
+++ b/backend/app/services/ingestion/IngestionServices.scala
@@ -76,7 +76,7 @@ object IngestionServices extends Logging {
       * @param text
       * @return
       */
-    def detectLanguage(blobUri: String, text: String): Option[String] = {
+    def detectLanguage(fieldIdentifier: String, text: String): Option[String] = {
       // clean a large block of text in case the file starts with lots of junk
       val textToClean = text.take(50000)
       val cleanedText = cleanTextForLanguageDetection(textToClean)
@@ -85,7 +85,7 @@ object IngestionServices extends Logging {
       if (result.isReasonablyCertain) {
         Some(result.getLanguage)
       } else {
-        logger.info(s"Unable to detect language for text in blob $blobUri. Tika result: ${result.getLanguage} with confidence ${result.getRawScore}")
+        logger.info(s"Unable to detect language for text in $fieldIdentifier. Tika result: ${result.getLanguage} with confidence ${result.getRawScore}")
         None
       }
     }
@@ -102,9 +102,12 @@ object IngestionServices extends Logging {
 
       val insertions = intermediateResources :+ Manifest.InsertEmail(context.email, context.parents.head)
 
+      val subjectDetectedLanguage = detectLanguage(s"${context.email.uri.value} email subject", context.email.subject)
+      val bodyDetectedLanguage = detectLanguage(s"${context.email.uri.value} email body", context.email.body)
+
       manifest.insert(insertions, rootUri).flatMap( _ =>
         // TODO once we get attempt everywhere we can remove the await
-        index.ingestEmail(context.email, context.ingestion, sourceMimeType, context.parentBlobs, context.workspace, context.languages).awaitEither(10.second)
+        index.ingestEmail(context.email, context.ingestion, sourceMimeType, context.parentBlobs, context.workspace, context.languages, subjectDetectedLanguage, bodyDetectedLanguage).awaitEither(10.second)
       )
     }
 

--- a/backend/app/services/ingestion/IngestionServices.scala
+++ b/backend/app/services/ingestion/IngestionServices.scala
@@ -50,6 +50,22 @@ trait IngestionServices {
 }
 
 object IngestionServices extends Logging {
+
+  private def cleanTextForLanguageDetection(text: String): String = {
+    text
+      .replaceAll("""https?://\S+""", "")                // URLs
+      .replaceAll("""www\.\S+""", "")                     // www URLs without scheme
+      .replaceAll("""[\w.+-]+@[\w.-]+\.\w+""", "")        // email addresses
+      .replaceAll("""[A-Za-z]:\\[\\\w.\-]+""", "")        // Windows paths
+      .replaceAll("""/[\w./\-]+""", "")                   // Unix paths (conservative)
+      .replaceAll("""<[^>]+>""", "")                      // HTML/XML tags
+      .replaceAll("""[0-9a-fA-F]{16,}""", "")             // long hex strings
+      .replaceAll("""[A-Za-z0-9+/=]{40,}""", "")          // base64-like strings
+      .replaceAll("""\b\d+\b""", "")                      // standalone numbers
+      .replaceAll("""\s{2,}""", " ")                      // collapse whitespace
+      .trim
+  }
+
   def apply(manifest: Manifest, index: Index, objectStorage: ObjectStorage, typeDetector: TypeDetector, mimeTypeMapper: MimeTypeMapper, postgresClient: PostgresClient, languageDetector: ThreadLocal[LanguageDetector])(implicit ec: ExecutionContext): IngestionServices = new IngestionServices {
     override def recordIngestionEvent(event: IngestionEvent) = postgresClient.insertEvent(event)
 
@@ -61,8 +77,11 @@ object IngestionServices extends Logging {
       * @return
       */
     def detectLanguage(blobUri: String, text: String): Option[String] = {
-      val result = languageDetector.get().detect(text.take(10000))
-      println(s"lang: ${result.getLanguage} confidence: ${result.getRawScore} reasonably certain: ${result.isReasonablyCertain}")
+      // clean a large block of text in case the file starts with lots of junk
+      val textToClean = text.take(50000)
+      val cleanedText = cleanTextForLanguageDetection(textToClean)
+      // Drop to just 10,000 characters to limit performance impact of language detection
+      val result = languageDetector.get().detect(cleanedText.take(10000))
       if (result.isReasonablyCertain) {
         Some(result.getLanguage)
       } else {

--- a/backend/test/services/index/ElasticsearchResourcesITest.scala
+++ b/backend/test/services/index/ElasticsearchResourcesITest.scala
@@ -588,7 +588,9 @@ class ElasticsearchResourcesITest extends AnyFreeSpec with Matchers with BeforeA
         sourceMimeType = "message/rfc822",
         parentBlobs = List.empty,
         workspace = None,
-        languages = List(English)
+        languages = List(English),
+        subjectDetectedLanguage = Some("en"),
+        bodyDetectedLanguage = Some("en"),
       ).await()
 
       TestSetup(users, reqUser = canSeeCatsUser) { controller =>

--- a/backend/test/services/manifest/Neo4JManifestITest.scala
+++ b/backend/test/services/manifest/Neo4JManifestITest.scala
@@ -9,6 +9,7 @@ import model.frontend.email.{EmailNeighbours, Neighbour, Email => FrontendEmail}
 import model.ingestion.{IngestionFile, WorkspaceItemContext}
 import model.manifest.{Blob, MimeType, WorkItem}
 import model.{Email, English, Recipient, Uri}
+import org.apache.tika.language.detect.LanguageDetector
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
@@ -516,7 +517,10 @@ class Neo4JManifestITest extends AnyFreeSpec
         val index = mock[Index]
         (index.ingestDocument _).expects(*, *, *, *).returning(Attempt.Right(()))
         val tika: Tika = Tika.createInstance
-        val ingestionServices: IngestionServices = IngestionServices(manifest, index, objectStorage, tika, mimeTypeMapper, new TestPostgresClient)(scala.concurrent.ExecutionContext.global)
+        val languageDetect = ThreadLocal.withInitial { () =>
+          LanguageDetector.getDefaultLanguageDetector.loadModels()
+        }
+        val ingestionServices: IngestionServices = IngestionServices(manifest, index, objectStorage, tika, mimeTypeMapper, new TestPostgresClient, languageDetect)(scala.concurrent.ExecutionContext.global)
 
         manifest.insertCollection(collectionUri.value, collectionUri.value, createdBy = "me").eitherValue.isRight should be(true)
         insertIngestion(collectionUri, Some(ingestionUri), fixed = false).eitherValue.isRight should be(true)

--- a/backend/test/test/integration/Helpers.scala
+++ b/backend/test/test/integration/Helpers.scala
@@ -10,6 +10,7 @@ import model.frontend.{Filter, SearchResults, TreeEntry, TreeNode}
 import model.manifest.{Blob, Collection, CollectionWithUsers}
 import model.user.UserPermissions
 import model.{CreateCollectionRequest, CreateIngestionRequest, English, Uri}
+import org.apache.tika.language.detect.LanguageDetector
 import org.neo4j.driver.Driver
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, Inside, OptionValues}
@@ -239,8 +240,10 @@ object Helpers extends Matchers with Logging with OptionValues with Inside {
     val annotations = Neo4jAnnotations.setupAnnotations(neo4jDriver, ec, queryLoggingConfig).toOption.get
 
     val typeDetector = new TestTypeDetector("application/pdf")
-
-    val ingestionServices = IngestionServices(manifest, elasticsearch.elasticResources, new TestObjectStorage(), typeDetector, new MimeTypeMapper(), new TestPostgresClient)
+    val languageDetector = ThreadLocal.withInitial { () =>
+      LanguageDetector.getDefaultLanguageDetector.loadModels()
+    }
+    val ingestionServices = IngestionServices(manifest, elasticsearch.elasticResources, new TestObjectStorage(), typeDetector, new MimeTypeMapper(), new TestPostgresClient, languageDetector)
 
     elasticsearch.resetIndices()
 

--- a/backend/test/utils/IndexTestHelpers.scala
+++ b/backend/test/utils/IndexTestHelpers.scala
@@ -61,7 +61,7 @@ class IndexTestHelpers(elasticsearchTestService: ElasticsearchTestService)(impli
 
     for {
       _ <- elasticsearchTestService.elasticResources.ingestDocument(documentUri, 0, ingestionData, languages)
-      _ <- elasticsearchTestService.elasticResources.addDocumentDetails(documentUri, Some(text), Map.empty, MetadataEnrichment.enrich(maybeExtractedMetadata, None), languages)
+      _ <- elasticsearchTestService.elasticResources.addDocumentDetails(documentUri, Some(text), Map.empty, MetadataEnrichment.enrich(maybeExtractedMetadata), languages, Some("en"))
       _ <- _addDocumentOcr(maybeOcrText.toList)
     } yield {
       documentUri

--- a/backend/test/utils/IndexTestHelpers.scala
+++ b/backend/test/utils/IndexTestHelpers.scala
@@ -49,7 +49,7 @@ class IndexTestHelpers(elasticsearchTestService: ElasticsearchTestService)(impli
       } else {
         val (lang, text) :: rest = entries
 
-        elasticsearchTestService.elasticResources.addDocumentOcr(documentUri, Some(text), lang).flatMap { _ =>
+        elasticsearchTestService.elasticResources.addDocumentOcr(documentUri, Some(text), lang, Some(lang.iso6391Code)).flatMap { _ =>
           if (rest.isEmpty) {
             Attempt.Right(())
           } else {
@@ -61,7 +61,7 @@ class IndexTestHelpers(elasticsearchTestService: ElasticsearchTestService)(impli
 
     for {
       _ <- elasticsearchTestService.elasticResources.ingestDocument(documentUri, 0, ingestionData, languages)
-      _ <- elasticsearchTestService.elasticResources.addDocumentDetails(documentUri, Some(text), Map.empty, MetadataEnrichment.enrich(maybeExtractedMetadata), languages)
+      _ <- elasticsearchTestService.elasticResources.addDocumentDetails(documentUri, Some(text), Map.empty, MetadataEnrichment.enrich(maybeExtractedMetadata, None), languages)
       _ <- _addDocumentOcr(maybeOcrText.toList)
     } yield {
       documentUri

--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,7 @@ lazy val backend = (project in file("backend"))
       // (Seems to be OK as of 2.7.0: https://tika.apache.org/2.7.0/parser_guide.html)
       "org.apache.tika" % "tika-parsers-standard-package" % "2.7.0",
       "org.apache.tika" % "tika-core" % "2.7.0",
+      "org.apache.tika" % "tika-langdetect-optimaize" % "2.7.0",
       "org.apache.commons" % "commons-compress" % "1.26.0",
       "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,
       "org.apache.logging.log4j" % "log4j-api" % log4jVersion,

--- a/common/src/main/scala/model/Language.scala
+++ b/common/src/main/scala/model/Language.scala
@@ -3,7 +3,7 @@ package model
 import play.api.libs.json._
 
 object Languages {
-  val all = List(Arabic, English, French, German, Russian, Portuguese, Persian, Spanish)
+  val all: List[Language] = List(Arabic, English, French, German, Russian, Portuguese, Persian, Spanish)
 
   def getByKey(key: String): Option[Language] = {
     all.find(l => l.key == key)


### PR DESCRIPTION
## What does this change?

In preparation for integrating giant with the new translation service https://github.com/guardian/transcription-service/pull/284 we need to know what language documents are in so we can decide whether or not they need translation.

Here I'm making use of [tikka's language detection functionality](https://tika.apache.org/2.3.0/detection.html#Language_Detection) to detect the language of a piece of text. I don't think this will be very reliable compared to other language detection methods, but it is quick and minimises additional dependencies. Giant really just needs to know whether or not a file is in english or not - any non-english files will be sent for translation.

Note that this PR doesn't have any user facing changes - it just adds some new fields to elasticsearch with the detected language information

## Language support in giant
Giant has long had awareness of languages. This is because tesseract needs to know the language of a PDF file in order to more accurately OCR it. Sam added language support to giant back here https://github.com/guardian/pfi/pull/327 with this aim in mind. 

The existing language support is at the `Ingestion` level - so you set one or more languages for a batch of files. This is quite wasteful - if you have an ingestion with 1 french file and 500 english files and you set the ingestion languages to 'french,english' then giant will run OCR for french and english on every file in the ingestion, essentially doubling the cost of OCR for the ingestion. There's no real way round this though unless you know the language of a document up front, as no metadata will tell you the language of the file, and we know that tesseract (via ocrmypdf) will perform poorly on cyrillic documents if you don't warn it what language you want to OCR in.

This PR introduces a document level language field to elasticsearch at `metadata.enrichedMetadata.detectedLanguageCode`, which is added by the DocumentBodyExtractor. This field will get set wherever tikka manages to detect the language of a document with a high degree of confidence. 

If `metadata.enrichedMetadata.detectedLanguageCode` is defined and set to a [supported language in giant](https://github.com/guardian/giant/blob/b007841285a525c5a13e61219c9caa5b0d0e66ed/common/src/main/scala/model/Language.scala#L42) at the point we come to OCR a document, then we pass that value to ocrmypdf/tesseract and ignore any top level languages set on the ingestion.

Note: there is no enforced ordering the DocumentBodyExtractor/OCRExtractor extractors. The DocumentBodyExtractor has a higher priority so where we only have 1 worker it will always happen first, but if we have e.g 2 workers and 1 document uploaded then OCR and DocumentBody extraction will happen at the same time so OCR will fall back to the Ingestion languages.

## OCR language detection
Given the above, we can assume that in some situations we will have multiple versions of the OCR text for a given document - one for each language specified on the ingestion. So when we do language detection we need to run it for the output of the ocr for each language, resulting in multiple different 'OCR detectedLanguageCode' values - one for each language.

To store this data in elasticsearch I've added a new ocrMetadata field within the metdata object with a `languages` property which is a map of language->OcrLanguageMetadata where OcrLanguageMetadata is an object with (currently) a single field - detectedLanguageCode. In future we could expect to add 'translationExtracted' or similar to this metadata field to track translations.

## Updating elasticsearch mapping
This PR requires changes to the elasticsearch mapping. This will be applied automatically to a new elasticsearch cluster but existing clusters will need to update the mapping like this:

```bash
curl -X PUT "localhost:9200/pfi/_mapping?pretty" -H 'Content-Type: application/json' -d'
{
  "properties": {
    "languageData": {
      "properties": {
        "text": {
          "properties": {
            "detectedLanguageCode": { "type": "text" },
            "translation": { "type": "text" }
          }
        },
        "emailBody": {
          "properties": {
            "detectedLanguageCode": { "type": "text" },
            "translation": { "type": "text" }
          }
        },
        "emailSubject": {
          "properties": {
            "detectedLanguageCode": { "type": "text" },
            "translation": { "type": "text" }
          }
        }
      }
    }
  }
}
```


## Language detection notes
In testing, I noticed that the DocumentBodyExtractor failed to detect the language for [this  PDF](https://github.com/user-attachments/files/27401231/Toast.sandwich.Wikipedia.pdf) (it guessed english but at not enough certainty) where it had succeded when that same document had been pasted in to a .txt file. The language detection of the OCR did work - possibly because it had all the urls dropped. With that in mind, I added a few AI generated regexs to drop various strings that are likely to be unhelpful when running language detection on a document


## How has this change been tested?
 - [x] Tested locally
 - [x] Tested on playground

## Things to think about
 - Does this change impact the external transcription service integration? If so, how has this been tested?
 - For UI changes: have you thought about accessibility? See https://github.com/guardian/accessibility/

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
