### PR TITLE
Scale giant workers according to available work

### DIFF
--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -236,8 +236,6 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
 
 object AWSWorkerControl {
 
-  val MINIMUM_TASKS_PER_WORKER = 2
-
   case class AsgState(
     desiredNumberOfWorkers: Int,
     lastEventTime: Long,
@@ -270,16 +268,15 @@ object AWSWorkerControl {
     val manuallyScaledDown = state.workerAsg.desiredNumberOfWorkers == 0
 
     val outstandingWork = state.outstandingFromIngestStore + state.outstandingFromTodos
-    val currentWorkers = state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers
-    val scaleThreshold = MINIMUM_TASKS_PER_WORKER * currentWorkers
+    val currentWorkerCount = state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers
 
     if(inCooldown || manuallyScaledDown) {
       None
       // we scale to the maximum size of the spot ASG (capacity might end up being met in the on demand ASG if no spot capacity is available)
-    } else if(outstandingWork > scaleThreshold * currentWorkers && state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers) {
+    } else if(outstandingWork > currentWorkerCount && state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers) {
       Some(AddNewWorker)
       // when scaling down automatically we check both asgs for excess capacity
-    } else if(outstandingWork <  scaleThreshold * currentWorkers && state.inProgress == 0 && state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers + state.spotWorkerAsg.minimumNumberOfWorkers) {
+    } else if(outstandingWork <  currentWorkerCount && state.inProgress == 0 && state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers + state.spotWorkerAsg.minimumNumberOfWorkers) {
       Some(RemoveWorker)
     } else {
       None

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -236,6 +236,8 @@ class AWSWorkerControl(config: WorkerConfig, discoveryConfig: AWSDiscoveryConfig
 
 object AWSWorkerControl {
 
+  val MINIMUM_TASKS_PER_WORKER = 2
+
   case class AsgState(
     desiredNumberOfWorkers: Int,
     lastEventTime: Long,
@@ -268,14 +270,16 @@ object AWSWorkerControl {
     val manuallyScaledDown = state.workerAsg.desiredNumberOfWorkers == 0
 
     val outstandingInTotal = state.outstandingFromIngestStore + state.outstandingFromTodos
+    val currentWorkers = state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers
+    val scaleThreshold = MINIMUM_TASKS_PER_WORKER * currentWorkers
 
     if(inCooldown || manuallyScaledDown) {
       None
-      // we scale to the maximum size of the spot ASG (capacity might end up being met in the on demand ASG if no spot capacity is availalbe)
-    } else if(outstandingInTotal > 0 && state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers) {
+      // we scale to the maximum size of the spot ASG (capacity might end up being met in the on demand ASG if no spot capacity is available)
+    } else if(outstandingInTotal > scaleThreshold * currentWorkers && state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers) {
       Some(AddNewWorker)
       // when scaling down automatically we check both asgs for excess capacity
-    } else if(outstandingInTotal == 0 && state.inProgress == 0 && state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers + state.spotWorkerAsg.minimumNumberOfWorkers) {
+    } else if(outstandingInTotal <  scaleThreshold * currentWorkers && state.inProgress == 0 && state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers + state.spotWorkerAsg.minimumNumberOfWorkers) {
       Some(RemoveWorker)
     } else {
       None

--- a/backend/app/utils/WorkerControl.scala
+++ b/backend/app/utils/WorkerControl.scala
@@ -269,17 +269,17 @@ object AWSWorkerControl {
     val inCooldown = state.workerAsg.lastEventTime > (now - cooldown) || state.spotWorkerAsg.lastEventTime > (now - cooldown)
     val manuallyScaledDown = state.workerAsg.desiredNumberOfWorkers == 0
 
-    val outstandingInTotal = state.outstandingFromIngestStore + state.outstandingFromTodos
+    val outstandingWork = state.outstandingFromIngestStore + state.outstandingFromTodos
     val currentWorkers = state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers
     val scaleThreshold = MINIMUM_TASKS_PER_WORKER * currentWorkers
 
     if(inCooldown || manuallyScaledDown) {
       None
       // we scale to the maximum size of the spot ASG (capacity might end up being met in the on demand ASG if no spot capacity is available)
-    } else if(outstandingInTotal > scaleThreshold * currentWorkers && state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers) {
+    } else if(outstandingWork > scaleThreshold * currentWorkers && state.spotWorkerAsg.desiredNumberOfWorkers < state.spotWorkerAsg.maximumNumberOfWorkers) {
       Some(AddNewWorker)
       // when scaling down automatically we check both asgs for excess capacity
-    } else if(outstandingInTotal <  scaleThreshold * currentWorkers && state.inProgress == 0 && state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers + state.spotWorkerAsg.minimumNumberOfWorkers) {
+    } else if(outstandingWork <  scaleThreshold * currentWorkers && state.inProgress == 0 && state.workerAsg.desiredNumberOfWorkers + state.spotWorkerAsg.desiredNumberOfWorkers > state.workerAsg.minimumNumberOfWorkers + state.spotWorkerAsg.minimumNumberOfWorkers) {
       Some(RemoveWorker)
     } else {
       None


### PR DESCRIPTION
## What does this change?
This PR makes an adjustment to how giant scales. I keep seeing situations where we have more workers than work remaining. This changes the scaling logic so that we allocate a minimum of 2 jobs to each worker, and if the remaining work is less than 2*numWorkers then we scale down, otherwise we scale up


## How has this change been tested?
 - [ ] Tested locally
 - [ ] Tested on playground
