### PR TITLE
Filter out useless system files before GUI upload

### DIFF
--- a/frontend/src/js/components/Uploads/FilePicker.tsx
+++ b/frontend/src/js/components/Uploads/FilePicker.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Button } from "semantic-ui-react";
 import { readFilesFromDragEvent } from "./dropZoneUtils";
+import { filterSystemFiles } from "./filterSystemFiles";
 
 type Props = {
   disabled: boolean;
@@ -77,7 +78,7 @@ export default class FilePicker extends React.Component<Props, State> {
         files.set(newPath, newFile);
       }
 
-      this.props.onAddFiles(files);
+      this.props.onAddFiles(filterSystemFiles(files));
 
       if (this.input.current) {
         // Avoids a bug where you add a folder, remove it and then try to add it again
@@ -99,7 +100,7 @@ export default class FilePicker extends React.Component<Props, State> {
     this.setState({ readingFiles: true });
     readFilesFromDragEvent(e)
       .then((files) => {
-        this.props.onAddFiles(files);
+        this.props.onAddFiles(filterSystemFiles(files));
       })
       .catch((error) => {
         console.error("Failed to read dropped files:", error);

--- a/frontend/src/js/components/Uploads/filterSystemFiles.spec.ts
+++ b/frontend/src/js/components/Uploads/filterSystemFiles.spec.ts
@@ -19,15 +19,17 @@ describe("filterSystemFiles", () => {
     expect([...result.keys()]).toEqual(["report.pdf", "photos/holiday.jpg"]);
   });
 
-  it("removes .DS_Store files", () => {
+  it("removes known junk basenames regardless of case", () => {
     const files = toMap([
       ["folder/.DS_Store", makeFile(".DS_Store")],
-      [".DS_Store", makeFile(".DS_Store")],
-      ["readme.md", makeFile("readme.md")],
+      [".ds_store", makeFile(".ds_store")],
+      ["folder/Thumbs.db", makeFile("Thumbs.db")],
+      ["DESKTOP.INI", makeFile("DESKTOP.INI")],
+      ["keep.txt", makeFile("keep.txt")],
     ]);
 
     const result = filterSystemFiles(files);
-    expect([...result.keys()]).toEqual(["readme.md"]);
+    expect([...result.keys()]).toEqual(["keep.txt"]);
   });
 
   it("removes AppleDouble resource fork files (._prefix)", () => {
@@ -41,50 +43,17 @@ describe("filterSystemFiles", () => {
     expect([...result.keys()]).toEqual(["folder/image.png"]);
   });
 
-  it("removes __MACOSX directory entries", () => {
+  it("removes files under junk directory segments", () => {
     const files = toMap([
       ["__MACOSX/folder/._file.txt", makeFile("._file.txt")],
-      ["__MACOSX/.DS_Store", makeFile(".DS_Store")],
+      [".Spotlight-V100/store.db", makeFile("store.db")],
+      [".Trashes/501/file.txt", makeFile("file.txt")],
+      [".fseventsd/0000001", makeFile("0000001")],
       ["docs/notes.txt", makeFile("notes.txt")],
     ]);
 
     const result = filterSystemFiles(files);
     expect([...result.keys()]).toEqual(["docs/notes.txt"]);
-  });
-
-  it("removes Windows system files", () => {
-    const files = toMap([
-      ["folder/Thumbs.db", makeFile("Thumbs.db")],
-      ["desktop.ini", makeFile("desktop.ini")],
-      ["data.csv", makeFile("data.csv")],
-    ]);
-
-    const result = filterSystemFiles(files);
-    expect([...result.keys()]).toEqual(["data.csv"]);
-  });
-
-  it("removes macOS system directories", () => {
-    const files = toMap([
-      [".Spotlight-V100/store.db", makeFile("store.db")],
-      [".Trashes/501/file.txt", makeFile("file.txt")],
-      [".fseventsd/0000001", makeFile("0000001")],
-      ["real-file.txt", makeFile("real-file.txt")],
-    ]);
-
-    const result = filterSystemFiles(files);
-    expect([...result.keys()]).toEqual(["real-file.txt"]);
-  });
-
-  it("is case-insensitive", () => {
-    const files = toMap([
-      [".ds_store", makeFile(".ds_store")],
-      ["THUMBS.DB", makeFile("THUMBS.DB")],
-      ["__MACOSX/file", makeFile("file")],
-      ["keep.txt", makeFile("keep.txt")],
-    ]);
-
-    const result = filterSystemFiles(files);
-    expect([...result.keys()]).toEqual(["keep.txt"]);
   });
 
   it("returns empty map when all files are junk", () => {

--- a/frontend/src/js/components/Uploads/filterSystemFiles.test.ts
+++ b/frontend/src/js/components/Uploads/filterSystemFiles.test.ts
@@ -1,0 +1,104 @@
+import { filterSystemFiles } from "./filterSystemFiles";
+
+function makeFile(name: string): File {
+  return new File([""], name);
+}
+
+function toMap(entries: [string, File][]): Map<string, File> {
+  return new Map(entries);
+}
+
+describe("filterSystemFiles", () => {
+  it("passes through normal files unchanged", () => {
+    const files = toMap([
+      ["report.pdf", makeFile("report.pdf")],
+      ["photos/holiday.jpg", makeFile("holiday.jpg")],
+    ]);
+
+    const result = filterSystemFiles(files);
+    expect([...result.keys()]).toEqual(["report.pdf", "photos/holiday.jpg"]);
+  });
+
+  it("removes .DS_Store files", () => {
+    const files = toMap([
+      ["folder/.DS_Store", makeFile(".DS_Store")],
+      [".DS_Store", makeFile(".DS_Store")],
+      ["readme.md", makeFile("readme.md")],
+    ]);
+
+    const result = filterSystemFiles(files);
+    expect([...result.keys()]).toEqual(["readme.md"]);
+  });
+
+  it("removes AppleDouble resource fork files (._prefix)", () => {
+    const files = toMap([
+      ["folder/._image.png", makeFile("._image.png")],
+      ["._document.pdf", makeFile("._document.pdf")],
+      ["folder/image.png", makeFile("image.png")],
+    ]);
+
+    const result = filterSystemFiles(files);
+    expect([...result.keys()]).toEqual(["folder/image.png"]);
+  });
+
+  it("removes __MACOSX directory entries", () => {
+    const files = toMap([
+      ["__MACOSX/folder/._file.txt", makeFile("._file.txt")],
+      ["__MACOSX/.DS_Store", makeFile(".DS_Store")],
+      ["docs/notes.txt", makeFile("notes.txt")],
+    ]);
+
+    const result = filterSystemFiles(files);
+    expect([...result.keys()]).toEqual(["docs/notes.txt"]);
+  });
+
+  it("removes Windows system files", () => {
+    const files = toMap([
+      ["folder/Thumbs.db", makeFile("Thumbs.db")],
+      ["desktop.ini", makeFile("desktop.ini")],
+      ["data.csv", makeFile("data.csv")],
+    ]);
+
+    const result = filterSystemFiles(files);
+    expect([...result.keys()]).toEqual(["data.csv"]);
+  });
+
+  it("removes macOS system directories", () => {
+    const files = toMap([
+      [".Spotlight-V100/store.db", makeFile("store.db")],
+      [".Trashes/501/file.txt", makeFile("file.txt")],
+      [".fseventsd/0000001", makeFile("0000001")],
+      ["real-file.txt", makeFile("real-file.txt")],
+    ]);
+
+    const result = filterSystemFiles(files);
+    expect([...result.keys()]).toEqual(["real-file.txt"]);
+  });
+
+  it("is case-insensitive", () => {
+    const files = toMap([
+      [".ds_store", makeFile(".ds_store")],
+      ["THUMBS.DB", makeFile("THUMBS.DB")],
+      ["__MACOSX/file", makeFile("file")],
+      ["keep.txt", makeFile("keep.txt")],
+    ]);
+
+    const result = filterSystemFiles(files);
+    expect([...result.keys()]).toEqual(["keep.txt"]);
+  });
+
+  it("returns empty map when all files are junk", () => {
+    const files = toMap([
+      [".DS_Store", makeFile(".DS_Store")],
+      ["._secret", makeFile("._secret")],
+    ]);
+
+    const result = filterSystemFiles(files);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty map for empty input", () => {
+    const result = filterSystemFiles(new Map());
+    expect(result.size).toBe(0);
+  });
+});

--- a/frontend/src/js/components/Uploads/filterSystemFiles.ts
+++ b/frontend/src/js/components/Uploads/filterSystemFiles.ts
@@ -1,0 +1,62 @@
+// Filenames and path segments commonly produced by macOS and Windows
+// that have no value as uploaded content.
+const JUNK_BASENAMES = new Set([
+  ".ds_store",
+  "thumbs.db",
+  "desktop.ini",
+  ".apdisk",
+]);
+
+const JUNK_PATH_SEGMENTS = ["__macosx"];
+
+// Directory names that are macOS system artifacts — if any segment
+// of the path matches one of these, the file is junk.
+const JUNK_DIRECTORY_NAMES = new Set([
+  ".spotlight-v100",
+  ".trashes",
+  ".fseventsd",
+  ".temporaryitems",
+]);
+
+function basename(path: string): string {
+  const lastSlash = path.lastIndexOf("/");
+  return lastSlash === -1 ? path : path.substring(lastSlash + 1);
+}
+
+function isSystemFile(path: string): boolean {
+  const name = basename(path).toLowerCase();
+
+  if (JUNK_BASENAMES.has(name)) {
+    return true;
+  }
+
+  // AppleDouble resource fork files (._<filename>)
+  if (name.startsWith("._")) {
+    return true;
+  }
+
+  // Paths containing macOS zip artifact directories or system directories
+  const lowerPath = path.toLowerCase();
+  const segments = lowerPath.split("/");
+
+  for (const segment of segments) {
+    if (
+      JUNK_PATH_SEGMENTS.includes(segment) ||
+      JUNK_DIRECTORY_NAMES.has(segment)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function filterSystemFiles(files: Map<string, File>): Map<string, File> {
+  const filtered = new Map<string, File>();
+  for (const [path, file] of files) {
+    if (!isSystemFile(path)) {
+      filtered.set(path, file);
+    }
+  }
+  return filtered;
+}

--- a/frontend/src/js/components/Uploads/filterSystemFiles.ts
+++ b/frontend/src/js/components/Uploads/filterSystemFiles.ts
@@ -18,8 +18,7 @@ const JUNK_SEGMENTS = new Set([
 ]);
 
 function basename(path: string): string {
-  const lastSlash = path.lastIndexOf("/");
-  return lastSlash === -1 ? path : path.substring(lastSlash + 1);
+  return path.split("/").reverse()[0];
 }
 
 function isSystemFile(path: string): boolean {

--- a/frontend/src/js/components/Uploads/filterSystemFiles.ts
+++ b/frontend/src/js/components/Uploads/filterSystemFiles.ts
@@ -1,5 +1,5 @@
-// Filenames and path segments commonly produced by macOS and Windows
-// that have no value as uploaded content.
+// Filenames commonly produced by macOS and Windows that have no value
+// as uploaded content.
 const JUNK_BASENAMES = new Set([
   ".ds_store",
   "thumbs.db",
@@ -7,11 +7,10 @@ const JUNK_BASENAMES = new Set([
   ".apdisk",
 ]);
 
-const JUNK_PATH_SEGMENTS = ["__macosx"];
-
-// Directory names that are macOS system artifacts — if any segment
-// of the path matches one of these, the file is junk.
-const JUNK_DIRECTORY_NAMES = new Set([
+// Directory names that are OS system artifacts — if any path segment
+// matches one of these, the file is junk.
+const JUNK_SEGMENTS = new Set([
+  "__macosx",
   ".spotlight-v100",
   ".trashes",
   ".fseventsd",
@@ -24,7 +23,8 @@ function basename(path: string): string {
 }
 
 function isSystemFile(path: string): boolean {
-  const name = basename(path).toLowerCase();
+  const lowerPath = path.toLowerCase();
+  const name = basename(lowerPath);
 
   if (JUNK_BASENAMES.has(name)) {
     return true;
@@ -35,28 +35,9 @@ function isSystemFile(path: string): boolean {
     return true;
   }
 
-  // Paths containing macOS zip artifact directories or system directories
-  const lowerPath = path.toLowerCase();
-  const segments = lowerPath.split("/");
-
-  for (const segment of segments) {
-    if (
-      JUNK_PATH_SEGMENTS.includes(segment) ||
-      JUNK_DIRECTORY_NAMES.has(segment)
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+  return lowerPath.split("/").some((segment) => JUNK_SEGMENTS.has(segment));
 }
 
 export function filterSystemFiles(files: Map<string, File>): Map<string, File> {
-  const filtered = new Map<string, File>();
-  for (const [path, file] of files) {
-    if (!isSystemFile(path)) {
-      filtered.set(path, file);
-    }
-  }
-  return filtered;
+  return new Map([...files].filter(([path]) => !isSystemFile(path)));
 }

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/index.tsx
@@ -22,6 +22,7 @@ import {
   INTERNAL_DRAG_MIME_TYPE,
   readFilesFromDragEvent,
 } from "../../Uploads/dropZoneUtils";
+import { filterSystemFiles } from "../../Uploads/filterSystemFiles";
 
 type Props<T> = {
   onSelectLeaf: (leaf: TreeLeaf<T>) => void;
@@ -192,8 +193,9 @@ export default class TreeBrowser<T> extends React.Component<Props<T>, State> {
 
       readFilesFromDragEvent(e)
         .then((files) => {
-          if (files.size > 0 && this.props.onDropFiles) {
-            this.props.onDropFiles(files, idOfLocationToMoveTo);
+          const filtered = filterSystemFiles(files);
+          if (filtered.size > 0 && this.props.onDropFiles) {
+            this.props.onDropFiles(filtered, idOfLocationToMoveTo);
           }
         })
         .catch((error) => {


### PR DESCRIPTION
Should address #380 

Problem: when users select directories from macOS or Windows machines, these system artifacts can number in the thousands and have no value as uploaded workspace content. Filtering them pre-upload avoids wasted bandwidth and keeps the upload list clean.

## What this PR does

During upload to workspace, we tell the client to filter out OS junk files (e.g. `.DS_Store`, `Thumbs.db`, AppleDouble `._` resource forks, `__MACOSX/` directories, `.Spotlight-V100`, `.Trashes`, etc.) via the `FilePicker` component. This happens before the the upload inventory reaches the upload dialog.

## How

A new `filterSystemFiles` utility applies to the file map in both the file-input `onChange` and drag-and-drop `onDrop` handlers. The logic checks:

1. Known junk basenames (`.ds_store`, `thumbs.db`, `desktop.ini`, `.apdisk`)
2. AppleDouble resource fork prefix (`._`)
3. Junk path segments (`__macosx`, `.spotlight-v100`, `.trashes`, `.fseventsd`, `.temporaryitems`)

All matching is case-insensitive.

## Why not the CLI also?

This is deliberately **not** applied in the CLI. The CLI can be used for forensic ingestion of evidence drives, disk images, and encrypted volumes where completeness matters. Files like `.DS_Store` contain directory listing metadata (file sizes, icon positions, timestamps) and `Thumbs.db` contains image thumbnail caches. These may be useful for forensic analysis. 

The GUI upload flow serves a different audience: end-users adding files from their laptops to a workspace. Nobody wants their `.DS_Store` files there.

## Tests

- [x] Local
- [x] Playground