### PR TITLE
DO NOT MERGE - for discussion. Experiment with separating workspace structure fetch from status

### DIFF
--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -3,7 +3,7 @@ package controllers.api
 import software.amazon.awssdk.services.sns.SnsClient
 import commands.DeleteResource
 import model.Uri
-import model.annotations.{ProcessingStage, Workspace, WorkspaceEntry, WorkspaceLeaf}
+import model.annotations.{ProcessingStage, Workspace, WorkspaceEntry, WorkspaceFileStatus, WorkspaceLeaf}
 import model.frontend.{TreeEntry, TreeLeaf, TreeNode}
 import model.ingestion.{ RemoteIngest, RemoteIngestStatus}
 import model.user.UserPermission.CanPerformAdminOperations
@@ -178,6 +178,34 @@ class Workspaces(
   def getContents(workspaceId: String) = ApiAction.attempt { req =>
     annotation.getWorkspaceContents(req.user.username, workspaceId)
       .map(workspace => Ok(Json.toJson(workspace)))
+  }
+
+  // Structure half of the structure/status split (issue #369). Returns the same
+  // Workspace envelope as `get` but the tree is built from a structure-only
+  // Cypher query — no per-file Resource lookups, all processingStage values are
+  // `Unknown`, and folder processing/failure roll-up counts are 0. The frontend
+  // pairs this with `/status` to fill in per-file state and recomputes the
+  // roll-up counts client-side.
+  def getStructure(workspaceId: String) = ApiAction.attempt { req: UserIdentityRequest[_] =>
+    for {
+      metadata <- annotation.getWorkspaceMetadata(req.user.username, workspaceId)
+      relevantRemoteJobs <- remoteIngestStore.getRelevantRemoteIngestJobs(workspaceId)
+      structure <- annotation.getWorkspaceStructure(req.user.username, workspaceId, relevantRemoteJobs)
+    } yield {
+      Ok(Json.toJson(Workspace.fromMetadataAndRootNode(metadata, structure)))
+    }
+  }
+
+  // Status half of the structure/status split (issue #369). Returns a flat list
+  // of file URIs with their current processing state — cheap to poll while
+  // ingestion runs.
+  def getStatus(workspaceId: String) = ApiAction.attempt { req =>
+    for {
+      _ <- annotation.getWorkspaceMetadata(req.user.username, workspaceId) // check workspace exists and user has access
+      statuses <- annotation.getWorkspaceStatus(req.user.username, workspaceId)
+    } yield {
+      Ok(Json.toJson(statuses))
+    }
   }
 
   def getTotalWordCount(workspaceId: String) = ApiAction.attempt { req =>

--- a/backend/app/model/annotations/Workspace.scala
+++ b/backend/app/model/annotations/Workspace.scala
@@ -13,6 +13,9 @@ object ProcessingStage {
   case class Processing(tasksRemaining: Int, note: Option[String]) extends ProcessingStage
   case object Processed extends ProcessingStage
   case object Failed extends ProcessingStage
+  // Placeholder used by the structure-only workspace endpoint, where per-file
+  // processing state is fetched separately via /status and merged client-side.
+  case object Unknown extends ProcessingStage
 
   implicit val format: Format[ProcessingStage] = Format(
     (value: JsValue) => (value \ "type").validate[String].flatMap {
@@ -29,6 +32,9 @@ object ProcessingStage {
 
       case "failed" =>
         JsSuccess(Failed)
+
+      case "unknown" =>
+        JsSuccess(Unknown)
     }
     ,
     {
@@ -43,6 +49,9 @@ object ProcessingStage {
 
       case Failed =>
         Json.obj("type" -> "failed")
+
+      case Unknown =>
+        Json.obj("type" -> "unknown")
     }
   )
 }
@@ -115,6 +124,24 @@ object WorkspaceEntry {
       ProcessingStage.Processed
     }
 
+    buildEntry(v, createdBy, maybeParentId, maybeCapturedFromURL, processingStage)
+  }
+
+  def fromNeo4jStructuralValue(
+    v: Value,
+    createdBy: PartialUser,
+    maybeParentId: Option[String],
+    maybeCapturedFromURL: Option[String]
+  ): TreeEntry[WorkspaceEntry] =
+    buildEntry(v, createdBy, maybeParentId, maybeCapturedFromURL, ProcessingStage.Unknown)
+
+  private def buildEntry(
+    v: Value,
+    createdBy: PartialUser,
+    maybeParentId: Option[String],
+    maybeCapturedFromURL: Option[String],
+    processingStage: ProcessingStage
+  ): TreeEntry[WorkspaceEntry] = {
     v.get("type").asString() match {
       case "folder" => TreeNode[WorkspaceNode](
         id = v.get("id").asString(),
@@ -152,6 +179,18 @@ object WorkspaceEntry {
       )
     }
   }
+}
+
+case class WorkspaceFileStatus(
+  uri: String,
+  processingStage: ProcessingStage,
+  numberOfTodos: Int,
+  note: Option[String],
+  hasFailures: Boolean
+)
+
+object WorkspaceFileStatus {
+  implicit val format: Format[WorkspaceFileStatus] = Json.format[WorkspaceFileStatus]
 }
 
 case class WorkspaceMetadata(id: String,

--- a/backend/app/services/annotations/Annotations.scala
+++ b/backend/app/services/annotations/Annotations.scala
@@ -16,6 +16,8 @@ trait Annotations {
   def getAllWorkspacesMetadata(currentUser: String): Attempt[List[WorkspaceMetadata]]
   def getWorkspaceMetadata(currentUser: String, id: String): Attempt[WorkspaceMetadata]
   def getWorkspaceContents(currentUser: String, id: String, remoteIngestsToMixin: List[RemoteIngest] = List.empty): Attempt[TreeEntry[WorkspaceEntry]]
+  def getWorkspaceStructure(currentUser: String, id: String, remoteIngestsToMixin: List[RemoteIngest] = List.empty): Attempt[TreeEntry[WorkspaceEntry]]
+  def getWorkspaceStatus(currentUser: String, id: String): Attempt[List[WorkspaceFileStatus]]
   def insertWorkspace(username: String, id: String, name: String, isPublic: Boolean, tagColor: String): Attempt[Unit]
   def updateWorkspaceName(currentUser: String, id: String, name: String): Attempt[Unit]
   def updateWorkspaceOwner(currentUser: String, id: String, owner: String): Attempt[Unit]

--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -201,6 +201,125 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
     }
   }
 
+  override def getWorkspaceStructure(currentUser: String, id: String, remoteIngestsToMixin: List[RemoteIngest] = List.empty): Attempt[TreeEntry[WorkspaceEntry]] = attemptTransaction { tx =>
+    tx.run(
+      """
+        |MATCH (workspace: Workspace { id: $id })
+        |WHERE (:User { username: $currentUser })-[:FOLLOWING|OWNS]->(workspace) OR workspace.isPublic
+        |
+        |OPTIONAL MATCH (workspace)<-[:PART_OF]-(node :WorkspaceNode)<-[:CREATED]-(nodeCreator :User)
+        |
+        |OPTIONAL MATCH (node)-[:PARENT]->(parentNode :WorkspaceNode)
+        |
+        |OPTIONAL MATCH (node)-[:FROM]->(remoteIngest: RemoteIngest)
+        |
+        |RETURN node, nodeCreator, parentNode.id, remoteIngest.url
+      """.stripMargin,
+      parameters(
+        "currentUser", currentUser,
+        "id", id
+      )
+    ).map { summary =>
+      val rows = summary.list().asScala
+
+      val realEntries = rows.map { r =>
+        val node = r.get("node")
+        val nodeCreator = DBUser.fromNeo4jValue(r.get("nodeCreator")).toPartial
+        val maybeParentNodeId = r.get("parentNode.id").optionally(_.asString())
+        val maybeCapturedFromURL = r.get("remoteIngest.url").optionally(_.asString())
+
+        WorkspaceEntry.fromNeo4jStructuralValue(node, nodeCreator, maybeParentNodeId, maybeCapturedFromURL)
+      }.toList
+
+      val synthesisedEntries = remoteIngestsToMixin.flatMap(_.asSyntheticEntries(
+        (parentFolderId: String, name: String) => {
+          realEntries.find { entry =>
+            entry.data.maybeParentId.contains(parentFolderId) &&
+              entry.name.equalsIgnoreCase(name)
+          }.map(_.id)
+        }
+      ))
+
+      val entries = realEntries ++ synthesisedEntries
+      val childrenByParent: Map[String, List[TreeEntry[WorkspaceEntry]]] =
+        entries.groupBy(_.data.maybeParentId.getOrElse("noParent"))
+
+      def buildNode(currentEntry: TreeEntry[WorkspaceEntry]): TreeEntry[WorkspaceEntry] = {
+        currentEntry match {
+          case leaf: TreeLeaf[WorkspaceEntry] => leaf
+          case node: TreeNode[WorkspaceEntry] => {
+            val children = childrenByParent.getOrElse(node.id, List.empty).map(buildNode)
+            node.copy(
+              children = children,
+              data = node.data match {
+                case wNode: WorkspaceNode => wNode.copy(
+                  descendantsLeafCount = children.map {
+                    case TreeNode(_, _, childNode: WorkspaceNode, _) => childNode.descendantsLeafCount
+                    case _: TreeLeaf[WorkspaceEntry] => 1
+                    case _ => 0
+                  }.sum,
+                  descendantsNodeCount = children.map {
+                    case TreeNode(_, _, childNode: WorkspaceNode, _) => 1 + childNode.descendantsNodeCount
+                    case _: TreeLeaf[WorkspaceEntry] => 0
+                    case _ => 0
+                  }.sum,
+                  // descendantsProcessingTaskCount and descendantsFailedCount are
+                  // recomputed client-side after /status merges; we leave them at 0
+                  // here so structure responses can be cached independently of state.
+                  descendantsProcessingTaskCount = 0,
+                  descendantsFailedCount = 0
+                )
+                case _ => node.data
+              },
+            )
+          }
+        }
+      }
+
+      val root = entries.find(_.data.maybeParentId.isEmpty).get
+      buildNode(root)
+    }
+  }
+
+  override def getWorkspaceStatus(currentUser: String, id: String): Attempt[List[WorkspaceFileStatus]] = attemptTransaction { tx =>
+    tx.run(
+      """
+        |MATCH (workspace: Workspace { id: $id })
+        |WHERE (:User { username: $currentUser })-[:FOLLOWING|OWNS]->(workspace) OR workspace.isPublic
+        |
+        |MATCH (workspace)<-[:PART_OF]-(node :WorkspaceNode { type: 'file' })
+        |WITH DISTINCT node.uri AS uri
+        |
+        |OPTIONAL MATCH (:Resource {uri: uri})<-[todo:TODO|PROCESSING_EXTERNALLY]-(:Extractor)
+        |RETURN uri,
+        |	count(todo) AS numberOfTodos,
+        |	collect(todo)[0].note AS note,
+        |	EXISTS { (:Resource {uri: uri})<-[:EXTRACTION_FAILURE]-(:Extractor) } AS hasFailures
+      """.stripMargin,
+      parameters(
+        "currentUser", currentUser,
+        "id", id
+      )
+    ).map { summary =>
+      summary.list().asScala.toList.map { r =>
+        val uri = r.get("uri").asString()
+        val numberOfTodos = r.get("numberOfTodos").asInt()
+        val note = r.get("note").optionally(_.asString())
+        val hasFailures = r.get("hasFailures").asBoolean()
+
+        val processingStage = if (hasFailures) {
+          ProcessingStage.Failed
+        } else if (numberOfTodos > 0) {
+          ProcessingStage.Processing(numberOfTodos, note)
+        } else {
+          ProcessingStage.Processed
+        }
+
+        WorkspaceFileStatus(uri, processingStage, numberOfTodos, note, hasFailures)
+      }
+    }
+  }
+
   override def insertWorkspace(username: String, id: String, name: String, isPublic: Boolean, tagColor: String): Attempt[Unit] = attemptTransaction { tx =>
     tx.run(
       """

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -64,6 +64,8 @@ PUT           /api/workspaces/:workspaceId/isPublic                         cont
 PUT           /api/workspaces/:workspaceId/name                             controllers.api.Workspaces.updateWorkspaceName(workspaceId: String)
 GET           /api/workspaces/:workspaceId                                  controllers.api.Workspaces.get(workspaceId: String)
 GET           /api/workspaces/:workspaceId/nodes                            controllers.api.Workspaces.getContents(workspaceId: String)
+GET           /api/workspaces/:workspaceId/structure                        controllers.api.Workspaces.getStructure(workspaceId: String)
+GET           /api/workspaces/:workspaceId/status                           controllers.api.Workspaces.getStatus(workspaceId: String)
 GET           /api/workspaces/:workspaceId/totalWordCount                   controllers.api.Workspaces.getTotalWordCount(workspaceId: String)
 POST          /api/workspaces/:workspaceId/text                             controllers.api.Workspaces.getText(workspaceId: String)
 PUT           /api/workspaces/:workspaceId/owner                            controllers.api.Workspaces.updateWorkspaceOwner(workspaceId: String)

--- a/backend/test/controllers/api/WorkspacesITest.scala
+++ b/backend/test/controllers/api/WorkspacesITest.scala
@@ -3,7 +3,7 @@ package controllers.api
 import com.dimafeng.testcontainers.lifecycle.and
 import com.dimafeng.testcontainers.scalatest.TestContainersForAll
 import com.dimafeng.testcontainers.{ElasticsearchContainer, Neo4jContainer}
-import model.annotations.{Workspace, WorkspaceEntry}
+import model.annotations.{ProcessingStage, Workspace, WorkspaceEntry, WorkspaceLeaf, WorkspaceNode}
 import model.frontend.{TreeEntry, TreeLeaf, TreeNode}
 import org.apache.pekko.util.Timeout
 import org.scalatest._
@@ -602,6 +602,127 @@ class WorkspacesITest extends AnyFunSuite
         parentNodeId = jimmyWorkspace.rootNodeId,
         name = "i"
       )) should be(404)
+    }
+  }
+
+  // Issue #369 structure/status split — parity coverage.
+  // Build the same fixture tree, fetch via both the legacy /get path and the new
+  // /structure + /status pair, and assert the new pair reassembles to content
+  // equivalent to /get. A drift between them is a regression.
+
+  // (id, name, maybeParentId, isFolder)
+  private type StructuralTuple = (String, String, Option[String], Boolean)
+
+  private def flattenStructure(entry: TreeEntry[WorkspaceEntry]): List[StructuralTuple] = {
+    val head: StructuralTuple = entry match {
+      case TreeNode(id, name, data, _) => (id, name, data.maybeParentId, true)
+      case leaf: TreeLeaf[WorkspaceEntry] => (leaf.id, leaf.name, leaf.data.maybeParentId, false)
+    }
+    val tail = entry match {
+      case TreeNode(_, _, _, children) => children.flatMap(flattenStructure)
+      case _: TreeLeaf[WorkspaceEntry] => List.empty
+    }
+    head :: tail
+  }
+
+  // (uri, processingStage, numberOfTodos, note, hasFailures)
+  private type StatusTuple = (String, ProcessingStage, Int, Option[String], Boolean)
+
+  private def leafStatusTuples(entry: TreeEntry[WorkspaceEntry]): List[StatusTuple] = entry match {
+    case TreeNode(_, _, _, children) => children.flatMap(leafStatusTuples)
+    case TreeLeaf(_, _, data: WorkspaceLeaf, _) =>
+      val numberOfTodos = data.processingStage match {
+        case ProcessingStage.Processing(tasksRemaining, _) => tasksRemaining
+        case _ => 0
+      }
+      val note = data.processingStage match {
+        case ProcessingStage.Processing(_, n) => n
+        case _ => None
+      }
+      val hasFailures = data.processingStage == ProcessingStage.Failed
+      List((data.uri, data.processingStage, numberOfTodos, note, hasFailures))
+    case _ => List.empty
+  }
+
+  test("getStructure returns the same tree shape as getContents") {
+    asUser("paul") { implicit controllers =>
+      val contents = getWorkspace(paulWorkspace.id).rootNode
+      val structure = getWorkspaceStructure(paulWorkspace.id).rootNode
+
+      flattenStructure(structure).sortBy(_._1) should be(flattenStructure(contents).sortBy(_._1))
+    }
+  }
+
+  test("getStructure marks every file leaf as Unknown and zeroes processing roll-ups") {
+    asUser("paul") { implicit controllers =>
+      val structure = getWorkspaceStructure(paulWorkspace.id).rootNode
+
+      def walk(entry: TreeEntry[WorkspaceEntry]): Unit = entry match {
+        case TreeNode(_, _, data: WorkspaceNode, children) =>
+          data.descendantsProcessingTaskCount should be(0)
+          data.descendantsFailedCount should be(0)
+          children.foreach(walk)
+        case TreeLeaf(_, _, data: WorkspaceLeaf, _) =>
+          data.processingStage should be(ProcessingStage.Unknown)
+        case _ => ()
+      }
+
+      walk(structure)
+    }
+  }
+
+  test("getStructure preserves structural roll-up counts (leaf + node)") {
+    asUser("paul") { implicit controllers =>
+      val contents = getWorkspace(paulWorkspace.id).rootNode
+      val structure = getWorkspaceStructure(paulWorkspace.id).rootNode
+
+      def nodeCounts(entry: TreeEntry[WorkspaceEntry]): List[(String, Long, Long)] = entry match {
+        case TreeNode(id, _, data: WorkspaceNode, children) =>
+          (id, data.descendantsLeafCount, data.descendantsNodeCount) :: children.flatMap(nodeCounts)
+        case _ => List.empty
+      }
+
+      nodeCounts(structure).sortBy(_._1) should be(nodeCounts(contents).sortBy(_._1))
+    }
+  }
+
+  test("getStatus returns one entry per unique file URI") {
+    asUser("paul") { implicit controllers =>
+      val contents = getWorkspace(paulWorkspace.id).rootNode
+      val statuses = getWorkspaceStatus(paulWorkspace.id)
+
+      val expectedUris = leafStatusTuples(contents).map(_._1).toSet
+      statuses.map(_.uri).toSet should be(expectedUris)
+      statuses.map(_.uri).distinct.size should be(statuses.size)
+    }
+  }
+
+  test("getStatus values match the per-file state in getContents") {
+    asUser("paul") { implicit controllers =>
+      val contents = getWorkspace(paulWorkspace.id).rootNode
+      val statuses = getWorkspaceStatus(paulWorkspace.id).map(s =>
+        s.uri -> (s.processingStage, s.numberOfTodos, s.note, s.hasFailures)
+      ).toMap
+
+      // Multiple workspace nodes may reference the same blob URI; their status
+      // tuples must agree (they come from the same Resource lookups).
+      val expectedByUri = leafStatusTuples(contents).groupBy(_._1).view.mapValues { tuples =>
+        val distinct = tuples.map { case (_, stage, todos, note, failures) => (stage, todos, note, failures) }.distinct
+        distinct should have size 1
+        distinct.head
+      }.toMap
+
+      statuses.keySet should be(expectedByUri.keySet)
+      expectedByUri.foreach { case (uri, expected) =>
+        statuses(uri) should be(expected)
+      }
+    }
+  }
+
+  test("getStatus returns an empty list for a workspace with no files") {
+    asUser("paul") { implicit controllers =>
+      val emptyWorkspace = createWorkspace("paul-empty", isPublic = false)
+      getWorkspaceStatus(emptyWorkspace.id) should be(List.empty)
     }
   }
 }

--- a/backend/test/test/TestAnnotations.scala
+++ b/backend/test/test/TestAnnotations.scala
@@ -1,7 +1,7 @@
 package test
 
 import model.Uri
-import model.annotations.{Comment, CommentAnchor, WorkspaceEntry, WorkspaceMetadata}
+import model.annotations.{Comment, CommentAnchor, WorkspaceEntry, WorkspaceFileStatus, WorkspaceMetadata}
 import model.frontend.TreeEntry
 import model.ingestion.RemoteIngest
 import services.annotations.Annotations
@@ -35,6 +35,8 @@ class TestAnnotations(usersToWorkspaces: Map[String, List[String]] = Map.empty) 
   override def getComments(uri: Uri): Attempt[List[Comment]] = Attempt.Left(UnsupportedOperationFailure(""))
   override def deleteComment(currentUser: String, commentId: String): Attempt[Unit] = Attempt.Left(UnsupportedOperationFailure(""))
   override def getWorkspaceContents(currentUser: String, id: String, remoteIngestsToMixin: List[RemoteIngest]): Attempt[TreeEntry[WorkspaceEntry]] = Attempt.Left(UnsupportedOperationFailure(""))
+  override def getWorkspaceStructure(currentUser: String, id: String, remoteIngestsToMixin: List[RemoteIngest]): Attempt[TreeEntry[WorkspaceEntry]] = Attempt.Left(UnsupportedOperationFailure(""))
+  override def getWorkspaceStatus(currentUser: String, id: String): Attempt[List[WorkspaceFileStatus]] = Attempt.Left(UnsupportedOperationFailure(""))
   override def getWorkspaceMetadata(currentUser: String, id: String): Attempt[WorkspaceMetadata] = Attempt.Left(UnsupportedOperationFailure(""))
   override def getBlobOwners(blobUri: String): Attempt[Set[String]] = Attempt.Left(UnsupportedOperationFailure(""))
 }

--- a/backend/test/test/integration/Helpers.scala
+++ b/backend/test/test/integration/Helpers.scala
@@ -5,7 +5,7 @@ import org.apache.pekko.util.Timeout
 import commands.IngestFileResult
 import controllers.api._
 import extraction.MimeTypeMapper
-import model.annotations.{Workspace, WorkspaceEntry, WorkspaceMetadata}
+import model.annotations.{Workspace, WorkspaceEntry, WorkspaceFileStatus, WorkspaceMetadata}
 import model.frontend.{Filter, SearchResults, TreeEntry, TreeNode}
 import model.manifest.{Blob, Collection, CollectionWithUsers}
 import model.user.UserPermissions
@@ -382,6 +382,14 @@ object Helpers extends Matchers with Logging with OptionValues with Inside {
 
   def getWorkspace(workspaceId: String)(implicit controllers: Controllers, timeout: Timeout): Workspace = {
     contentAsJson(controllers.workspace.get(workspaceId).apply(FakeRequest())).as[Workspace]
+  }
+
+  def getWorkspaceStructure(workspaceId: String)(implicit controllers: Controllers, timeout: Timeout): Workspace = {
+    contentAsJson(controllers.workspace.getStructure(workspaceId).apply(FakeRequest())).as[Workspace]
+  }
+
+  def getWorkspaceStatus(workspaceId: String)(implicit controllers: Controllers, timeout: Timeout): List[WorkspaceFileStatus] = {
+    contentAsJson(controllers.workspace.getStatus(workspaceId).apply(FakeRequest())).as[List[WorkspaceFileStatus]]
   }
 
   def getAllWorkspaces()(implicit controllers: Controllers, timeout: Timeout): List[WorkspaceMetadata] = {


### PR DESCRIPTION
> [!NOTE]
> The new endpoints in this PR are not actually used so should not be harmful.
> This PR allows us to test the endpoints and if we think it's a good idea then 
> we would have to actually engage them via (not insignificant) frontend changes.

## Background context

Workspace fetch was a single Neo4j query producing one JSON payload that mixed two things with very different change profiles:

- **Structure** — tree shape, names, parents, ownership. Changes only when a user adds/moves/deletes items.
- **Per-file processing status** — `Processing`/`Processed`/`Failed`. Changes constantly while ingestion runs, irrelevant for folders.

The frontend re-fetches the whole tree every 60s while *anything* is processing, meaning we pay the cost of the stable thing on every poll. Splitting them apart lets polling be cheap (status only) and lets structure become independently
cacheable.

Background and analysis is in #369; but the many comments in that thread make it atough read. The TL;DR:

1. First-pass analysis identified per-row `Resource` lookups in the contents query as the main opportunity.
2. Local benchmarks misattributed the cost to Scala-side row parsing — turned out to be misleading because local Docker has zero network between app and Neo4j.
3. Playground instrumentation against a 100k item workspace showed the real cost was **Neo4j → app drain**   (the Cypher does ~200k node-lookups against  `:Resource` and ships their  aggregated results over the network).
4. A variant-comparison spike confirmed that stripping the per-file `Resource` lookups reduces drain by **57%** at 101k items.

The instrumentation that produced (2)–(4) lives on the throwaway branch `ljh-workspace-perf-instrumentation` — it's not the basis for this PR, just the evidence behind the plan.

## What this PR does

Two new endpoints alongside the existing `/api/workspaces/:id`:

- `GET /api/workspaces/:id/structure` — tree without per-file processing state.  Same Cypher as `getWorkspaceContents` minus the per-row `Resource` lookups  (`OPTIONAL MATCH (:Resource {uri: node.uri})…`) and the `EXISTS { … EXTRACTION_FAILURE … }` subquery.
- `GET /api/workspaces/:id/status` — flat list of `{uri, processingStage, numberOfTodos, note, hasFailures}` for files only, deduped by URI.

Existing `/api/workspaces/:id` and `/nodes` paths are unchanged; nothing currently consumes the new endpoints. The frontend rewrite (parallel fetch on initial load, status-only polling, client-side roll-up recompute) is a separate session.

A new `ProcessingStage.Unknown` placeholder is set on file leaves in `/structure` — the frontend will overwrite it once `/status` lands. All folder processing roll-up counts (`descendantsProcessingTaskCount`, `descendantsFailedCount`) are pinned to 0 in `/structure` for the same reason; the frontend will recompute them client-side after the merge.

## Empirical validation (deployed to playground)

Same 101,021-item real workspace as the variant-comparison in #369. Six runs per endpoint, warm-up discarded, median of runs 2–6:

| Metric | `/get` (control) | `/structure` | `/status` |
|---|---|---|---|
| TTFB | 5.96s | **3.63s** | 3.07s |
| Total | 12.11s | 11.08s | 5.49s |
| Body bytes (uncompressed) | 46.53 MB | 46.16 MB | 17.49 MB |
| Body bytes (gzipped, `/status`) | — | — | 6.76 MB |

**`/structure` TTFB is −39% vs `/get`**, comfortably beating the −31% TTFB delta the variant-comparison predicted. Body bytes within 0.8% as predicted (structural fields — UUIDs, names, parent pointers — dominate the payload; the win is entirely on the Neo4j drain side, not on serialised size).

User-perceived "tree available" time after the frontend lands will be `max(TTFB(structure), TTFB(status)) = 3.63s` — the two endpoints fire in parallel and the tree renders as soon as structure arrives.

TTFB is the metric that matters because the ALB enforces a 60s `idle_timeout` on TTFB specifically (see `router.yaml` in `investigations-platform`). At 1M items, linear extrapolation from these numbers puts the structural endpoint comfortably under the cap; the current `/get` does not.

## Test suggestions:

- [x] Playground curl on a 101k-item real workspace: TTFB, body bytes, HTTP 200, deterministic body across runs.
- [ ] Reviewer eyes on `ProcessingStage.Unknown` as the structure placeholder — shape, JSON encoding, and the small handful of new pattern-match cases (all existing `match` sites on `ProcessingStage` use `case _ =>` fallbacks, so adding the variant is safe).
