### PR TITLE
Guard the viewer against resources with no extracted text

### DIFF
--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -97,6 +97,9 @@ const PageViewerContent: FC<{
   }
 
   if (view === "table") {
+    if (!resource.text) {
+      return renderNoPreview();
+    }
     return <TablePreview text={resource.text.contents} />;
   } else if (view === "preview") {
     return <Preview resource={resource} />;

--- a/frontend/src/js/components/viewer/Viewer.tsx
+++ b/frontend/src/js/components/viewer/Viewer.tsx
@@ -233,6 +233,9 @@ class Viewer extends React.Component<Props, State> {
 
   renderFullContents(resource: Resource, view: string) {
     if (view === "table") {
+      if (!resource.text) {
+        return this.renderNoPreview();
+      }
       return <TablePreview text={resource.text.contents} />;
     } else if (view === "preview") {
       return <Preview resource={resource} />;
@@ -269,7 +272,7 @@ class Viewer extends React.Component<Props, State> {
         // Only matters if a user has manually changed the view in the URL params or is visiting a link with them in
         return this.renderNoPreview();
       }
-    } else if (resource.extracted) {
+    } else if (resource.extracted && resource.text) {
       return this.renderTextPreview(resource, resource.text, "text");
     } else if (resource.children.length) {
       return (

--- a/frontend/src/js/types/Resource.ts
+++ b/frontend/src/js/types/Resource.ts
@@ -71,7 +71,10 @@ export type Resource = BasicResource & {
   comments: CommentData[];
   selection?: ResourceRange;
   previewStatus: string;
-  text: HighlightableText;
+  // The API omits `text` entirely for resources with no extracted text
+  // (e.g. large documents whose document-level extraction was skipped/failed).
+  // It must be optional so call sites are forced to guard against it.
+  text?: HighlightableText;
   ocr?: {
     [lang: string]: HighlightableText;
   };

--- a/frontend/src/js/util/resourceUtils.spec.ts
+++ b/frontend/src/js/util/resourceUtils.spec.ts
@@ -44,6 +44,13 @@ describe("hasTextContent", () => {
     });
     expect(hasTextContent(resource)).toBe(false);
   });
+
+  test("returns false when text is undefined", () => {
+    const resource = makeResource({
+      text: undefined,
+    });
+    expect(hasTextContent(resource)).toBe(false);
+  });
 });
 
 describe("getDefaultView", () => {
@@ -122,7 +129,7 @@ describe("getDefaultView", () => {
 
   test("returns undefined when resource.text is undefined", () => {
     const resource = makeResource({
-      text: undefined as unknown as HighlightableText,
+      text: undefined,
     });
     expect(getDefaultView(resource)).toBeUndefined();
   });

--- a/frontend/src/js/util/resourceUtils.ts
+++ b/frontend/src/js/util/resourceUtils.ts
@@ -78,7 +78,7 @@ export function getCurrentResource(prefix: string): string {
 }
 
 export function hasTextContent(resource: Resource): boolean {
-  return resource.text.contents.trim() !== "";
+  return !!resource.text && resource.text.contents.trim() !== "";
 }
 
 export function getDefaultView(resource: Resource): string | undefined {
@@ -136,7 +136,7 @@ export function definitelyNotAUnifiedViewer(
   }
 
   const noTextButHasOcr =
-    resource.text.contents.length === 0 && resource.ocr
+    (!resource.text || resource.text.contents.length === 0) && resource.ocr
       ? Object.entries(resource.ocr)[0]
       : undefined;
   if (noTextButHasOcr) {
@@ -145,6 +145,10 @@ export function definitelyNotAUnifiedViewer(
       view,
       highlightableText,
     };
+  }
+
+  if (!resource.text) {
+    return undefined;
   }
 
   return {


### PR DESCRIPTION
Addresses the crash that surfaced #750 and #751

Make `Resource.text` optional and guard the viewer call sites that dereference it, so the document viewer no longer crashes to a blank page when the API returns a resource without document-level extracted text.

## Why

The API can legitimately return a resource with no `text` field — e.g. when a document is returned as a `BasicResource` rather than a full document (large documents above the page-count gate, or the content-length fallback). However the frontend type declared `text: HighlightableText` as always-present, so `hasTextContent` was written as:

```ts
return resource.text.contents.trim() !== "";
```

When `resource.text` is `undefined`, this throws `TypeError: Cannot read properties of undefined (reading 'contents')` inside `PreviewSwitcher.render`. With no error boundary, the whole viewer unmounts and the page renders blank.

## Changes

- `Resource.text` is now optional (`text?: HighlightableText`), matching what the API actually returns.
- `hasTextContent` and the other call sites that dereferenced `resource.text` (`definitelyNotAUnifiedViewer`, the table view in `PageViewerOrFallback` and `Viewer`, and `Viewer`'s extracted-text branch) are guarded against the undefined case.
- Added a regression test for `hasTextContent` with undefined `text`.

## Behaviour change

The only behavioural difference is in cases that previously crashed: the legacy `Viewer` fallback now degrades gracefully (children tree / "cannot display this document") instead of throwing. The standard page-by-page combined view is unaffected — it never reads `resource.text`.

## Testing

- [x] Local dev - manually verified: a document returned without text now renders via the combined page view instead of blanking.
- [ ]  Preview
