### PR TITLE
Index WorkspaceNode.uri to speed up blob deletion and access checks

### DIFF
--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -40,6 +40,10 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
         tx.run("CREATE CONSTRAINT IF NOT EXISTS FOR (workspace :Workspace) REQUIRE workspace.id IS UNIQUE")
         tx.run("CREATE CONSTRAINT IF NOT EXISTS FOR (node :WorkspaceNode) REQUIRE node.id IS UNIQUE")
         tx.run("CREATE CONSTRAINT IF NOT EXISTS FOR (comment :Comment) REQUIRE comment.id IS UNIQUE")
+        // WorkspaceNode is looked up by uri (not just id) when deleting a blob. Without this index
+        // that lookup is a label scan over every WorkspaceNode on every delete, which dominates the
+        // delete cost as the number of workspace items grows. (id is already unique-constrained.)
+        tx.run("CREATE INDEX IF NOT EXISTS FOR (node :WorkspaceNode) ON (node.uri)")
         Right(())
       }
     } yield Right(())


### PR DESCRIPTION
Very long PR description for a single-line change! Adds a single Neo4j index on `WorkspaceNode.uri`, created idempotently in `Neo4jAnnotations.setup()`:

```cypher
CREATE INDEX IF NOT EXISTS FOR (node :WorkspaceNode) ON (node.uri)
```

### Why 

I was looking at the slowness (and frequent timeouts) of single-file deletes. I knew that there's a heap of cleanup necessary (e.g. if something is in multiple workspaces, if there are duplicate files across datasets etc), but with help from Monsieur Claude, the Neo4j cost appeared not to be the descendant cleanup (served by the `Resource.uri` range index) but actually a **`WorkspaceNode {uri}` lookup that had no index**. 

`WorkspaceNode` is uniquely constrained on `id`, but several queries look it up by `uri`, which forced a `NodeByLabelScan` over *every* `WorkspaceNode` on each call. Consequently the cost grows with the total number of items across all workspaces.

### What this change should do

Two queries show significant benefit:
- **`deleteBlob`** — the `OPTIONAL MATCH (w:WorkspaceNode {uri})` in the blob-delete query.
- **`getWorkspacesForBlob`** — `MATCH (w:WorkspaceNode {uri})-[:PART_OF]->(workspace)`, which previously expanded every `PART_OF` edge.

> [!NOTE]
> A third uri-keyed query, `getWorkspaceChildrenWithUri` (workspace upload path), is already efficient — it anchors on the unique-indexed parent `WorkspaceNode {id}` and only filters the target folder's direct children — so it neither needs nor is harmed by this new index.

### Measured impact (playground)

NB at the time of writing Plaground has 112,557 Workspace nodes.

I used a throwaway PROFILE diagnostic branch ([ljh-diag-workspacenode-uri-profile](https://github.com/guardian/giant/tree/ljh-diag-workspacenode-uri-profile)) to measure `deleteBlob` and `getWorkspacesForBlob` before and after creating the index (non-destructive — the branch creates then drops the index):

| Query | Before (DB hits) | After (DB hits) | Operator: before → after |
|---|---:|---:|---|
| `getWorkspacesForBlob` | 229,359 | 177 | `Expand(All)` over ~112k `PART_OF` edges → `NodeIndexSeek` |
| `deleteBlob` WorkspaceNode lookup | 450,250 | 26 | `NodeByLabelScan` over ~225k rows → `NodeIndexSeek` (6 hits) |

### Relevance to the workspace-performance epic (#369) and lazy loading (#744)

**Orthogonal.** The workspace tree-load and lazy-loading hot paths traverse from the `Workspace` by relationships and key `WorkspaceNode` on `id`; they never look it up by `uri`, so this index doesn't touch them. (A separate PROFILE of `getWorkspaceContents` on a synthetic 50k-item workspace showed ~2M DB hits / ~25 MB held in memory, linear in tree size — confirming #369 is structural, i.e. whole-tree fetch + per-node status, not a missing index.) This change complements that work but does not substitute for it.

### What calls the affected functions

- **`deleteBlob`** → `DeleteResource` (single-file delete from the UI: `Workspaces.deleteBlob` / `Blobs.delete`) and the CLI's ingestion/collection deletion (`DeleteIngestions`, which loops per blob).
- **`getWorkspacesForBlob`** → `Blobs.userHasViewAccessToBlob`, an access-control check run when viewing/deleting a blob that isn't already visible to the user via a collection.

## Building the index on existing data

On first deploy, `setup()` runs `CREATE INDEX IF NOT EXISTS`, which Neo4j builds **online / in the background**: no write lock, no downtime, and `CREATE INDEX` returns immediately, so **app startup is not blocked** waiting for population (unlike the diagnostic, which explicitly `awaitIndexes`). Until the index reaches `ONLINE`, the affected queries simply fall back to today's scan behaviour — i.e. no worse than current. The build is a one-off cost roughly proportional to the WorkspaceNode count (on playground's ~112k it completed in ~a couple of seconds); `IF NOT EXISTS` makes every subsequent deploy a no-op. The only ongoing cost is a tiny per-`WorkspaceNode` write overhead, negligible against the read savings.

## How has this change been tested?
 - [x] Tested on playground — the before/after numbers above were measured against playground's live graph via a temporary, non-destructive PROFILE diagnostic (created the index, profiled, dropped it).
 - [x] Tested locally — existing `Neo4jManifest` / single-file delete integration tests still pass. This is a schema-only change, so there are no new unit tests.

### Recommended QA
- Deploy and confirm a `RANGE` index on `WorkspaceNode(uri)` appears in `SHOW INDEXES` and reaches `ONLINE`.
- Delete a file in a large workspace; confirm it still deletes correctly and the `Delete blob from neo4j: took …` timing log drops.
- Spot-check that view-access for a workspace-only (non-collection) file still behaves correctly.

## User-facing impact

Single-file deletes and blob access-checks get faster and no longer deteriorate as the number of workspace items grows.