### PR TITLE
Giant: show page number in combined viewer

### DIFF
--- a/frontend/src/js/components/PageViewer/PageNavInput.module.css
+++ b/frontend/src/js/components/PageViewer/PageNavInput.module.css
@@ -1,0 +1,35 @@
+.container {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 8px;
+  font-weight: normal;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.label {
+  opacity: 0.8;
+}
+
+.input {
+  width: 3.5em;
+  box-sizing: border-box;
+  padding: 2px 4px;
+  text-align: center;
+  font-size: 13px;
+  color: white;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 3px;
+}
+
+.input:focus {
+  outline: none;
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.total {
+  opacity: 0.8;
+}

--- a/frontend/src/js/components/PageViewer/PageNavInput.tsx
+++ b/frontend/src/js/components/PageViewer/PageNavInput.tsx
@@ -1,5 +1,6 @@
 import React, { FC, KeyboardEventHandler, useEffect, useState } from "react";
 import styles from "./PageNavInput.module.css";
+import { parsePageInput } from "./pageInput";
 
 type PageNavInputProps = {
   // The page currently at the centre of the viewport.
@@ -27,18 +28,18 @@ export const PageNavInput: FC<PageNavInputProps> = ({
   }, [currentPage, isFocused]);
 
   const commit = () => {
-    const parsed = parseInt(value, 10);
-    if (Number.isFinite(parsed)) {
-      const clamped = Math.min(Math.max(parsed, 1), totalPages);
-      // Skip no-op jumps so simply focusing and blurring doesn't snap the
-      // scroll to the top of the page you're already on.
-      if (clamped !== currentPage) {
-        onJumpToPage(clamped);
-      }
-      setValue(String(clamped));
-    } else {
+    const target = parsePageInput(value, totalPages);
+    if (target === null) {
+      // Unusable input (empty, non-numeric): revert to the current page.
       setValue(String(currentPage));
+      return;
     }
+    // Skip no-op jumps so simply focusing and blurring doesn't snap the
+    // scroll to the top of the page you're already on.
+    if (target !== currentPage) {
+      onJumpToPage(target);
+    }
+    setValue(String(target));
   };
 
   const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {

--- a/frontend/src/js/components/PageViewer/PageNavInput.tsx
+++ b/frontend/src/js/components/PageViewer/PageNavInput.tsx
@@ -1,0 +1,81 @@
+import React, { FC, KeyboardEventHandler, useEffect, useState } from "react";
+import styles from "./PageNavInput.module.css";
+
+type PageNavInputProps = {
+  // The page currently at the centre of the viewport.
+  currentPage: number;
+  totalPages: number;
+  onJumpToPage: (page: number) => void;
+};
+
+// A footer control showing "Page [n] / total" for the combined page view.
+// The number is an editable field: type a page and press Enter (or blur) to
+// jump there. While not being edited it tracks the scroll position.
+export const PageNavInput: FC<PageNavInputProps> = ({
+  currentPage,
+  totalPages,
+  onJumpToPage,
+}) => {
+  const [value, setValue] = useState(String(currentPage));
+  const [isFocused, setIsFocused] = useState(false);
+
+  // Follow the scroll position while the field isn't being edited.
+  useEffect(() => {
+    if (!isFocused) {
+      setValue(String(currentPage));
+    }
+  }, [currentPage, isFocused]);
+
+  const commit = () => {
+    const parsed = parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      const clamped = Math.min(Math.max(parsed, 1), totalPages);
+      // Skip no-op jumps so simply focusing and blurring doesn't snap the
+      // scroll to the top of the page you're already on.
+      if (clamped !== currentPage) {
+        onJumpToPage(clamped);
+      }
+      setValue(String(clamped));
+    } else {
+      setValue(String(currentPage));
+    }
+  };
+
+  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    if (event.key === "Enter") {
+      event.currentTarget.blur();
+    } else if (event.key === "Escape") {
+      setValue(String(currentPage));
+      event.currentTarget.blur();
+    }
+  };
+
+  return (
+    <span className={styles.container}>
+      <span className={styles.label}>Page</span>
+      <input
+        className={styles.input}
+        type="text"
+        inputMode="numeric"
+        autoComplete="off"
+        aria-label="Current page, type a number to jump"
+        value={value}
+        onFocus={() => {
+          // Clear the field so typing replaces the page number rather than
+          // inserting alongside it. (Selecting the text instead is fragile:
+          // the mouseup after a click deselects it.) An empty field on blur
+          // reverts to the current page via commit().
+          setIsFocused(true);
+          setValue("");
+        }}
+        onBlur={() => {
+          setIsFocused(false);
+          commit();
+        }}
+        onChange={(e) => setValue(e.target.value.replace(/[^0-9]/g, ""))}
+        onKeyDown={onKeyDown}
+      />
+      <span className={styles.total}>/ {totalPages}</span>
+    </span>
+  );
+};

--- a/frontend/src/js/components/PageViewer/PageNavInput.tsx
+++ b/frontend/src/js/components/PageViewer/PageNavInput.tsx
@@ -75,7 +75,12 @@ export const PageNavInput: FC<PageNavInputProps> = ({
         onChange={(e) => setValue(e.target.value.replace(/[^0-9]/g, ""))}
         onKeyDown={onKeyDown}
       />
-      <span className={styles.total}>/ {totalPages}</span>
+      <span
+        className={styles.total}
+        title="Total number of pages in the document. This may not match the page numbers printed on the pages (e.g. when a document has introductory pages before page 1)."
+      >
+        / {totalPages}
+      </span>
     </span>
   );
 };

--- a/frontend/src/js/components/PageViewer/PageViewer.tsx
+++ b/frontend/src/js/components/PageViewer/PageViewer.tsx
@@ -19,6 +19,8 @@ type PageViewerProps = {
   focusedFindHighlight: HighlightForSearchNavigation | null;
   rotation: number;
   scale: number;
+  jumpRequest?: { page: number; nonce: number } | null;
+  onVisiblePageChange?: (pageNumber: number) => void;
 };
 
 export const PageViewer: FC<PageViewerProps> = ({
@@ -30,6 +32,8 @@ export const PageViewer: FC<PageViewerProps> = ({
   focusedFindHighlight,
   rotation,
   scale,
+  jumpRequest,
+  onVisiblePageChange,
 }) => {
   const params = new URLSearchParams(document.location.search);
 
@@ -91,6 +95,8 @@ export const PageViewer: FC<PageViewerProps> = ({
           rotation={rotation}
           scale={scale}
           firstPageDimensions={firstPageDimensions}
+          jumpRequest={jumpRequest}
+          onVisiblePageChange={onVisiblePageChange}
         />
       ) : null}
     </main>

--- a/frontend/src/js/components/PageViewer/VirtualScroll.tsx
+++ b/frontend/src/js/components/PageViewer/VirtualScroll.tsx
@@ -30,7 +30,12 @@ type VirtualScrollProps = {
   totalPages: number;
   pageNumbersToPreload: number[];
 
-  jumpToPage?: number | null;
+  // A jump request carries a nonce so the same target page can be requested
+  // repeatedly (e.g. jump to 5, scroll away, jump to 5 again). Keying the jump
+  // effect on the nonce also stops a zoom-driven pageHeight change from
+  // re-triggering an old jump and fighting the scroll-preservation effect.
+  jumpRequest?: { page: number; nonce: number } | null;
+  onVisiblePageChange?: (pageNumber: number) => void;
 
   rotation: number;
   scale: number;
@@ -57,7 +62,8 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
   focusedSearchHighlight,
 
   totalPages,
-  jumpToPage,
+  jumpRequest,
+  onVisiblePageChange,
   pageNumbersToPreload,
 
   rotation,
@@ -232,20 +238,46 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     });
   }, [pageHeight, totalPages, debouncedSetPageRange]);
 
-  const throttledSetPageRangeFromScrollPosition = useMemo(
-    () => throttle(setPageRangeFromScrollPosition, 75),
-    [setPageRangeFromScrollPosition],
+  // Report which page is at the centre of the viewport for the footer readout.
+  // Computed directly from the scroll position rather than from pageRange.middle
+  // because that value is debounced for large jumps, which would make the
+  // readout visibly lag during fast scrolls.
+  const reportVisiblePage = useCallback(() => {
+    if (viewport?.current && onVisiblePageChange) {
+      const v = viewport.current;
+      const currentMid = v.scrollTop + v.clientHeight / 2;
+      const pageNumber = Math.min(
+        Math.max(Math.floor(currentMid / pageHeight) + 1, 1),
+        totalPages,
+      );
+      onVisiblePageChange(pageNumber);
+    }
+  }, [onVisiblePageChange, pageHeight, totalPages]);
+
+  const handleScroll = useCallback(() => {
+    setPageRangeFromScrollPosition();
+    reportVisiblePage();
+  }, [setPageRangeFromScrollPosition, reportVisiblePage]);
+
+  const throttledHandleScroll = useMemo(
+    () => throttle(handleScroll, 75),
+    [handleScroll],
   );
 
-  // TODO: try just useEffect
+  // Only act on a jump when its nonce changes, not on every pageHeight change.
+  // Otherwise zooming (which changes pageHeight) would re-apply the last jump
+  // and override the scroll-preservation effect above.
+  const lastAppliedJumpNonce = useRef<number | null>(null);
   useLayoutEffect(() => {
-    if (viewport?.current) {
-      if (jumpToPage) {
-        const scrollTo = (jumpToPage - 1) * pageHeight;
-        viewport.current.scrollTop = scrollTo;
-      }
+    if (
+      viewport?.current &&
+      jumpRequest &&
+      jumpRequest.nonce !== lastAppliedJumpNonce.current
+    ) {
+      lastAppliedJumpNonce.current = jumpRequest.nonce;
+      viewport.current.scrollTop = (jumpRequest.page - 1) * pageHeight;
     }
-  }, [pageHeight, jumpToPage]);
+  }, [pageHeight, jumpRequest]);
 
   useLayoutEffect(() => {
     if (viewport?.current && focusedFindHighlight) {
@@ -339,7 +371,7 @@ export const VirtualScroll: FC<VirtualScrollProps> = ({
     <div
       ref={viewport}
       className={styles.scrollContainer}
-      onScroll={throttledSetPageRangeFromScrollPosition}
+      onScroll={throttledHandleScroll}
     >
       <div className={styles.pages} style={{ height: totalPages * pageHeight }}>
         {renderedPages.map((page) => (

--- a/frontend/src/js/components/PageViewer/pageInput.spec.ts
+++ b/frontend/src/js/components/PageViewer/pageInput.spec.ts
@@ -1,0 +1,28 @@
+import { parsePageInput } from "./pageInput";
+
+describe("parsePageInput", () => {
+  test("returns the page when it is within range", () => {
+    expect(parsePageInput("5", 10)).toBe(5);
+  });
+
+  test("clamps a page above the total down to the total", () => {
+    expect(parsePageInput("99", 10)).toBe(10);
+  });
+
+  test("clamps a page below 1 up to 1", () => {
+    expect(parsePageInput("0", 10)).toBe(1);
+    expect(parsePageInput("-3", 10)).toBe(1);
+  });
+
+  test("parses a leading number followed by other characters", () => {
+    expect(parsePageInput("7abc", 10)).toBe(7);
+  });
+
+  test("returns null for empty input", () => {
+    expect(parsePageInput("", 10)).toBeNull();
+  });
+
+  test("returns null for non-numeric input", () => {
+    expect(parsePageInput("abc", 10)).toBeNull();
+  });
+});

--- a/frontend/src/js/components/PageViewer/pageInput.ts
+++ b/frontend/src/js/components/PageViewer/pageInput.ts
@@ -1,0 +1,13 @@
+import clamp from "lodash/clamp";
+
+/**
+ * Resolve a raw page-number input (as typed into the footer's page field)
+ * to a valid page in the range [1, totalPages], or null if the input isn't
+ * a usable number.
+ *
+ * Pure and side-effect free so it can be unit tested directly.
+ */
+export function parsePageInput(raw: string, totalPages: number): number | null {
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) ? clamp(parsed, 1, totalPages) : null;
+}

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useState } from "react";
+import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import authFetch from "../util/auth/authFetch";
 import { useParams } from "react-router-dom";
@@ -59,6 +59,8 @@ const PageViewerContent: FC<{
   focusedFindHighlight: HighlightForSearchNavigation | null;
   rotation: number;
   scale: number;
+  jumpRequest: { page: number; nonce: number } | null;
+  onVisiblePageChange: (pageNumber: number) => void;
 }> = ({
   uri,
   totalPages,
@@ -69,6 +71,8 @@ const PageViewerContent: FC<{
   focusedFindHighlight,
   rotation,
   scale,
+  jumpRequest,
+  onVisiblePageChange,
 }) => {
   const dispatch = useDispatch();
   const resource = useSelector<GiantState, Resource | null>(
@@ -88,6 +92,8 @@ const PageViewerContent: FC<{
         focusedFindHighlight={focusedFindHighlight}
         rotation={rotation}
         scale={scale}
+        jumpRequest={jumpRequest}
+        onVisiblePageChange={onVisiblePageChange}
       />
     );
   }
@@ -172,6 +178,29 @@ export const PageViewerOrFallback: FC<{}> = () => {
 
   const [rotation, setRotation] = useState(0);
   const [scale, setScale] = useState(1);
+
+  // Page position readout + jump-to-page for the combined view footer.
+  // currentPage is the page at the centre of the viewport, reported by
+  // VirtualScroll as the user scrolls. jumpRequest carries an incrementing
+  // nonce so the same target can be requested more than once.
+  const [currentPage, setCurrentPage] = useState(1);
+  const [jumpRequest, setJumpRequest] = useState<{
+    page: number;
+    nonce: number;
+  } | null>(null);
+  const jumpNonce = useRef(0);
+
+  const jumpToPage = useCallback((page: number) => {
+    jumpNonce.current += 1;
+    setJumpRequest({ page, nonce: jumpNonce.current });
+  }, []);
+
+  // Reset position state when navigating to a different document. The viewer
+  // remounts (keyed on uri) and starts at the top, but this state lives here.
+  useEffect(() => {
+    setCurrentPage(1);
+    setJumpRequest(null);
+  }, [uri]);
 
   const rotateClockwise = useCallback(
     () => setRotation((r) => (r + 90) % 360),
@@ -265,6 +294,8 @@ export const PageViewerOrFallback: FC<{}> = () => {
         focusedFindHighlight={pageFind.focusedHighlight}
         rotation={rotation}
         scale={scale}
+        jumpRequest={jumpRequest}
+        onVisiblePageChange={setCurrentPage}
       />
     );
     return (
@@ -289,6 +320,11 @@ export const PageViewerOrFallback: FC<{}> = () => {
             pageFind={isCombinedOrUnset(view) ? pageFind : undefined}
             pageViewControls={
               isCombinedOrUnset(view) ? pageViewControls : undefined
+            }
+            pageNav={
+              isCombinedOrUnset(view)
+                ? { currentPage, onJumpToPage: jumpToPage }
+                : undefined
             }
           />
         )}

--- a/frontend/src/js/components/viewer/DocumentFooter.tsx
+++ b/frontend/src/js/components/viewer/DocumentFooter.tsx
@@ -8,6 +8,7 @@ import ZoomOutIcon from "react-icons/lib/md/zoom-out";
 import PreviewSwitcher from "./PreviewSwitcher";
 import { DocNavButton } from "./DocNavButton";
 import { FindInput } from "../PageViewer/FindInput";
+import { PageNavInput } from "../PageViewer/PageNavInput";
 import { keyboardShortcuts } from "../../util/keyboardShortcuts";
 import { KeyboardShortcut } from "../UtilComponents/KeyboardShortcut";
 
@@ -27,12 +28,18 @@ type PageViewControls = {
   zoomOut: () => void;
 };
 
+type PageNav = {
+  currentPage: number;
+  onJumpToPage: (page: number) => void;
+};
+
 type DocumentFooterProps = {
   uri: string;
   workspaceNav: WorkspaceNavigation;
   totalPages?: number;
   pageFind?: PageFindState;
   pageViewControls?: PageViewControls;
+  pageNav?: PageNav;
 };
 
 export const DocumentFooter: FC<DocumentFooterProps> = ({
@@ -41,6 +48,7 @@ export const DocumentFooter: FC<DocumentFooterProps> = ({
   totalPages,
   pageFind,
   pageViewControls,
+  pageNav,
 }) => {
   const resource = useSelector<GiantState, Resource | null>(
     (state) => state.resource,
@@ -155,6 +163,13 @@ export const DocumentFooter: FC<DocumentFooterProps> = ({
       )}
       {pageViewControls && (
         <span className="document__footer-view-controls">
+          {pageNav && totalPages !== undefined && (
+            <PageNavInput
+              currentPage={pageNav.currentPage}
+              totalPages={totalPages}
+              onJumpToPage={pageNav.onJumpToPage}
+            />
+          )}
           <button onClick={pageViewControls.zoomIn} title="Zoom in">
             <ZoomInIcon />
           </button>

--- a/frontend/src/js/components/viewer/DocumentFooter.tsx
+++ b/frontend/src/js/components/viewer/DocumentFooter.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useCallback, useEffect, useMemo, useRef } from "react";
 import { useSelector } from "react-redux";
-import RotateLeft from "react-icons/lib/md/rotate-left";
-import RotateRight from "react-icons/lib/md/rotate-right";
-import ZoomInIcon from "react-icons/lib/md/zoom-in";
-import ZoomOutIcon from "react-icons/lib/md/zoom-out";
+import RotateLeft from "react-icons/lib/fa/rotate-left";
+import RotateRight from "react-icons/lib/fa/repeat";
+import ZoomInIcon from "react-icons/lib/fa/search-plus";
+import ZoomOutIcon from "react-icons/lib/fa/search-minus";
 
 import PreviewSwitcher from "./PreviewSwitcher";
 import { DocNavButton } from "./DocNavButton";

--- a/frontend/src/stylesheets/components/_document.scss
+++ b/frontend/src/stylesheets/components/_document.scss
@@ -102,6 +102,8 @@
   display: flex;
   align-items: center;
   gap: 2px;
+  // Small breathing room before the view switcher ("Combined" etc.)
+  margin-right: 8px;
 
   button {
     background: none;

--- a/frontend/src/stylesheets/components/_document.scss
+++ b/frontend/src/stylesheets/components/_document.scss
@@ -109,6 +109,9 @@
     color: white;
     cursor: pointer;
     padding: 2px;
+    // Icons are sized in em, so bumping font-size enlarges them for
+    // legibility at footer scale (zoom +/- and rotate direction).
+    font-size: 17px;
     display: flex;
     align-items: center;
 


### PR DESCRIPTION
FIxes #309 

Adds a **page position indicator** to the combined page viewer's footer, plus a quick **jump-to-page** control. Previously there was no way to see which page you were on in a long document, or to navigate to a specific page without manually scrolling.

<img width="100%" alt="page numbers in combined viewer" src="https://github.com/user-attachments/assets/5bfc81a9-38d7-45f2-b9a1-578484a23abe" />
<p/>
    
While in there, I also improved the legibility of the existing zoom/rotate icons, which were hard to read at footer size.

Before:
<img width="100%" alt="zoom and rotate icons before" src="https://github.com/user-attachments/assets/1a1018a8-9e0c-421d-857d-c7a68ee4d255" />

After:
<img width="100%" alt="zoom and rotate icons after" src="https://github.com/user-attachments/assets/654f2247-d843-4a3d-a602-c038e4d4361f" />

## Changes

**Page indicator + jump-to-page** 
- Shows `Page n / N` in the combined-view footer, next to the zoom/rotate controls.
- The number tracks the page at the **centre of the viewport** as you scroll.
- It's an editable field: click it (the field clears), type a page, press **Enter** (or click away) to jump. **Esc** cancels.
- Out-of-range values clamp to `1…N`; no-op jumps (the page you're already on) are ignored.

**Footer icon legibility**
- Switched zoom/rotate from Material to Font Awesome glyphs (already used elsewhere in Giant) and bumped the size from ~13px to 17px, so the `+`/`−` and rotation direction are actually visible.

## Implementation notes

- No backend changes — page count already comes from `/api/pages2/{uri}/pageCount`.
- `VirtualScroll` reports the centre page via `onVisiblePageChange`, computed directly from scroll position rather than the debounced `pageRange.middle`, so the readout doesn't lag during fast scrolls.
- The old unused `jumpToPage` prop became a nonce-carrying `jumpRequest`, so the same target can be requested repeatedly and a zoom-driven `pageHeight` change no longer re-applies a stale jump.

## Testing

Local
- [x] Local
- [x] Playground - e.g. [this file](https://playground.pfi.gutools.co.uk/viewer/m6sv67LRucUnrJeUTqyaYA8iXdFbWWnDsfhhhxcStUsy4XE0T1M17OPsWRB-o-8u8fibcTux4ClSbV_KPUO9wQ?navId=6e753dca-0813-4add-a5fb-e04e01304241&navIndex=0&view=combined)

*Test note*: Jump lands at the top of the target page, while the readout reports the centre page — so jumping to page 5 may immediately read "5" or "6" depending on zoom level. This is intentional, but flagging it as it can look like an off-by-one.
