### PR TITLE
Giant search: switch search.js and searchBox.js to typescript (no class-function conversion)

### DIFF
--- a/frontend/src/js/actions/urlParams/updateSearchQuery.ts
+++ b/frontend/src/js/actions/urlParams/updateSearchQuery.ts
@@ -17,14 +17,14 @@ export function updateSearchText(text: string): UrlParamsAction {
   };
 }
 
-export function updatePage(page: number): UrlParamsAction {
+export function updatePage(page: string): UrlParamsAction {
   return {
     type: UrlParamsActionType.SEARCHQUERY_PAGE_UPDATE,
     page: page,
   };
 }
 
-export function updatePageSize(pageSize: number): UrlParamsAction {
+export function updatePageSize(pageSize: string): UrlParamsAction {
   return {
     type: UrlParamsActionType.SEARCHQUERY_PAGE_SIZE_UPDATE,
     pageSize: pageSize,

--- a/frontend/src/js/components/Search/Search.tsx
+++ b/frontend/src/js/components/Search/Search.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 import _isEqual from "lodash/fp/isEqual";
 import SearchBox from "./SearchBox";
@@ -11,69 +10,81 @@ import { Checkbox } from "../UtilComponents/Checkbox";
 import { KeyboardShortcut } from "../UtilComponents/KeyboardShortcut";
 import Select from "react-select";
 
-import { searchResultsPropType } from "../../types/SearchResults";
 import _get from "lodash/get";
 import _debounce from "lodash/debounce";
 
-import { suggestedFieldsPropType } from "../../types/SuggestedFields";
 import { keyboardShortcuts } from "../../util/keyboardShortcuts";
 import SearchVisualizations from "./SearchVisualizations";
 import { calculateSearchTitle } from "../UtilComponents/documentTitle";
 
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
+import { AnyAction } from "redux";
+import { ThunkDispatch } from "redux-thunk";
 
-import { updateSearchText } from "../../actions/urlParams/updateSearchQuery";
+import { GiantState } from "../../types/redux/GiantState";
+import {
+  updateSearchText,
+  updateSearchQueryFilters,
+  updatePage,
+  updatePageSize,
+  updateSortBy,
+} from "../../actions/urlParams/updateSearchQuery";
 import { performSearch } from "../../actions/search/performSearch";
 import { clearSearch } from "../../actions/search/clearSearch";
-import { updateSearchQueryFilters } from "../../actions/urlParams/updateSearchQuery";
-import { updatePage } from "../../actions/urlParams/updateSearchQuery";
-import { updatePageSize } from "../../actions/urlParams/updateSearchQuery";
-import { updateSortBy } from "../../actions/urlParams/updateSearchQuery";
 import { getSuggestedFields } from "../../actions/search/getSuggestedFields";
 import { resetResource } from "../../actions/resources/getResource";
 import { updatePreference } from "../../actions/preferences";
 
-class Search extends React.Component {
-  static propTypes = {
-    urlParams: PropTypes.shape({
-      q: PropTypes.string,
-      page: PropTypes.any,
-      pageSize: PropTypes.any,
-      sortBy: PropTypes.string,
-      filters: PropTypes.any,
-    }),
-    lastUri: PropTypes.string,
-    updateSearchText: PropTypes.func.isRequired,
-    updatePage: PropTypes.func.isRequired,
-    updatePageSize: PropTypes.func.isRequired,
-    updateSortBy: PropTypes.func.isRequired,
-    performSearch: PropTypes.func.isRequired,
-    clearSearch: PropTypes.func.isRequired,
-    updateSearchQueryFilters: PropTypes.func.isRequired,
-    resetResource: PropTypes.func.isRequired,
-    getSuggestedFields: PropTypes.func.isRequired,
-    updatePreference: PropTypes.func.isRequired,
-    preferences: PropTypes.object,
-    search: PropTypes.shape({
-      isSearchInProgress: PropTypes.bool.isRequired,
-      currentQuery: PropTypes.object,
-      currentResults: searchResultsPropType,
-      suggestedFields: PropTypes.arrayOf(suggestedFieldsPropType),
-      searchFailed: PropTypes.bool,
-    }).isRequired,
-  };
+interface StateProps {
+  urlParams: GiantState["urlParams"];
+  search: GiantState["search"];
+  lastUri: string | undefined;
+  preferences: GiantState["app"]["preferences"];
+}
 
-  state = {
+interface DispatchProps {
+  getSuggestedFields: () => void;
+  updateSearchText: (text: string) => void;
+  updatePage: (page: string) => void;
+  updatePageSize: (pageSize: string) => void;
+  updateSortBy: (sortBy: string) => void;
+  performSearch: (query: GiantState["urlParams"]) => void;
+  clearSearch: () => void;
+  updateSearchQueryFilters: (filters: object) => void;
+  resetResource: () => void;
+  updatePreference: (key: string, value: unknown) => void;
+}
+
+type SearchProps = StateProps & DispatchProps;
+
+interface SearchState {
+  visibleText: string;
+}
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SearchBoxHandle {
+  focus(): void;
+  select(): void;
+}
+
+class Search extends React.Component<SearchProps, SearchState> {
+  searchBox: SearchBoxHandle | null = null;
+
+  state: SearchState = {
     visibleText: "",
   };
 
-  selectSearchBox = (e) => {
+  selectSearchBox = (e: KeyboardEvent) => {
     e.preventDefault();
-    this.searchBox.focus();
+    this.searchBox?.focus();
   };
 
-  clearSearch = (e) => {
+  clearSearch = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
 
     this.updateVisibleText("");
@@ -82,10 +93,10 @@ class Search extends React.Component {
     this.props.updateSearchQueryFilters({});
     this.props.updatePage("1");
     this.setState({ visibleText: "" });
-    this.searchBox.select();
+    this.searchBox?.select();
   };
 
-  debouncedUpdate = _debounce((text) => {
+  debouncedUpdate = _debounce((text: string) => {
     if (text !== this.props.urlParams.q) {
       this.props.updatePage("1");
     }
@@ -94,13 +105,13 @@ class Search extends React.Component {
     this.triggerSearch(this.props.urlParams);
   }, 500);
 
-  updateVisibleText = (text) => {
+  updateVisibleText = (text: string) => {
     this.setState({
       visibleText: text,
     });
   };
 
-  triggerSearch(query) {
+  triggerSearch(query: GiantState["urlParams"]) {
     if (query.q) {
       this.props.resetResource();
       this.props.performSearch(query);
@@ -131,7 +142,7 @@ class Search extends React.Component {
     document.title = calculateSearchTitle(this.props.search.currentQuery);
   }
 
-  UNSAFE_componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props: SearchProps) {
     const before = {
       filters: props.urlParams.filters,
       page: props.urlParams.page,
@@ -159,7 +170,7 @@ class Search extends React.Component {
     document.title = "Giant";
   }
 
-  pageSelectCallback = (page) => {
+  pageSelectCallback = (page: number) => {
     this.props.updatePage(page.toString());
   };
 
@@ -179,9 +190,33 @@ class Search extends React.Component {
 
   renderControls() {
     // TODO replace with user preferences for page size
-    const pageSize = this.props.urlParams.pageSize || "100";
+    const pageSizeValue = this.props.urlParams.pageSize ?? "100";
     // TODO replace with user preferences for sort order
-    const sortBy = this.props.urlParams.sortBy || "relevance";
+    const sortByValue = this.props.urlParams.sortBy || "relevance";
+
+    const sortByOptions: SelectOption[] = [
+      { value: "relevance", label: "Sort by relevance" },
+      { value: "size-asc", label: "Sort by size (smallest first)" },
+      { value: "size-desc", label: "Sort by size (largest first)" },
+      {
+        value: "date-created-asc",
+        label: "Sort by date created (oldest first)",
+      },
+      {
+        value: "date-created-desc",
+        label: "Sort by date created (newest first)",
+      },
+    ];
+    const pageSizeOptions: SelectOption[] = [
+      { value: "25", label: "25 results per page" },
+      { value: "50", label: "50 results per page" },
+      { value: "100", label: "100 results per page" },
+    ];
+
+    const currentSortBy = sortByOptions.find((o) => o.value === sortByValue);
+    const currentPageSize = pageSizeOptions.find(
+      (o) => o.value === pageSizeValue,
+    );
 
     return (
       <div className="search__controls">
@@ -199,37 +234,25 @@ class Search extends React.Component {
         </Checkbox>
         <Select
           className="search__control"
-          value={sortBy}
-          options={[
-            { value: "relevance", label: "Sort by relevance" },
-            { value: "size-asc", label: "Sort by size (smallest first)" },
-            { value: "size-desc", label: "Sort by size (largest first)" },
-            {
-              value: "date-created-asc",
-              label: "Sort by date created (oldest first)",
-            },
-            {
-              value: "date-created-desc",
-              label: "Sort by date created (newest first)",
-            },
-          ]}
+          value={currentSortBy}
+          options={sortByOptions}
           onChange={(v) => {
+            const option = v as SelectOption | null;
+            if (!option) return;
             this.props.updatePage("1");
-            this.props.updateSortBy(v.value);
+            this.props.updateSortBy(option.value);
           }}
           clearable={false}
         />
         <Select
           className="search__control"
-          value={pageSize}
-          options={[
-            { value: "25", label: "25 results per page" },
-            { value: "50", label: "50 results per page" },
-            { value: "100", label: "100 results per page" },
-          ]}
+          value={currentPageSize}
+          options={pageSizeOptions}
           onChange={(v) => {
+            const option = v as SelectOption | null;
+            if (!option) return;
             this.props.updatePage("1");
-            this.props.updatePageSize(v.value);
+            this.props.updatePageSize(option.value);
           }}
           clearable={false}
         />
@@ -267,10 +290,9 @@ class Search extends React.Component {
           func={this.selectSearchBox}
         />
         <SearchBox
-          ref={(input) => (this.searchBox = input)}
+          ref={(input: SearchBoxHandle | null) => (this.searchBox = input)}
           updateVisibleText={this.updateVisibleText}
           resetQuery={this.clearSearch}
-          addQuery={this.addQuery}
           q={this.state.visibleText}
           isSearchInProgress={this.props.search.isSearchInProgress}
           suggestedFields={this.props.search.suggestedFields}
@@ -308,7 +330,7 @@ class Search extends React.Component {
   }
 }
 
-function mapStateToProps(state) {
+function mapStateToProps(state: GiantState): StateProps {
   return {
     urlParams: state.urlParams,
     search: state.search,
@@ -317,7 +339,9 @@ function mapStateToProps(state) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(
+  dispatch: ThunkDispatch<GiantState, undefined, AnyAction>,
+): DispatchProps {
   return {
     getSuggestedFields: bindActionCreators(getSuggestedFields, dispatch),
     updateSearchText: bindActionCreators(updateSearchText, dispatch),
@@ -335,4 +359,12 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Search);
+export default connect<
+  StateProps,
+  DispatchProps,
+  Record<string, never>,
+  GiantState
+>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Search);

--- a/frontend/src/js/components/Search/Search.tsx
+++ b/frontend/src/js/components/Search/Search.tsx
@@ -102,7 +102,9 @@ class Search extends React.Component<SearchProps, SearchState> {
     }
     this.props.updateSearchText(text);
 
-    this.triggerSearch(this.props.urlParams);
+    // Use the freshly-typed text rather than this.props.urlParams.q, which
+    // is the pre-dispatch value and would lag by one Enter press.
+    this.triggerSearch({ ...this.props.urlParams, q: text });
   }, 500);
 
   updateVisibleText = (text: string) => {

--- a/frontend/src/js/components/Search/SearchBox.tsx
+++ b/frontend/src/js/components/Search/SearchBox.tsx
@@ -1,35 +1,32 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 import { ProgressAnimation } from "../UtilComponents/ProgressAnimation";
-import { suggestedFieldsPropType } from "../../types/SuggestedFields";
-
 import InputSupper from "../UtilComponents/InputSupper";
+import { SuggestedField } from "../../types/SuggestedFields";
 
-export default class SearchBox extends React.Component {
-  static propTypes = {
-    q: PropTypes.string.isRequired,
-    isSearchInProgress: PropTypes.bool.isRequired,
-    updateVisibleText: PropTypes.func.isRequired,
-    resetQuery: PropTypes.func.isRequired,
-    suggestedFields: PropTypes.arrayOf(suggestedFieldsPropType),
-    updateSearchText: PropTypes.func.isRequired,
-  };
+interface InputSupperHandle {
+  focus(): void;
+  select(): void;
+}
+
+export interface SearchBoxProps {
+  q: string;
+  isSearchInProgress: boolean;
+  updateVisibleText: (text: string) => void;
+  resetQuery: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  suggestedFields?: SuggestedField[];
+  updateSearchText: () => void;
+}
+
+export default class SearchBox extends React.Component<SearchBoxProps> {
+  searchInput: InputSupperHandle | null = null;
 
   focus = () => {
-    if (this.searchInput !== document.activeElement) {
-      this.searchInput.focus();
-      // If you previously did select and didn't type anything the input box 'remembers' it was selected
-      // so we need this hack to reset that...
-      const value = this.searchInput.value;
-      this.searchInput.value = value;
-    }
+    this.searchInput?.focus();
   };
 
   select = () => {
-    if (this.searchInput !== document.activeElement) {
-      this.searchInput.select();
-    }
+    this.searchInput?.select();
   };
 
   render() {
@@ -42,7 +39,7 @@ export default class SearchBox extends React.Component {
       <div>
         <div className="search-box">
           <InputSupper
-            ref={(s) => (this.searchInput = s)}
+            ref={(s: InputSupperHandle | null) => (this.searchInput = s)}
             className="search-box__input"
             value={this.props.q}
             chips={this.props.suggestedFields}

--- a/frontend/src/js/types/SearchResults.ts
+++ b/frontend/src/js/types/SearchResults.ts
@@ -73,6 +73,7 @@ export type SearchResults = {
   hits: number;
   took: number;
   page: number;
+  pageSize: number;
   pages: number;
   results: SearchResult[];
 };
@@ -82,6 +83,7 @@ export const searchResultsPropType = PropTypes.shape({
   hits: PropTypes.number.isRequired,
   took: PropTypes.number.isRequired,
   page: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired,
   pages: PropTypes.number.isRequired,
   results: PropTypes.arrayOf(searchResultPropType).isRequired,
 });

--- a/frontend/src/js/types/SuggestedFields.ts
+++ b/frontend/src/js/types/SuggestedFields.ts
@@ -1,5 +1,10 @@
 import PropTypes from "prop-types";
 
+export interface SuggestedField {
+  name: string;
+  type: string;
+}
+
 export const suggestedFieldsPropType = PropTypes.shape({
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,

--- a/frontend/src/js/types/redux/GiantActions.ts
+++ b/frontend/src/js/types/redux/GiantActions.ts
@@ -127,11 +127,11 @@ interface SearchQueryTextUpdateType {
 }
 interface SearchQueryPageUpdateType {
   type: UrlParamsActionType.SEARCHQUERY_PAGE_UPDATE;
-  page: any;
+  page: string;
 }
 interface SearchQueryPageSizeUpdateType {
   type: UrlParamsActionType.SEARCHQUERY_PAGE_SIZE_UPDATE;
-  pageSize: any;
+  pageSize: string;
 }
 interface SearchQuerySortByUpdateType {
   type: UrlParamsActionType.SEARCHQUERY_SORT_BY_UPDATE;

--- a/frontend/src/js/types/redux/GiantState.ts
+++ b/frontend/src/js/types/redux/GiantState.ts
@@ -7,6 +7,7 @@ import { Auth } from "../Auth";
 import { Config } from "../Config";
 import { Resource, BasicResource } from "../Resource";
 import { SearchResults } from "../SearchResults";
+import { SuggestedField } from "../SuggestedFields";
 import { PagedDocument } from "../../reducers/pagesReducer";
 
 export interface WorkspacesState {
@@ -54,10 +55,11 @@ export type ExpandedFiltersState = { [key: string]: boolean };
 export type DescendantResources = { [key: string]: BasicResource };
 
 export type SearchState = {
-  // TODO: type the rest of search state
   currentResults?: SearchResults;
   currentQuery?: { q: string };
   isSearchInProgress: boolean;
+  suggestedFields: SuggestedField[];
+  searchFailed?: boolean;
 };
 
 export type LoadingState = boolean;

--- a/frontend/src/js/types/redux/GiantState.ts
+++ b/frontend/src/js/types/redux/GiantState.ts
@@ -42,7 +42,7 @@ export interface UrlParamsState {
   view?: string;
   details?: object;
   page?: string;
-  pageSize?: number;
+  pageSize?: string;
   sortBy?: string;
   highlight?: string;
   currentWorkspace?: string;


### PR DESCRIPTION
**Pure types-only migration of the search page (`Search.js` / `SearchBox.js`) from JavaScript class components to TypeScript  class components, plus a handful of small upstream type fixes  that the migration surfaced.**

**Redone after review feedback**: removes the conversion from  class based components to functions because it was too much in one PR - see comment from Phil below.

**Precursor to the ljh-searchux-v2 PR stack** (#653, #662, #663, #664, #665) — lifting the migration out of the v2 feature work means those feature PRs become smaller and purely additive. **Stands on its own** as a refactor: even if the v2 stack never lands, the search page now has proper TypeScript types and three latent type inconsistencies are fixed.

## What's in the PR

Seven commits in logical order:

1. **Convert `types/SuggestedFields.js` to TypeScript** — exports a
   proper `SuggestedField` interface alongside the existing
   `PropTypes` shape.
2. **Complete `SearchState` typing in `GiantState`** — adds
   `suggestedFields: SuggestedField[]` and `searchFailed?: boolean`,
   which the reducer manages but the type previously elided.
3. **Use string types for URL params page and pageSize** —
   `updatePage` / `updatePageSize` signatures, matching action payload
   types, and `UrlParamsState.pageSize` all become `string`, matching
   every existing call site.
4. **Add `pageSize` to `SearchResults` type** — the runtime API has
   always returned it and the search reducer reads it.
5. **Migrate `SearchBox.js` to TypeScript** — same class structure,
   same methods. Adds `Props` interface and a small `InputSupperHandle`
   interface for the ref.
6. **Migrate `Search.js` to TypeScript** — same class structure, same
   lifecycle methods (including `UNSAFE_componentWillReceiveProps`),
   same `_debounce` class field, same `connect()` +
   `bindActionCreators`. Adds `StateProps`, `DispatchProps`, and
   `SearchState` interfaces. Uses `ThunkDispatch` in
   `mapDispatchToProps` so thunk action creators type-check.
7. **Fix search requiring double Enter on first visit** — small UX
   bug surfaced while smoke-testing the migration: the debounced
   search was firing with the stale URL `q` rather than the
   freshly-typed text.

## What this PR is *not*

- Not a class → functional conversion. That's the separate follow-up.
- Not a switch from `connect()` to `useDispatch` / `useSelector`.
- Not a `react-select` upgrade. v1 is still pinned; a type-honest
  option-lookup pattern replaces the previously-passed-as-string
  `value` prop.

## Verification

- `npx tsc --noEmit`: no new errors (only the 3 pre-existing
  `@types/lodash` baseline).
- `cd frontend && CI=1 BROWSER=none npx react-scripts build`:
  compiles with the pre-existing `@elastic/charts` source-map
  warnings; no errors.
- `cd frontend && CI=1 npx react-scripts test --watchAll=false`:
  23 suites / 204 tests passing.

## Test plan

- [x] Load `/search` cold — initial search fires with the URL `q`
- [x] Type in the search box — debounced search fires after 500 ms
- [x] Press Enter — search fires (no need to press twice)
- [x] Click Clear — query empties, filters reset, search box selected
- [x] Click a filter in the sidebar — search refires with new filters
- [x] Change page size / sort order / page — each refires the search
- [x] Toggle Compact / Show Date Created Graph
- [x] S shortcut — search box focuses
- [x] Navigate away from `/search` — title resets to "Giant"
