### PR TITLE
Raise the document page-count gate from 500 to 1000

### DIFF
--- a/backend/app/commands/GetResource.scala
+++ b/backend/app/commands/GetResource.scala
@@ -54,9 +54,10 @@ case class GetResource(uri: Uri, mode: ResourceFetchMode, username: String, mani
 
     case ResourceFetchMode.WithData(query) =>
       index.getPageCount(uri).flatMap {
-        // From testing we know that page counts over 500 start to run into
-        // rendering difficulties in the browser.
-        case Some(pageCount) if pageCount > 500 => Attempt.Right(resource)
+        // Above this page count we return the bare resource rather than merging
+        // in its text/OCR/preview, to avoid rendering difficulties in the browser
+        // for very large documents.
+        case Some(pageCount) if pageCount > 1000 => Attempt.Right(resource)
         case _ => (for {
           indexed <- index.getResource(uri, query)
           comments <- annotations.getComments(uri)


### PR DESCRIPTION
## What

`GetResource` only merges a document's extracted text, OCR and preview into the
API response when the document's page count is at or below a threshold. Above it,
the bare `BasicResource` is returned (no text/OCR/preview) to avoid browser
rendering difficulties. This raises that threshold from **500 to 1000 pages**.

## Why

- The `> 500` limit has been unchanged since the initial open-source commit (May
  2021) and almost certainly predates it — it dates from an era of far less
  capable user hardware.
- Our users' machines have improved enormously since then, so the point at which
  a full-document text/OCR view actually becomes a rendering problem is well above
  500 pages.
- In practice this meant legitimate multi-hundred-page documents (e.g. ~550–600pp
  PDFs) were effectively unreadable: the document views returned no text, OCR or
  preview at all. The underlying text and OCR had been extracted correctly and
  were present in Elasticsearch all along — the gate was simply withholding them.

## Testing

- Verified locally: with the threshold at 1000, ~550 and ~600 page PDFs now return
  their full extracted text (~420k chars) and OCR, and the Text / OCR / Preview
  views render without errors.
- This exposes data that already exists in the index; it does **not** trigger any
  re-extraction.

Proper fix for the underlying logic to follow