### PR TITLE
Replacing minio for Garage for local development 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ fingerprint.cache
 neo4j-transaction-*.log
 timing-*.csv
 node_modules/
-minio-data/
 logs/
 backend/public/build
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Giant uses three databases, run locally in Docker through [docker-compose.yaml](
 
 - [neo4j](https://neo4j.com/)
 - [Elasticsearch](https://www.elastic.co/elasticsearch/)
-- [minio](https://min.io/) (for S3 compatibility)
+- [garage](https://garagehq.deuxfleurs.fr) (for S3 compatibility)
 
 There are two optional dependencies:
 
@@ -105,8 +105,8 @@ dev-nginx setup-app util/nginx-mapping.yml
     - Enter `bob` as the password when prompted
 - Elasticsearch: https://elasticsearch.pfi.local.dev-gutools.co.uk/
 - Cerebro (to manage Elasticsearch): https://cerebro.pfi.local.dev-gutools.co.uk/
-- Minio: https://minio.pfi.local.dev-gutools.co.uk/
-    - Username: `minio-user`
+- Garage: https://garage.pfi.local.dev-gutools.co.uk/
+    - Username: `garage-user`
     - Password: `reallyverysecret`
 
 ### Running Tests

--- a/backend/app/services/Config.scala
+++ b/backend/app/services/Config.scala
@@ -159,7 +159,7 @@ case class PreviewConfig(
 case class S3Config(
   region: String,
   buckets: BucketConfig,
-  // These settings are used just for Minio
+  // These settings are used just for Garage
   endpoint: Option[String],
   accessKey: Option[String],
   secretKey: Option[String],

--- a/backend/app/utils/aws/S3Client.scala
+++ b/backend/app/utils/aws/S3Client.scala
@@ -27,7 +27,7 @@ class S3Client(config: S3Config)(implicit executionContext: ExecutionContext) {
 
   def attemptS3[T](f: => T): Attempt[T] = Attempt.catchNonFatal(f)(AwsErrors.exceptionToFailure)
 
-  // Minio only works with the deprecated method on the client. This is a copy paste into our code to avoid the warnings
+  // Garage only works with the deprecated method on the client. This is a copy paste into our code to avoid the warnings
   def doesBucketExist(bucket: String): Boolean = try {
     s3.headBucket(HeadBucketRequest.builder().bucket(bucket).build())
     true

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -168,7 +168,7 @@ s3 {
   }
 
   region = "garage"
-  endpoint = "http://127.0.0.1:9090"
+  endpoint = "http://127.0.0.1:3900"
   accessKey = "garage-user"
   secretKey = "reallyverysecret"
 }

--- a/backend/conf/application.conf
+++ b/backend/conf/application.conf
@@ -167,9 +167,9 @@ s3 {
     remoteIngestion = "remote-ingest-data"
   }
 
-  region = "us-east-1"
+  region = "garage"
   endpoint = "http://127.0.0.1:9090"
-  accessKey = "minio-user"
+  accessKey = "garage-user"
   secretKey = "reallyverysecret"
 }
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -74,12 +74,12 @@ nohup pfi-cli ingest \
 
 ### Running pfi-cli locally
 When running locally pfi-cli works best when pointed directly at the play server rather than at giant.local.blah. You also
-need to make sure you tell pfi-cli to use minio rather than uploading stuff to S3. Here are some example commands:
+need to make sure you tell pfi-cli to use garage rather than uploading stuff to S3. Here are some example commands:
 
 ```bash
 ./pfi cli login --token $GIANT_KEY --uri http://localhost:9001
 ./pfi-cli create-ingestion --uri http://localhost:9001 --ingestionUri testfolder/test
-./pfi-cli ingest --path ~/stufftoingest --languages english --ingestionUri testfolder/test --minioAccessKey minio-user --minioEndpoint http://localhost:9090 --minioSecretKey reallyverysecret
+./pfi-cli ingest --path ~/stufftoingest --languages english --ingestionUri testfolder/test --garageIngestKey garage-user --garageEndpoint http://localhost:3900 --garageSecretKey reallyverysecret
 ```
 
 **Tip:** Add `--verbose` to see detailed output during development:

--- a/cli/src/main/scala/com/gu/pfi/cli/Main.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/Main.scala
@@ -131,7 +131,7 @@ object Main extends App with Logging {
           ingestArgs.ingestionBucket()
         ).flatMap { _ =>
           val source = IngestionSource(options)
-          val credentials = AwsCredentials.credentialsV2(ingestArgs.minioAccessKey.toOption, ingestArgs.minioSecretKey.toOption, ingestArgs.awsProfile.toOption)
+          val credentials = AwsCredentials.credentialsV2(ingestArgs.garageAccessKey.toOption, ingestArgs.garageSecretKey.toOption, ingestArgs.awsProfile.toOption)
           val ingestionS3Client = new DefaultIngestionS3Client(options.ingestCmd, credentials)
 
           val command = new RunIngestion(services.ingestion, ingestionS3Client, services.veracrypt)

--- a/cli/src/main/scala/com/gu/pfi/cli/Options.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/Options.scala
@@ -66,9 +66,9 @@ class IngestCommandOptions extends Subcommand("ingest") with CommonOptions with 
     val region = opt[String]("region", noshort = true, default = Some("eu-west-1"),
       descr = "AWS region for the ingestion S3 bucket")
 
-    val garageAccessKey = opt[String]("minioAccessKey", descr = "Access key (only required when using Garage)", noshort = true)
-    val garageSecretKey = opt[String]("minioSecretKey", descr = "Secret key (only required when using Garage)", noshort = true)
-    val garageEndpoint = opt[String]("minioEndpoint", descr = "Endpoint (only required when using Garage, defaults to localhost)", default = Some("http://127.0.0.1:3900"))
+    val garageAccessKey = opt[String]("garageAccessKey", descr = "Access key (only required when using Garage)", noshort = true)
+    val garageSecretKey = opt[String]("garageSecretKey", descr = "Secret key (only required when using Garage)", noshort = true)
+    val garageEndpoint = opt[String]("garageEndpoint", descr = "Endpoint (only required when using Garage, defaults to localhost)", default = Some("http://127.0.0.1:3900"))
 
     val awsProfile = opt[String]("awsProfile", descr = "AWS profile to use for S3 upload credentials", noshort = true)
     val sseAlgorithm = opt[String]("sseAlgorithm", descr = "Mandate S3 use a server-side encryption algorithm (eg aws:kms)", noshort = true)

--- a/cli/src/main/scala/com/gu/pfi/cli/Options.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/Options.scala
@@ -66,9 +66,9 @@ class IngestCommandOptions extends Subcommand("ingest") with CommonOptions with 
     val region = opt[String]("region", noshort = true, default = Some("eu-west-1"),
       descr = "AWS region for the ingestion S3 bucket")
 
-    val minioAccessKey = opt[String]("minioAccessKey", descr = "Access key (only required when using Minio)", noshort = true)
-    val minioSecretKey = opt[String]("minioSecretKey", descr = "Secret key (only required when using Minio)", noshort = true)
-    val minioEndpoint = opt[String]("minioEndpoint", descr = "Endpoint (only required when using Minio, defaults to localhost)", default = Some("http://127.0.0.1:9090"))
+    val garageAccessKey = opt[String]("minioAccessKey", descr = "Access key (only required when using Garage)", noshort = true)
+    val garageSecretKey = opt[String]("minioSecretKey", descr = "Secret key (only required when using Garage)", noshort = true)
+    val garageEndpoint = opt[String]("minioEndpoint", descr = "Endpoint (only required when using Garage, defaults to localhost)", default = Some("http://127.0.0.1:3900"))
 
     val awsProfile = opt[String]("awsProfile", descr = "AWS profile to use for S3 upload credentials", noshort = true)
     val sseAlgorithm = opt[String]("sseAlgorithm", descr = "Mandate S3 use a server-side encryption algorithm (eg aws:kms)", noshort = true)

--- a/cli/src/main/scala/com/gu/pfi/cli/service/IngestionS3Client.scala
+++ b/cli/src/main/scala/com/gu/pfi/cli/service/IngestionS3Client.scala
@@ -25,11 +25,10 @@ trait IngestionS3Client {
 }
 
 class DefaultIngestionS3Client(cmd: IngestCommandOptions, credentials: AwsCredentialsProvider)(implicit ec: ExecutionContext) extends IngestionS3Client with Logging {
-  val s3Async: S3AsyncClient = (cmd.minioAccessKey.toOption, cmd.minioSecretKey.toOption, cmd.minioEndpoint.toOption) match {
-    case (Some(_), Some(_), Some(minioEndpoint)) =>
-      // https://docs.minio.io/docs/how-to-use-aws-sdk-for-java-with-minio-server
+  val s3Async: S3AsyncClient = (cmd.garageAccessKey.toOption, cmd.garageSecretKey.toOption, cmd.garageEndpoint.toOption) match {
+    case (Some(_), Some(_), Some(garageEndpoint)) =>
       S3AsyncClient.crtBuilder()
-        .endpointOverride(new URI(minioEndpoint))
+        .endpointOverride(new URI(garageEndpoint))
         .credentialsProvider(credentials)
         .forcePathStyle(true)
         .minimumPartSizeInBytes(100L * 1024 * 1024)
@@ -37,25 +36,24 @@ class DefaultIngestionS3Client(cmd: IngestCommandOptions, credentials: AwsCreden
         .build()
 
     case _ =>
-      logger.info("Not all minio parameters were supplied, using AWS S3")
+      logger.info("Not all garage parameters were supplied, using AWS S3")
       S3AsyncClient.crtBuilder()
         .credentialsProvider(credentials)
         .region(Region.of(cmd.region()))
         .build()
   }
 
-  val s3: S3Client  = (cmd.minioAccessKey.toOption, cmd.minioSecretKey.toOption, cmd.minioEndpoint.toOption) match {
-    case (Some(_), Some(_), Some(minioEndpoint)) =>
-      // https://docs.minio.io/docs/how-to-use-aws-sdk-for-java-with-minio-server
+  val s3: S3Client  = (cmd.garageAccessKey.toOption, cmd.garageSecretKey.toOption, cmd.garageEndpoint.toOption) match {
+    case (Some(_), Some(_), Some(garageEndpoint)) =>
       S3Client.builder()
-        .endpointOverride(new URI(minioEndpoint))
+        .endpointOverride(new URI(garageEndpoint))
         .credentialsProvider(credentials)
         .forcePathStyle(true)
         .region(Region.of(cmd.region()))
         .build()
 
     case _ =>
-      logger.info("Not all minio parameters were supplied, using AWS S3")
+      logger.info("Not all garage parameters were supplied, using AWS S3")
       S3Client.builder()
         .credentialsProvider(credentials)
         .region(Region.of(cmd.region()))

--- a/common/src/main/scala/utils/AwsCredentials.scala
+++ b/common/src/main/scala/utils/AwsCredentials.scala
@@ -5,7 +5,7 @@ import scala.jdk.CollectionConverters._
 
 object AwsCredentials {
   def credentialsV2(accessKey: Option[String] = None, secretKey: Option[String] = None, profile: Option[String] = None): AwsCredentialsProvider = {
-    val credentialsProviders = minioCredentialsV2(accessKey, secretKey) ++ awsCredentialsV2(profile)
+    val credentialsProviders = garageCredentialsV2(accessKey, secretKey) ++ awsCredentialsV2(profile)
     AwsCredentialsProviderChain.builder()
       .credentialsProviders(credentialsProviders.asJava)
       .build()
@@ -18,7 +18,7 @@ object AwsCredentials {
     )
   }
 
-  private def minioCredentialsV2(accessKey: Option[String], secretKey: Option[String]): List[AwsCredentialsProvider] = {
+  private def garageCredentialsV2(accessKey: Option[String], secretKey: Option[String]): List[AwsCredentialsProvider] = {
     (accessKey, secretKey) match {
       case (Some(ak), Some(sk)) =>
         List(StaticCredentialsProvider.create(AwsBasicCredentials.create(ak, sk)))

--- a/common/src/main/scala/utils/AwsS3Clients.scala
+++ b/common/src/main/scala/utils/AwsS3Clients.scala
@@ -22,10 +22,9 @@ object AwsS3Clients {
   }
 
   private def buildS3ClientV2(credentials: AwsCredentialsProvider, region: Region, endpoint: Option[String]): S3Client = endpoint match {
-    case Some(minioEndpoint) =>
-      // https://docs.minio.io/docs/how-to-use-aws-sdk-for-java-with-minio-server
+    case Some(garageEndpoint) =>
       S3Client.builder()
-        .endpointOverride(new URI(minioEndpoint))
+        .endpointOverride(new URI(garageEndpoint))
         .credentialsProvider(credentials)
         .forcePathStyle(true)
         .region(region)
@@ -39,10 +38,9 @@ object AwsS3Clients {
   }
 
   private def buildS3ClientAsyncV2(credentials: AwsCredentialsProvider, region: Region, endpoint: Option[String]): S3AsyncClient = endpoint match {
-    case Some(minioEndpoint) =>
-      // https://docs.minio.io/docs/how-to-use-aws-sdk-for-java-with-minio-server
+    case Some(garageEndpoint) =>
       S3AsyncClient.builder()
-        .endpointOverride(new URI(minioEndpoint))
+        .endpointOverride(new URI(garageEndpoint))
         .credentialsProvider(credentials)
         .forcePathStyle(true)
         .region(region)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,21 +46,42 @@ services:
     volumes:
       - ${PWD}/util/local-cerebro.conf:/opt/cerebro/conf/cerebro.conf
 
-  minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-    container_name: pfi-minio
-    environment:
-      MINIO_ROOT_USER: minio-user
-      MINIO_ROOT_PASSWORD: reallyverysecret
+  garage:
+    image: dxflrs/garage:v2.3.0
+    container_name: garage
+    restart: unless-stopped
     volumes:
-      - minio:/data
+        - ./infra/garage/garage.toml:/etc/garage.toml:ro
+        - /var/lib/garage/meta:/var/lib/garage/meta
+        - /var/lib/garage/data:/var/lib/garage/data
+    environment:
+      GARAGE_DEFAULT_ACCESS_KEY: "garage-user"
+      GARAGE_DEFAULT_SECRET_KEY: "reallyverysecret"
+      GARAGE_DEFAULT_BUCKET: "test_bucket"
     ports:
-      - 9090:9000
-      - 9091:9001
-    entrypoint:
-      sh
-    command:
-      -c 'mkdir -p /data/ingest-data && mkdir -p /data/remote-ingest-data && mkdir -p /data/transcription-output-data && mkdir -p /data/ingest-data-dead-letter && mkdir -p /data/data && mkdir -p /data/preview && minio server /data --console-address ":9001"'
+        - 9090:3900
+        - 9093:3903
+
+  garage-ui:
+    image: noooste/garage-ui:latest
+    container_name: garage-ui
+    restart: unless-stopped
+    ports:
+      - 9091:8080
+    depends_on:
+      - garage
+    environment:
+      # Garage S3 Configuration
+      GARAGE_UI_GARAGE_ENDPOINT: "garage:3900"
+      GARAGE_UI_GARAGE_ADMIN_ENDPOINT: "http://garage:3903"
+
+      # Server Configuration
+      GARAGE_UI_SERVER_HOST: "0.0.0.0"
+      GARAGE_UI_SERVER_PORT: "8080"
+      GARAGE_UI_SERVER_ENVIRONMENT: "production"
+      GARAGE_UI_GARAGE_ADMIN_TOKEN: "secret"
+      GARAGE_UI_GARAGE_REGION: "garage"
+
 
   postgres:
     image: postgres:15.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   neo4j:
 #    image: ${NEO4J_IMAGE_OVERRIDE:-neo4j/neo4j-arm64-experimental:3.5.30}
@@ -51,16 +51,18 @@ services:
     container_name: garage
     restart: unless-stopped
     volumes:
-        - ./infra/garage/garage.toml:/etc/garage.toml:ro
-        - /var/lib/garage/meta:/var/lib/garage/meta
-        - /var/lib/garage/data:/var/lib/garage/data
+      - ./infra/garage/garage.toml:/etc/garage.toml:ro
+      - garage-data:/var/lib/garage/data
+      - garage-meta:/var/lib/garage/meta
     environment:
       GARAGE_DEFAULT_ACCESS_KEY: "garage-user"
       GARAGE_DEFAULT_SECRET_KEY: "reallyverysecret"
-      GARAGE_DEFAULT_BUCKET: "test_bucket"
+      # to make garage work with a default user we need to specific a default bucket
+      GARAGE_DEFAULT_BUCKET: "unused-bucket"
     ports:
-        - 9090:3900
-        - 9093:3903
+      - 3900:3900
+      - 3903:3903
+    command: /garage server --single-node --default-bucket
 
   garage-ui:
     image: noooste/garage-ui:latest
@@ -81,7 +83,6 @@ services:
       GARAGE_UI_SERVER_ENVIRONMENT: "production"
       GARAGE_UI_GARAGE_ADMIN_TOKEN: "secret"
       GARAGE_UI_GARAGE_REGION: "garage"
-
 
   postgres:
     image: postgres:15.3
@@ -105,7 +106,10 @@ volumes:
   elasticsearch:
     driver: local
 
-  minio:
+  garage-data:
+    driver: local
+
+  garage-meta:
     driver: local
 
   postgres-data:

--- a/docs/02-admin-quickstart.md
+++ b/docs/02-admin-quickstart.md
@@ -68,6 +68,6 @@ pfi-cli ingest \
   --ingestionUri <collection_name>/<ingestion_name> \
   --path <path to the data on disk>
   --languages <comma_separated_languages eg english,russian> \
-  --minioAccessKey <see application.conf> \
-  --minioSecretKey <see application.conf>
+  --garageAccessKey <see application.conf> \
+  --garageSecretKey <see application.conf>
 ```

--- a/infra/garage/garage.toml
+++ b/infra/garage/garage.toml
@@ -1,0 +1,27 @@
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+
+replication_factor = 1
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "c50b7c699e15d5c646f2f08c0edd34a134ab3abf572cb41dd22ef437e74800f4"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.localhost"
+
+[s3_web]
+bind_addr = "[::]:3902"
+root_domain = ".web.garage.localhost"
+index = "index.html"
+
+[k2v_api]
+api_bind_addr = "[::]:3904"
+
+[admin]
+api_bind_addr = "[::]:3903"
+admin_token = "secret"
+metrics_token = "8pgYYvCJ/Cg5bWjKEZIhZkAGt0kIeRWTl8n/2DpQH8g="

--- a/scripts/initialise-garage.sh
+++ b/scripts/initialise-garage.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+for bucket in ingest-data ingest-data-dead-letter data preview transcription-output-data remote-ingest-data; do
+  docker exec garage /garage bucket info $bucket >/dev/null 2>&1 || docker exec garage /garage bucket create $bucket
+  docker exec garage /garage bucket allow --read --write --owner --key garage-user $bucket
+done
+
+echo "Garage buckets created (if they did not already exist) and permissions set."

--- a/scripts/start-backend.sh
+++ b/scripts/start-backend.sh
@@ -23,7 +23,7 @@ AVAILABLE_MEMORY=$( docker stats --format "{{.MemUsage}}" --no-stream \
 
 # This is a threshold of 5 GiB, about 5.4 GB.
 # elasticsearch wants 4 GiB (https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html)
-# and we leave some headroom for neo4j and minio.
+# and we leave some headroom for neo4j and garage.
 if [ $AVAILABLE_MEMORY -lt 5 ]; then
     echo "For elasticsearch to run within a Docker container, you must give Docker \
     at least 6GB of memory from the Preferences menu."
@@ -34,5 +34,7 @@ if [ ! -f "$SCRIPTPATH/../backend/conf/site.conf" ]; then
     echo "You do not have a site config, please run scripts/cluster-setup.sh" >&2
     exit 1
 fi
+
+./scripts/initialise-garage.sh
 
 sbt backend/run -mem 4096 -jvm-debug 5005

--- a/scripts/wipe_data.sh
+++ b/scripts/wipe_data.sh
@@ -17,6 +17,3 @@ curl                                                  \
      "localhost:9200/_all/_delete_by_query?q=*" 2>&1 > /dev/null
 
 
-if [ -d ../minio-data ]; then
-    rm -r ../minio-data
-fi

--- a/util/nginx-mapping.yml
+++ b/util/nginx-mapping.yml
@@ -9,7 +9,7 @@ mappings:
     port: 7687
   - prefix: elasticsearch.pfi
     port: 9200
-  - prefix: minio.pfi
-    port: 9090
+  - prefix: garage.pfi
+    port: 3900
   - prefix: cerebro.pfi
     port: 9091


### PR DESCRIPTION
## What does this change?

Minio has gone [out of support](https://github.com/minio/minio?tab=readme-ov-file). [Garage](https://garagehq.deuxfleurs.fr/) seems to be a well-funded alternative.  

It's mostly a drop-in replacement although:
- the initiatlisation is done a bit differently (we've done it in a separate script) 
- you have to setup a ui (we've chosen [garage ui](https://github.com/Noooste/garage-ui) as it seems well-maintained) separately

## How has this change been tested?
 - [x] Tested locally

