### PR TITLE
Don't alarm on Elasticsearch 409 version conflicts

### DIFF
--- a/backend/app/utils/controller/FailureToResultMapper.scala
+++ b/backend/app/utils/controller/FailureToResultMapper.scala
@@ -156,6 +156,10 @@ class CloudWatchReportingFailureToResultMapper(metricsService: MetricsService) e
          // Not found can occur during normal usage, for example clicking the path to an ingestion you can't see
          // from a file within that ingestion that is shared with you via a workspace
          NotFoundFailure(_) |
+         // A 409 from Elasticsearch is an optimistic-concurrency (version) conflict, which happens during normal
+         // usage when two operations touch the same document at once (e.g. concurrent workspace add/remove). It's
+         // not a fault, so don't alarm on it.
+         ElasticSearchQueryFailure(_, 409, _) |
          // We expect this to happen if a worker is terminated midway through an OCR job. Another worker will pick it up
          SubprocessInterruptedFailure =>
 


### PR DESCRIPTION
Part of the effort to reduce alarm noise - see https://github.com/guardian/investigations-internal-issues/issues/66

## What

Stop the `pfi-giant-investigations-rex-FailureAlarm` (metric `PFI/ErrorsInGiantFailureToResultMapper`) paging us near-daily on benign Elasticsearch 409 version conflicts.

## Why

The alarm fires on any unexpected failure routed through `FailureToResultMapper`. Investigating a typical page, the trigger turned out to be a single Elasticsearch **409 `version_conflict_engine_exception`** — an optimistic-concurrency collision that happens during normal use when two operations touch the same document at once. The likely source is concurrent workspace add/remove (`addResourceToWorkspace` / `removeResourceFromWorkspace` in `ElasticsearchResources.scala`), which run `update_by_query` against the shared `pfi` document and its children with the default `conflicts=abort`, so a concurrent write aborts the request with a 409.

This is ES's optimistic concurrency control working **as intended** — it *prevented* a stale overwrite. It should log, but not escalate to an alarm email.

A real, sustained Elasticsearch problem still alarms. This change only suppresses the **409** conflict status.

### Example log that fired the alarm

A normal user action (workspace edit) producing a single 409:

<details>
<summary>Kibana record (<code>pfi-logs-app-7.17.9-2026.05.29</code>, 2026-05-29 08:48:22Z)</summary>

```
level:        ERROR
logger_name:  utils.controller.FailureToResultMapper$
message:      Elasticsearch query failure
user.name:    mateusz.karpow@guardian.co.uk
stage:        rex   stack: pfi-giant

elasticsearchResponse:
{"took":42,"timed_out":false,"total":1,"updated":0,"deleted":0,"batches":1,
 "version_conflicts":1,"noops":0,"retries":{"bulk":0,"search":0},
 "failures":[{"index":"pfi",
   "id":"ODqOkbH2cgLPkvxXyu8o6Pk7rn5WJU4Ud5ScpwaJ6DlYgQZn-FE8x1SNwLxl_09DtSCBIuh2mKw0wy7-gshG1Q",
   "cause":{"type":"version_conflict_engine_exception",
     "reason":"[...]: version conflict, required seqNo [5067614], primary term [6]. current document has seqNo [5067616] and primary term [6]",
     "index_uuid":"3Huw85sCTY21bsfhN-oAoQ","shard":"0","index":"pfi"},
   "status":409}]}

stack_trace:
java.lang.IllegalStateException: ElasticError(409,409,None,None,None,List(),None,None,None,List())
	at services.ElasticsearchSyntax.$anonfun$executeNoReturn$1(ElasticsearchSyntax.scala:101)
	...
```
</details>

## How

Add `ElasticSearchQueryFailure(_, 409, _)` to the suppression list in `CloudWatchReportingFailureToResultMapper`. The 409 still logs and still returns its status to the client — it just no longer increments the alarm metric.

## Out of scope (follow-up)

The 409 also means the user's workspace update may have been partially applied or lost (the request aborts rather than retrying). A proper retry-on-conflict is the more complete fix, but it needs care: the `add` painless script isn't idempotent, so a naïve retry could create duplicate workspace entries. Tracking that separately.

