### PR TITLE
Fix workspace tree keyboard navigation and scroll behaviour

### DIFF
--- a/frontend/src/js/components/UtilComponents/TreeBrowser/Leaf.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/Leaf.tsx
@@ -62,6 +62,14 @@ export default class Leaf<T> extends React.Component<Props<T>, {}> {
 
   onKeyDown = (e: React.KeyboardEvent<HTMLTableRowElement>) => {
     e.stopPropagation();
+
+    // The arrow keys drive selection and expansion. Prevent the browser's
+    // native arrow-scroll, which otherwise fights the focus-driven scroll and
+    // shoves the selected row up out of view behind the toolbar.
+    if (e.key.startsWith("Arrow")) {
+      e.preventDefault();
+    }
+
     switch (e.key) {
       case "Enter":
         this.props.onSelect(this.props.entry);

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
@@ -78,6 +78,13 @@ export default class Node<T> extends React.Component<Props<T>, State> {
   onKeyDown = (e: React.KeyboardEvent<HTMLTableRowElement>) => {
     e.stopPropagation();
 
+    // The arrow keys drive selection and expand/collapse. Prevent the browser's
+    // native arrow-scroll, which otherwise fights the focus-driven scroll and
+    // shoves the selected row up out of view behind the toolbar.
+    if (e.key.startsWith("Arrow")) {
+      e.preventDefault();
+    }
+
     switch (e.key) {
       case "Escape":
         this.props.clearFocus();

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/Node.tsx
@@ -316,6 +316,11 @@ export default class Node<T> extends React.Component<Props<T>, State> {
   }
 
   render() {
+    // Child refs are pushed (not assigned) by the ref callbacks below, and
+    // unmounted children never remove themselves, so the array must be reset
+    // each render to avoid retaining stale/detached rows (mirrors index.tsx).
+    this.childReactComponents = [];
+
     const { hoveredOver } = this.state;
     const focused = this.isFocused();
     const selected = this.isSelected();

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/keyboardNavigation.spec.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/keyboardNavigation.spec.tsx
@@ -162,4 +162,22 @@ describe("workspace tree keyboard navigation", () => {
     // Only the deliberate middle collapse — not a second one from the final Enter.
     expect(handlers.onCollapseNode).toHaveBeenCalledTimes(1);
   });
+
+  // Arrow keys must cancel their default action, otherwise the browser's native
+  // scroll fights the focus-driven scroll and pushes the selected row out of view.
+  it("prevents the default (native scroll) on arrow keys", () => {
+    mount();
+    rowByName(container, "folder").focus();
+
+    const arrowDown = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      (document.activeElement as HTMLElement).dispatchEvent(arrowDown);
+    });
+
+    expect(arrowDown.defaultPrevented).toBe(true);
+  });
 });

--- a/frontend/src/js/components/UtilComponents/TreeBrowser/keyboardNavigation.spec.tsx
+++ b/frontend/src/js/components/UtilComponents/TreeBrowser/keyboardNavigation.spec.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { act, Simulate } from "react-dom/test-utils";
+import TreeBrowser from "./index";
+import {
+  ColumnsConfig,
+  TreeEntry,
+  TreeLeaf,
+  TreeNode,
+} from "../../../types/Tree";
+
+// A folder containing a single openable child.
+const child: TreeLeaf<null> = {
+  id: "child",
+  name: "child",
+  data: null,
+  isExpandable: false,
+};
+const folder: TreeNode<null> = {
+  id: "folder",
+  name: "folder",
+  data: null,
+  children: [child],
+};
+
+const columnsConfig: ColumnsConfig<null> = {
+  sortDescending: false,
+  sortColumn: "name",
+  columns: [
+    {
+      name: "name",
+      align: "left",
+      style: {},
+      render: (entry: TreeEntry<null>) => <span>{entry.name}</span>,
+      sort: (a, b) => a.name.localeCompare(b.name),
+    },
+  ],
+};
+
+const handlers = {
+  onSelectLeaf: jest.fn(),
+  onExpandNode: jest.fn(),
+  onCollapseNode: jest.fn(),
+};
+
+// Mirrors the Workspaces container: it owns expanded/focused/selected state, so
+// that handler calls produce the re-renders that exercise the keyboard paths.
+// The whole tree is in memory up-front, as it is for the workspace view.
+class Harness extends React.Component<
+  {},
+  {
+    expanded: TreeEntry<null>[];
+    focused: TreeEntry<null> | null;
+    selected: TreeEntry<null>[];
+  }
+> {
+  state = {
+    expanded: [] as TreeEntry<null>[],
+    focused: null as TreeEntry<null> | null,
+    selected: [] as TreeEntry<null>[],
+  };
+
+  render() {
+    return (
+      <TreeBrowser<null>
+        rootId="root"
+        tree={[folder]}
+        showColumnHeaders={false}
+        columnsConfig={columnsConfig}
+        selectedEntries={this.state.selected}
+        focusedEntry={this.state.focused}
+        expandedEntries={this.state.expanded}
+        clearFocus={() => this.setState({ focused: null })}
+        onFocus={(entry) => this.setState({ focused: entry })}
+        onSelectLeaf={(leaf) => {
+          handlers.onSelectLeaf(leaf.id);
+          this.setState({ selected: [leaf] });
+        }}
+        onExpandLeaf={() => {}}
+        onExpandNode={(entry) => {
+          handlers.onExpandNode(entry.id);
+          this.setState((s) => ({ expanded: [...s.expanded, entry] }));
+        }}
+        onCollapseNode={(entry) => {
+          handlers.onCollapseNode(entry.id);
+          this.setState((s) => ({
+            expanded: s.expanded.filter((e) => e.id !== entry.id),
+          }));
+        }}
+        onMoveItems={() => {}}
+        onClickColumn={() => {}}
+        onContextMenu={() => {}}
+      />
+    );
+  }
+}
+
+function rowByName(container: HTMLElement, name: string): HTMLElement {
+  const row = Array.from(container.querySelectorAll("tr")).find((r) =>
+    Array.from(r.querySelectorAll("span")).some((s) => s.textContent === name),
+  );
+  if (!row) throw new Error(`No tree row found for "${name}"`);
+  return row as HTMLElement;
+}
+
+// Deliver a key to whichever row currently holds focus, as a browser would.
+function press(key: string) {
+  const el = document.activeElement;
+  if (!el) throw new Error("No focused element to receive the key press");
+  act(() => {
+    Simulate.keyDown(el, { key });
+  });
+}
+
+describe("workspace tree keyboard navigation", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+  });
+
+  function mount() {
+    act(() => {
+      ReactDOM.render(<Harness />, container);
+    });
+  }
+
+  it("ArrowDown into an expanded folder then Enter opens the child", () => {
+    mount();
+    rowByName(container, "folder").focus(); // tab into the tree
+
+    press("Enter"); // expand the folder
+    press("ArrowDown"); // move focus onto the child
+    press("Enter"); // open the child
+
+    expect(handlers.onSelectLeaf).toHaveBeenCalledWith("child");
+    expect(handlers.onCollapseNode).not.toHaveBeenCalled();
+  });
+
+  // Regression: a child row that unmounts on collapse used to leave a stale ref
+  // behind in Node, so after re-expanding, ArrowDown focused a detached row
+  // (a no-op) and the next Enter re-collapsed the folder instead of opening the
+  // child. See Node.render resetting childReactComponents.
+  it("opens the child after the folder is collapsed and re-expanded", () => {
+    mount();
+    rowByName(container, "folder").focus();
+
+    press("Enter"); // expand
+    press("Enter"); // collapse
+    press("Enter"); // re-expand
+    press("ArrowDown"); // must land on the live child row
+    press("Enter"); // must open the child, not re-collapse the folder
+
+    expect(handlers.onSelectLeaf).toHaveBeenCalledWith("child");
+    // Only the deliberate middle collapse — not a second one from the final Enter.
+    expect(handlers.onCollapseNode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/stylesheets/components/_workspace.scss
+++ b/frontend/src/stylesheets/components/_workspace.scss
@@ -1,6 +1,8 @@
 .workspace {
   width: calc(100vw - #{$sidebarWidth} - #{$baseSpacing * 4});
   height: calc(100vh - #{$headerHeight} - 115px);
+  display: flex;
+  flex-direction: column;
 
   &__header {
     display: flex;
@@ -134,18 +136,24 @@
 
 .workspace__tree {
   position: relative;
-  height: 100%;
+  // Fill the space left by the toolbar above, rather than height:100% (which
+  // resolves to the full .workspace height and ignores the toolbar, pushing the
+  // scroll viewport's bottom off-screen).
+  flex: 1 1 auto;
+  min-height: 0;
   width: 100%;
   display: flex;
   flex-direction: column;
   overflow: auto;
 
   &--fixed {
+    flex: none;
     height: 300px;
   }
 
   &-header {
     display: flex;
+    flex: 0 0 auto;
     justify-content: space-between;
     gap: $baseSpacing;
   }


### PR DESCRIPTION
This addresses three related bugs in the workspace tree view.

### 1. Folder re-collapses instead of opening the child (after collapse + re-expand)
`Node` accumulated child component refs by *pushing* in the ref callback but never resetting the array — unlike `TreeBrowser/index.tsx`, which resets it each render. When a child row unmounts on collapse its stale, detached ref stayed at index 0; on re-expand, CursorDown focused that detached row (a no-op), leaving DOM focus on the folder, so the next Return keystroke re-collapsed the parent folder instead of acting on the "selected" item. Whereas a direct mouse click focuses the live row properly, so Return opens it, as you'd expect. 

Fix: reset `childReactComponents` each render in `Node`.

### 2. Selected row scrolls up behind the toolbar during keyboard nav
The row key handlers moved the selection on arrow keys but never called `preventDefault`, so the browser *also* ran its native cursor scroll. That extra scroll fought the focus-driven `scrollIntoView` and pushed the selected row up out of view behind the "New Folder / last refreshed" toolbar. 

Fix: cancel the default for arrow keys in `Node` and `Leaf`, making both selection change and scroll behaviour more like that seen in the MacOS Finder.

### 3. Bottom of the scroll viewport sat off-screen
`.workspace__tree` used `height: 100%` inside a non-flex `.workspace`, so it resolved to the full workspace height and ignored the 50px toolbar above it, pushing the bottom of the scroll area off-screen. 

Fix: make `.workspace` a flex column and let the tree flex into the remaining space. (Separate, smaller issue from #2 — kept here as it's adjacent.)

Before:

<img width="100%" alt="before" src="https://github.com/user-attachments/assets/2dbb6d54-382f-4f2b-9254-97235d1c3f42" />

After:

<img width="100%" alt="after" src="https://github.com/user-attachments/assets/3fd61794-26d8-4965-88ce-46d72897e4d0" />


## Testing
- [x] Local dev.
- Monsieur Claude tells me that `keyboardNavigation.spec.tsx` has the repo's first component-mount tests (hand-rolled `ReactDOM.render` + `act` + `Simulate`, as there's no testing-library) — flagging in case this pattern is not acceptable. We could just remove the test. 