### PR TITLE
Giant: get workspace count before loading

### DIFF
--- a/backend/app/model/annotations/Workspace.scala
+++ b/backend/app/model/annotations/Workspace.scala
@@ -160,14 +160,18 @@ case class WorkspaceMetadata(id: String,
                              tagColor: String,
                              creator: PartialUser,
                              owner: PartialUser,
-                             followers: List[PartialUser]
+                             followers: List[PartialUser],
+                             // Total count of WorkspaceNodes in the workspace.
+                             // Optional because some metadata fetches (e.g. blob → workspace lookup)
+                             // don't need the count and skip the aggregation.
+                             nodeCount: Option[Long] = None
 )
 
 object WorkspaceMetadata {
   implicit val write: Writes[WorkspaceMetadata] = Json.writes[WorkspaceMetadata]
   implicit val read: Reads[WorkspaceMetadata] = Json.reads[WorkspaceMetadata]
 
-  def fromNeo4jValue(v: Value, creator: DBUser, owner:DBUser, followers: List[DBUser]): WorkspaceMetadata = {
+  def fromNeo4jValue(v: Value, creator: DBUser, owner: DBUser, followers: List[DBUser], nodeCount: Option[Long] = None): WorkspaceMetadata = {
     WorkspaceMetadata(
       v.get("id").asString(),
       v.get("name").asString(),
@@ -175,7 +179,8 @@ object WorkspaceMetadata {
       v.get("tagColor").asString(),
       creator.toPartial,
       owner.toPartial,
-      followers.map(_.toPartial)
+      followers.map(_.toPartial),
+      nodeCount
     )
   }
 }

--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -53,8 +53,8 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         |MATCH (creator :User)-[:CREATED]->(workspace)<-[:FOLLOWING]-(follower :User)
         |MATCH (owner :User)-[:OWNS]->(workspace)
         |WITH workspace, creator, owner, collect(distinct follower) AS followers
-        |OPTIONAL MATCH (workspace)<-[:PART_OF]-(node :WorkspaceNode)
-        |RETURN workspace, creator, owner, followers, count(node) AS nodeCount
+        |RETURN workspace, creator, owner, followers,
+        |  COUNT { (workspace)<-[:PART_OF]-() } AS nodeCount
       """.stripMargin,
       parameters(
         "currentUser", currentUser
@@ -80,8 +80,8 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         |MATCH (creator :User)-[:CREATED]->(workspace)<-[:FOLLOWING]-(follower :User)
         |MATCH (owner :User)-[:OWNS]->(workspace)
         |WITH workspace, creator, owner, collect(distinct follower) AS followers
-        |OPTIONAL MATCH (workspace)<-[:PART_OF]-(node :WorkspaceNode)
-        |RETURN workspace, creator, owner, followers, count(node) AS nodeCount
+        |RETURN workspace, creator, owner, followers,
+        |  COUNT { (workspace)<-[:PART_OF]-() } AS nodeCount
       """.stripMargin,
       parameters(
         "currentUser", currentUser,

--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -52,7 +52,9 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         |WHERE (:User { username: $currentUser })-[:FOLLOWING|OWNS]->(workspace) OR workspace.isPublic
         |MATCH (creator :User)-[:CREATED]->(workspace)<-[:FOLLOWING]-(follower :User)
         |MATCH (owner :User)-[:OWNS]->(workspace)
-        |RETURN workspace, creator, owner, collect(distinct follower) as followers
+        |WITH workspace, creator, owner, collect(distinct follower) AS followers
+        |OPTIONAL MATCH (workspace)<-[:PART_OF]-(node :WorkspaceNode)
+        |RETURN workspace, creator, owner, followers, count(node) AS nodeCount
       """.stripMargin,
       parameters(
         "currentUser", currentUser
@@ -63,8 +65,9 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         val creator = DBUser.fromNeo4jValue(r.get("creator"))
         val owner = DBUser.fromNeo4jValue(r.get("owner"))
         val followers = r.get("followers").asList[DBUser](DBUser.fromNeo4jValue(_)).asScala.toList
+        val nodeCount = Some(r.get("nodeCount").asLong())
 
-        WorkspaceMetadata.fromNeo4jValue(workspace, creator, owner, followers)
+        WorkspaceMetadata.fromNeo4jValue(workspace, creator, owner, followers, nodeCount)
       }
     }
   }
@@ -76,7 +79,9 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         |WHERE (:User { username: $currentUser })-[:FOLLOWING|OWNS]->(workspace) OR workspace.isPublic
         |MATCH (creator :User)-[:CREATED]->(workspace)<-[:FOLLOWING]-(follower :User)
         |MATCH (owner :User)-[:OWNS]->(workspace)
-        |RETURN workspace, creator, owner, collect(distinct follower) as followers
+        |WITH workspace, creator, owner, collect(distinct follower) AS followers
+        |OPTIONAL MATCH (workspace)<-[:PART_OF]-(node :WorkspaceNode)
+        |RETURN workspace, creator, owner, followers, count(node) AS nodeCount
       """.stripMargin,
       parameters(
         "currentUser", currentUser,
@@ -91,8 +96,9 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         val creator = DBUser.fromNeo4jValue(r.head.get("creator"))
         val owner = DBUser.fromNeo4jValue(r.head.get("owner"))
         val followers = r.head.get("followers").asList[DBUser](DBUser.fromNeo4jValue(_)).asScala.toList
+        val nodeCount = Some(r.head.get("nodeCount").asLong())
 
-        WorkspaceMetadata.fromNeo4jValue(workspace, creator, owner, followers)
+        WorkspaceMetadata.fromNeo4jValue(workspace, creator, owner, followers, nodeCount)
       }
     }
   }

--- a/backend/test/controllers/api/WorkspacesITest.scala
+++ b/backend/test/controllers/api/WorkspacesITest.scala
@@ -3,7 +3,7 @@ package controllers.api
 import com.dimafeng.testcontainers.lifecycle.and
 import com.dimafeng.testcontainers.scalatest.TestContainersForAll
 import com.dimafeng.testcontainers.{ElasticsearchContainer, Neo4jContainer}
-import model.annotations.{Workspace, WorkspaceEntry}
+import model.annotations.{Workspace, WorkspaceEntry, WorkspaceMetadata}
 import model.frontend.{TreeEntry, TreeLeaf, TreeNode}
 import org.apache.pekko.util.Timeout
 import org.scalatest._
@@ -602,6 +602,31 @@ class WorkspacesITest extends AnyFunSuite
         parentNodeId = jimmyWorkspace.rootNodeId,
         name = "i"
       )) should be(404)
+    }
+  }
+
+  test("workspace metadata includes nodeCount") {
+    asUser("paul") { implicit controllers =>
+      val allMetadata = getAllWorkspaces()
+      val paulMetadata = allMetadata.find(_.id == paulWorkspace.id).value
+
+      // buildTree creates 9 items (6 files + 3 folders) plus the root node = 10
+      paulMetadata.nodeCount should contain(10L)
+    }
+  }
+
+  test("nodeCount updates when items are added") {
+    asUser("paul") { implicit controllers =>
+      createWorkspaceFolderAssertingSuccess(
+        workspaceId = paulWorkspace.id,
+        parentNodeId = paulWorkspace.rootNodeId,
+        name = "new-folder"
+      )
+
+      val allMetadata = getAllWorkspaces()
+      val paulMetadata = allMetadata.find(_.id == paulWorkspace.id).value
+
+      paulMetadata.nodeCount should contain(11L)
     }
   }
 }

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -1268,9 +1268,29 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
 
   render() {
     if (!this.props.currentWorkspace && this.props.match.params.id) {
+      const workspaceId = this.props.match.params.id;
+      const metadata = this.props.workspacesMetadata.find(
+        (w) => w.id === workspaceId,
+      );
+      const isLargeWorkspace =
+        metadata?.nodeCount !== undefined && metadata.nodeCount > 50000;
+
       return (
         <div className="app__main-content">
           <EuiLoadingSpinner size="l" />
+          {isLargeWorkspace && metadata && (
+            <EuiText
+              size="s"
+              color="subdued"
+              style={{ marginTop: 16, textAlign: "center" }}
+            >
+              <p>
+                The workspace <strong>{metadata.name}</strong> contains
+                approximately {metadata.nodeCount!.toLocaleString()} items and
+                may take some time to load. Please be patient.
+              </p>
+            </EuiText>
+          )}
         </div>
       );
     }

--- a/frontend/src/js/types/Workspaces.ts
+++ b/frontend/src/js/types/Workspaces.ts
@@ -45,6 +45,7 @@ export type WorkspaceMetadata = {
   owner: PartialUser;
   creator: PartialUser;
   followers: PartialUser[];
+  nodeCount?: number;
 };
 
 export type WorkspaceContents = {


### PR DESCRIPTION
As part of my attempts to understand workspace performance problems it occurred to me that without fixing anything we could at least tell people what is happening. With this change when people go to /workspaces we get the counts of their workspaces – adding COUNT appears to be a very cheap addition.  And when a user clicks on a workspace, if the size is greater than 50,000 items we warn people that it will take a while to load and that assuming giant has crashed and refreshing etc will not help.

<img width="2010" height="1662" alt="2026-05-19 17 04 11" src="https://github.com/user-attachments/assets/c2682c15-c8f4-4cdf-b13d-7f8f11842d0c" />


I think this is worth doing while we know there are people clicking on big public workspaces and then telling me that they just got the spinning wheel no matter how many times they refreshed (i.e. they never waited long enough and keep going back to square one).  And later, having the count available means we can have a threshold for how to load workspaces - fully if small; progressively if large; lazily if huge. Making such thresholds configurable also allows us to soft launch lazy loading with what is effectively a "feature switch": the gate heights. See #744 .

- [x] Tested on playground - see gif above