### PR TITLE
Make file deletion failures (a bit) more consistent and (a tiny bit) more intelligible

### DIFF
--- a/backend/app/commands/DeleteResource.scala
+++ b/backend/app/commands/DeleteResource.scala
@@ -9,7 +9,7 @@ import services.manifest.Manifest
 import services.observability.PostgresClient
 import services.previewing.PreviewService
 import utils.{Logging, Timing}
-import utils.attempt.{Attempt, DeleteFailure, IllegalStateFailure}
+import utils.attempt.{Attempt, DeleteFailure, HasChildrenFailure}
 
 import scala.concurrent.ExecutionContext
 
@@ -54,16 +54,17 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
      }
 
      private def deleteResource(uri: Uri): Attempt[Unit] = timeAsync("Total to delete resource", {
-       val successAttempt = Attempt.Right(())
        for {
-         // clean up observability data
-         _ <- Attempt.fromEither(timeSync("Deleting blob observability events", postgresClient.deleteBlobIngestionEventsAndMetadata(uri.value)))
-         // For blobs not processed by the OcrMyPdfExtractor, ocrLanguages will be an empty list
-         ocrLanguages <- timeAsync("Getting langs from neo4j", manifest.getLanguagesProcessedByOcrMyPdf(uri))
-         // Not everything has a preview but S3 returns success for deleting an object that doesn't exist so we're fine
+         // Postgres cleanup, ingest storage delete, and OCR language query are independent — run concurrently
+         ocrLanguages <- {
+           val postgresDelete = Attempt.fromEither(timeSync("Deleting blob observability events", postgresClient.deleteBlobIngestionEventsAndMetadata(uri.value)))
+           val ingestStorageDelete = Attempt.fromEither(timeSync("Ingest storage S3 delete", objectStorage.delete(uri.toStoragePath)))
+           val ocrLanguagesQuery = timeAsync("Getting langs from neo4j", manifest.getLanguagesProcessedByOcrMyPdf(uri))
+           postgresDelete.zipWith(ingestStorageDelete)((_, _) => ()).zipWith(ocrLanguagesQuery)((_, langs) => langs)
+         }
+         // Preview deletion depends on ocrLanguages
          pagePreviewS3Keys <- timeAsync("Get page preview S3 keys", getPagePreviewS3Keys(uri, ocrLanguages))
          _ <- timeAsync("Preview storage S3 delete", deleteFromS3Preview(uri, pagePreviewS3Keys))
-         _ <- Attempt.fromEither(timeSync("Ingest storage S3 delete", objectStorage.delete(uri.toStoragePath)))
          _ <- timeAsync("Delete blob from neo4j", manifest.deleteBlob(uri))
          // We use the index to determine what blobs are in a collection.
          // So we should delete from the index last, so that if any of the above
@@ -72,7 +73,6 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
          // it would think the blob no longer exists even though there may
          // be traces in neo4j or S3).
          _ <- timeAsync("Delete blob from elasticsearch", index.delete(uri.value))
-         _ <- successAttempt
        } yield {
          ()
        }
@@ -82,10 +82,9 @@ class DeleteResource( manifest: Manifest, index: Index, previewStorage: ObjectSt
      def deleteBlobCheckChildren(id: String): Attempt[Unit] = {
        val uri = Uri(id)
 
-       // casting to an option here because Attempt[Resource] and Attempt[Unit] are incompatible - so can't use a for comprehension with toAttempt
        val deleteResult = manifest.getResource(uri).toOption map { resource =>
          if (resource.children.isEmpty) deleteResource(uri)
-         else Attempt.Left[Unit](IllegalStateFailure(s"Cannot delete $uri as it has child nodes"))
+         else Attempt.Left[Unit](HasChildrenFailure(s"Cannot delete as it has ${resource.children.size} child resource(s). Delete or move them first."))
        }
        deleteResult.getOrElse(Attempt.Left(DeleteFailure("Failed to fetch resource")))
      }

--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -436,14 +436,17 @@ class Workspaces(
   }
 
   def deleteBlob(workspaceId: String, blobUri: String) = ApiAction.attempt { req =>
-    annotation.getBlobOwners(blobUri).flatMap { owners =>
-      if (owners.size == 1 && owners.head == req.user.username) {
+    manifest.getCollectionsForBlob(blobUri).flatMap { collections =>
+      // Use the same authorization logic as Blobs.deleteForNonAdmin:
+      // allow if there's only 1 collection and the user can see it,
+      // or if the user created all collections containing this blob
+      if ((collections.size == 1 && collections.head._2.contains(req.user.username)) || collections.forall(c => c._1.createdBy == Some(req.user.username))) {
         logAction(req.user, workspaceId, s"Deleting resource from Giant if no children. Resource uri: $blobUri")
         val deleteResource = new DeleteResource(manifest, index, previewStorage, objectStorage, postgresClient)
         deleteResource.deleteBlobCheckChildren(blobUri)
       } else {
         logAction(req.user, workspaceId, s"Can't delete resource due to file ownership conflict. Resource uri: $blobUri")
-        Attempt.Left[Unit](DeleteNotAllowed("Failed to delete resource"))
+        Attempt.Left[Unit](DeleteNotAllowed("Cannot delete: file is owned by or visible to other users"))
       }
     } map (_ => NoContent)
   }

--- a/backend/app/utils/controller/FailureToResultMapper.scala
+++ b/backend/app/utils/controller/FailureToResultMapper.scala
@@ -111,6 +111,9 @@ object FailureToResultMapper extends Logging {
       case DeleteFailure(msg) =>
         logUserAndMessage(user, s"Delete failed: ${msg}")
         Results.InternalServerError(msg)
+      case HasChildrenFailure(msg) =>
+        logUserAndMessage(user, s"Delete blocked by child resources: $msg")
+        Results.Conflict(msg)
       case WorkspaceCopyFailure(msg) =>
         logUserAndMessage(user, s"Workspace copy failed: ${msg}")
         Results.InternalServerError(msg)

--- a/common/src/main/scala/utils/attempt/Failure.scala
+++ b/common/src/main/scala/utils/attempt/Failure.scala
@@ -128,6 +128,8 @@ case class ContentTooLongFailure(msg: String) extends Failure
 
 case class DeleteFailure(msg: String) extends Failure
 
+case class HasChildrenFailure(msg: String) extends Failure
+
 case class WorkspaceCopyFailure(msg: String) extends Failure
 
 case class DeleteNotAllowed(msg: String) extends Failure

--- a/frontend/src/js/actions/workspaces/deleteResourceFromWorkspace.ts
+++ b/frontend/src/js/actions/workspaces/deleteResourceFromWorkspace.ts
@@ -21,15 +21,15 @@ export function deleteResourceFromWorkspace(
       })
       .catch((error) => {
         onCompleteHandler(false);
-        dispatch(errorRenamingItem(error));
+        dispatch(errorDeletingResource(error));
       });
   };
 }
 
-function errorRenamingItem(error: Error): AppAction {
+function errorDeletingResource(error: Error): AppAction {
   return {
     type: AppActionType.APP_SHOW_ERROR,
-    message: `Failed to delete or remove`,
+    message: `Failed to delete file: ${error.message}`,
     error: error,
   };
 }

--- a/frontend/src/js/components/viewer/DeleteButtonModal.tsx
+++ b/frontend/src/js/components/viewer/DeleteButtonModal.tsx
@@ -18,6 +18,7 @@ export function DeleteButtonModal({
 }) {
   const [modalOpen, setModalOpen] = useState(false);
   const [deleteStatus, setDeleteStatus] = useState<DeleteStatus>("unconfirmed");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   if (!resource) {
     return null;
@@ -30,13 +31,15 @@ export function DeleteButtonModal({
     failed: "Failed to delete",
   };
 
+  const defaultFailedMessage =
+    "Failed to delete item. Please contact the administrator to delete this item.";
+
   const modalMessage: Record<DeleteStatus, string> = {
     unconfirmed:
       "Are you sure you want to delete this item? This action will permanently delete the item from giant.",
     deleting: "",
     deleted: "This item has been successfully deleted.",
-    failed:
-      "Failed to delete item. Please contact the administrator to delete this item.",
+    failed: errorMessage || defaultFailedMessage,
   };
 
   const hasChildResources = resource.children.length > 0;
@@ -47,10 +50,12 @@ export function DeleteButtonModal({
   const deleteItem = async () => {
     try {
       setDeleteStatus("deleting");
+      setErrorMessage(null);
       await deleteBlob(resource.uri);
       setDeleteStatus("deleted");
     } catch (e) {
       setDeleteStatus("failed");
+      setErrorMessage(e instanceof Error ? e.message : null);
       console.error("Error deleting item", e);
     }
   };

--- a/frontend/src/js/util/auth/authFetch.ts
+++ b/frontend/src/js/util/auth/authFetch.ts
@@ -27,11 +27,10 @@ export default function authFetch(
       );
       return response;
     })
-    .then((response) => {
-      // reject if the status wasn't OK
-      // TODO: SAH this should throw an object so that error messages from the server can be sensibly displayed
+    .then(async (response) => {
       if (!response.ok) {
-        throw Error(response.statusText);
+        const body = await response.text();
+        throw new Error(body || response.statusText);
       }
       return response;
     });


### PR DESCRIPTION
This doesn't really fix anything, but it does help distinguish between a few different kinds of failure. 

- Parallelise independent steps in `DeleteResource` (Postgres cleanup, ingest S3 delete, and OCR language query run concurrently) - the only really substantive change here. Elasticsearch still comes last.  It might make things a tiny bit faster. 
- Unify authorization logic in `Workspaces.deleteBlob` to use the same `getCollectionsForBlob` check as `Blobs.deleteForNonAdmin,` eliminating inconsistent behaviour between the two delete entry points. This is a tidy-up and I hope isn't controversial. 
- Surface backend error messages to the user by reading the response body in `authFetch` instead of discarding it. See long-standing TODO at [frontend/src/js/util/auth/authFetch.ts](https://github.com/guardian/giant/blob/6751bda34e3958aa57672562a1b96fb48f6aa335/frontend/src/js/util/auth/authFetch.ts#L32). 
- Display actual failure reason in `DeleteButtonModal insteas` of generic message. This isn't particularly informative but it's better than nowt. It does not expose anything significant security-wise. 
- Rename misnamed `errorRenamingItem` to `errorDeletingResource` and include the error message in the displayed text.
- Add `HasChildrenFailure` type mapped to 409 (conflict error), replacing the generic 500 `IllegalStateFailure` when deletion is blocked by children. Just feels a bit more appropriate and provides something more actionable to the user. 

## How has this change been tested?
 - [x] Tested locally
 - [ ] Tested on playground

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
