### PR TITLE
Take search results to the Combined view when the match is there

### DIFF
--- a/backend/app/controllers/api/PagesController.scala
+++ b/backend/app/controllers/api/PagesController.scala
@@ -19,17 +19,32 @@ import utils.controller.{AuthApiController, AuthControllerComponents}
 class PagesController(val controllerComponents: AuthControllerComponents, manifest: Manifest,
     index: Index, pagesService: Pages2, annotations: Annotations, previewStorage: ObjectStorage) extends AuthApiController {
 
-  def getPageCount(uri: Uri) = ApiAction.attempt { req =>
+  def getPageCount(uri: Uri, q: Option[String]) = ApiAction.attempt { req =>
     val countAttempt = pagesService.getPageCount(uri)
     val dimensionsAttempt = pagesService.getFirstPageDimensions(uri)
       .recoverWith { case _ => Attempt.Right(None) }
+    // Answers "would the Combined view show a match for this search?" alongside
+    // the count, so the frontend can choose the initial view for a document
+    // opened from search results in a single round trip (issues #733 / #760).
+    // A failure here (e.g. a query elasticsearch can't parse) must not stop the
+    // document opening: it reports as "no match", which keeps the search-forced
+    // flat view.
+    val searchMatchAttempt = Attempt.sequenceOption(
+      q.filter(_.trim.nonEmpty).map { query =>
+        Attempt.catchNonFatalBlasé(Chips.parseQueryString(query).query)
+          .flatMap(parsed => pagesService.hasSearchMatch(uri, parsed))
+          .recoverWith { case _ => Attempt.Right(false) }
+      }
+    )
     for {
       count <- countAttempt
       dimensions <- dimensionsAttempt
+      searchMatchesInPages <- searchMatchAttempt
     } yield {
       Ok(Json.obj(
         "pageCount" -> count,
-        "dimensions" -> dimensions
+        "dimensions" -> dimensions,
+        "searchMatchesInPages" -> searchMatchesInPages
       ))
     }
   }

--- a/backend/app/services/index/Pages2.scala
+++ b/backend/app/services/index/Pages2.scala
@@ -151,6 +151,23 @@ class Pages2(val client: ElasticClient, indexNamePrefix: String)(implicit val ex
     }
   }
 
+  // Cheap existence check: does the query match anywhere in this document's
+  // pages? A single count query — unlike findInPages + the geometry pipeline
+  // behind findInDocument/searchInDocument, this never touches S3 or computes
+  // highlight geometry. Used to decide the initial view for a document opened
+  // from search results (issues #733 / #760).
+  def hasSearchMatch(uri: Uri, query: String): Attempt[Boolean] = {
+    execute {
+      count(textIndexName).query(
+        must(buildQuery(query)).filter(
+          termQuery(PagesFields.resourceId, uri.value)
+        )
+      )
+    }.map { resp =>
+      resp.count > 0
+    }
+  }
+
   private def buildQuery(query: String) =
     queryStringQuery(query)
     .defaultOperator("and")

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -43,7 +43,7 @@ DELETE        /api/comments/:commentId                                      cont
 GET           /api/pages/text/:uri                                          controllers.api.Resource.getTextPages(uri: model.Uri, top: Double, bottom: Double, q: Option[String], language: Option[model.Language])
 GET           /api/pages/preview/:language/:uri/:pageNumber                 controllers.api.Resource.getPagePreview(uri: model.Uri, language: model.Language, pageNumber: Int)
 
-GET           /api/pages2/:uri/pageCount                                    controllers.api.PagesController.getPageCount(uri: model.Uri)
+GET           /api/pages2/:uri/pageCount                                    controllers.api.PagesController.getPageCount(uri: model.Uri, q: Option[String])
 GET           /api/pages2/:uri/find                                         controllers.api.PagesController.findInDocument(uri: model.Uri, q: String)
 GET           /api/pages2/:uri/search                                       controllers.api.PagesController.searchInDocument(uri: model.Uri, q: String)
 GET           /api/pages2/:uri/:pageNumber/preview                          controllers.api.PagesController.getPagePreview(uri: model.Uri, pageNumber: Int)

--- a/backend/test/services/index/ElasticsearchPagesITest.scala
+++ b/backend/test/services/index/ElasticsearchPagesITest.scala
@@ -126,5 +126,43 @@ class ElasticsearchPagesITest extends AnyFreeSpec with Matchers with BeforeAndAf
         result shouldBe None
       }
     }
+
+    "hasSearchMatch" - {
+      val uri = Uri("has-search-match-test")
+      val page = Page(page = 1, Map(English -> "brown fox jumped near hedge"), PageDimensions.A4_PORTRAIT)
+
+      "return true when the query matches the document's pages" in {
+        elasticsearchTestService.elasticPages.addPageContents(uri, Seq(page)).successValue
+
+        pages2.hasSearchMatch(uri, "fox").successValue shouldBe true
+      }
+
+      "return false when the query does not match" in {
+        elasticsearchTestService.elasticPages.addPageContents(uri, Seq(page)).successValue
+
+        pages2.hasSearchMatch(uri, "badger").successValue shouldBe false
+      }
+
+      "respect quoted phrases" in {
+        elasticsearchTestService.elasticPages.addPageContents(uri, Seq(page)).successValue
+
+        pages2.hasSearchMatch(uri, "\"brown fox\"").successValue shouldBe true
+        pages2.hasSearchMatch(uri, "\"fox brown\"").successValue shouldBe false
+      }
+
+      "not match content from other documents" in {
+        val otherUri = Uri("has-search-match-other-doc")
+        val otherPage = Page(page = 1, Map(English -> "badger slept here"), PageDimensions.A4_PORTRAIT)
+        elasticsearchTestService.elasticPages.addPageContents(uri, Seq(page)).successValue
+        elasticsearchTestService.elasticPages.addPageContents(otherUri, Seq(otherPage)).successValue
+
+        pages2.hasSearchMatch(uri, "badger").successValue shouldBe false
+        pages2.hasSearchMatch(otherUri, "badger").successValue shouldBe true
+      }
+
+      "return false for a document with no pages" in {
+        pages2.hasSearchMatch(Uri("has-search-match-no-pages"), "fox").successValue shouldBe false
+      }
+    }
   }
 }

--- a/frontend/src/js/components/PageViewer/resolveInitialPagedView.spec.ts
+++ b/frontend/src/js/components/PageViewer/resolveInitialPagedView.spec.ts
@@ -1,0 +1,119 @@
+import {
+  COMBINED_VIEW,
+  isTextLikeView,
+  resolveInitialPagedView,
+} from "./resolveInitialPagedView";
+
+describe("isTextLikeView", () => {
+  it("treats text and any ocr.* variant as text-like", () => {
+    expect(isTextLikeView("text")).toBe(true);
+    expect(isTextLikeView("ocr")).toBe(true);
+    expect(isTextLikeView("ocr.english")).toBe(true);
+  });
+
+  it("does not treat combined, transcript or other views as text-like", () => {
+    expect(isTextLikeView(COMBINED_VIEW)).toBe(false);
+    expect(isTextLikeView("transcript.english")).toBe(false);
+    expect(isTextLikeView("vttTranscript.english")).toBe(false);
+    expect(isTextLikeView("preview")).toBe(false);
+    expect(isTextLikeView("table")).toBe(false);
+  });
+});
+
+describe("resolveInitialPagedView", () => {
+  const base = {
+    totalPages: 10,
+    currentView: undefined as string | undefined,
+    hasSearchQuery: false,
+    searchMatchesInPages: null as boolean | null,
+  };
+
+  it("waits until the page count is known", () => {
+    expect(resolveInitialPagedView({ ...base, totalPages: null })).toEqual({
+      kind: "wait",
+    });
+  });
+
+  it("does nothing for non-paged documents (no Combined view exists)", () => {
+    expect(
+      resolveInitialPagedView({
+        ...base,
+        totalPages: 0,
+        currentView: "text",
+        hasSearchQuery: true,
+      }),
+    ).toEqual({ kind: "keep" });
+  });
+
+  it("defaults a paged document with no view to Combined", () => {
+    expect(
+      resolveInitialPagedView({ ...base, currentView: undefined }),
+    ).toEqual({ kind: "set", view: COMBINED_VIEW });
+  });
+
+  describe("when search has forced a text-like view", () => {
+    const forced = {
+      ...base,
+      currentView: "text",
+      hasSearchQuery: true,
+    };
+
+    it("waits for the page-match probe before deciding", () => {
+      expect(
+        resolveInitialPagedView({ ...forced, searchMatchesInPages: null }),
+      ).toEqual({ kind: "wait" });
+    });
+
+    it("switches to Combined when the match is reachable in the pages", () => {
+      expect(
+        resolveInitialPagedView({ ...forced, searchMatchesInPages: true }),
+      ).toEqual({ kind: "set", view: COMBINED_VIEW });
+    });
+
+    it("honours the forced view when the match is not in the pages", () => {
+      // e.g. lossy Tesseract OCR, cross-field, or a future translation match
+      expect(
+        resolveInitialPagedView({ ...forced, searchMatchesInPages: false }),
+      ).toEqual({ kind: "keep" });
+    });
+
+    it("applies the same logic to an ocr.* view", () => {
+      expect(
+        resolveInitialPagedView({
+          ...forced,
+          currentView: "ocr.english",
+          searchMatchesInPages: true,
+        }),
+      ).toEqual({ kind: "set", view: COMBINED_VIEW });
+    });
+  });
+
+  it("honours a text view opened without a search query", () => {
+    expect(
+      resolveInitialPagedView({
+        ...base,
+        currentView: "text",
+        hasSearchQuery: false,
+        // probe never runs, so this stays null
+        searchMatchesInPages: null,
+      }),
+    ).toEqual({ kind: "keep" });
+  });
+
+  it("honours an explicit non-text view such as transcript even during search", () => {
+    expect(
+      resolveInitialPagedView({
+        ...base,
+        currentView: "transcript.english",
+        hasSearchQuery: true,
+        searchMatchesInPages: false,
+      }),
+    ).toEqual({ kind: "keep" });
+  });
+
+  it("honours an explicit combined view", () => {
+    expect(
+      resolveInitialPagedView({ ...base, currentView: COMBINED_VIEW }),
+    ).toEqual({ kind: "keep" });
+  });
+});

--- a/frontend/src/js/components/PageViewer/resolveInitialPagedView.spec.ts
+++ b/frontend/src/js/components/PageViewer/resolveInitialPagedView.spec.ts
@@ -22,33 +22,26 @@ describe("isTextLikeView", () => {
 
 describe("resolveInitialPagedView", () => {
   const base = {
-    totalPages: 10,
+    pageCount: 10,
     currentView: undefined as string | undefined,
     hasSearchQuery: false,
-    searchMatchesInPages: null as boolean | null,
+    searchMatchesInPages: null as boolean | null | undefined,
   };
-
-  it("waits until the page count is known", () => {
-    expect(resolveInitialPagedView({ ...base, totalPages: null })).toEqual({
-      kind: "wait",
-    });
-  });
 
   it("does nothing for non-paged documents (no Combined view exists)", () => {
     expect(
       resolveInitialPagedView({
         ...base,
-        totalPages: 0,
+        pageCount: 0,
         currentView: "text",
         hasSearchQuery: true,
+        searchMatchesInPages: true,
       }),
-    ).toEqual({ kind: "keep" });
+    ).toBeUndefined();
   });
 
   it("defaults a paged document with no view to Combined", () => {
-    expect(
-      resolveInitialPagedView({ ...base, currentView: undefined }),
-    ).toEqual({ kind: "set", view: COMBINED_VIEW });
+    expect(resolveInitialPagedView(base)).toBe(COMBINED_VIEW);
   });
 
   describe("when search has forced a text-like view", () => {
@@ -58,23 +51,27 @@ describe("resolveInitialPagedView", () => {
       hasSearchQuery: true,
     };
 
-    it("waits for the page-match probe before deciding", () => {
-      expect(
-        resolveInitialPagedView({ ...forced, searchMatchesInPages: null }),
-      ).toEqual({ kind: "wait" });
-    });
-
     it("switches to Combined when the match is reachable in the pages", () => {
       expect(
         resolveInitialPagedView({ ...forced, searchMatchesInPages: true }),
-      ).toEqual({ kind: "set", view: COMBINED_VIEW });
+      ).toBe(COMBINED_VIEW);
     });
 
     it("honours the forced view when the match is not in the pages", () => {
       // e.g. lossy Tesseract OCR, cross-field, or a future translation match
       expect(
         resolveInitialPagedView({ ...forced, searchMatchesInPages: false }),
-      ).toEqual({ kind: "keep" });
+      ).toBeUndefined();
+    });
+
+    it("honours the forced view when the answer is unknown", () => {
+      // e.g. a backend that predates the searchMatchesInPages parameter
+      expect(
+        resolveInitialPagedView({ ...forced, searchMatchesInPages: null }),
+      ).toBeUndefined();
+      expect(
+        resolveInitialPagedView({ ...forced, searchMatchesInPages: undefined }),
+      ).toBeUndefined();
     });
 
     it("applies the same logic to an ocr.* view", () => {
@@ -84,7 +81,7 @@ describe("resolveInitialPagedView", () => {
           currentView: "ocr.english",
           searchMatchesInPages: true,
         }),
-      ).toEqual({ kind: "set", view: COMBINED_VIEW });
+      ).toBe(COMBINED_VIEW);
     });
   });
 
@@ -94,26 +91,26 @@ describe("resolveInitialPagedView", () => {
         ...base,
         currentView: "text",
         hasSearchQuery: false,
-        // probe never runs, so this stays null
+        // no query is sent with the pageCount request, so this stays null
         searchMatchesInPages: null,
       }),
-    ).toEqual({ kind: "keep" });
+    ).toBeUndefined();
   });
 
-  it("honours an explicit non-text view such as transcript even during search", () => {
+  it("honours a non-text view such as transcript even when the pages match", () => {
     expect(
       resolveInitialPagedView({
         ...base,
         currentView: "transcript.english",
         hasSearchQuery: true,
-        searchMatchesInPages: false,
+        searchMatchesInPages: true,
       }),
-    ).toEqual({ kind: "keep" });
+    ).toBeUndefined();
   });
 
   it("honours an explicit combined view", () => {
     expect(
       resolveInitialPagedView({ ...base, currentView: COMBINED_VIEW }),
-    ).toEqual({ kind: "keep" });
+    ).toBeUndefined();
   });
 });

--- a/frontend/src/js/components/PageViewer/resolveInitialPagedView.ts
+++ b/frontend/src/js/components/PageViewer/resolveInitialPagedView.ts
@@ -1,0 +1,89 @@
+export const COMBINED_VIEW = "combined";
+
+/**
+ * Views whose content is derived from the page text that backs the Combined
+ * view, and which Elasticsearch therefore highlights against fields the page
+ * index also contains (`text`, `ocr`). A match in one of these is normally also
+ * reachable in Combined.
+ *
+ * Transcript / vttTranscript views are deliberately excluded: that content does
+ * not live in the page index, and audio/video documents have no pages anyway.
+ * The same will apply to any future translation view.
+ */
+export function isTextLikeView(view: string): boolean {
+  return view === "text" || view.startsWith("ocr");
+}
+
+type ViewResolution =
+  // Not enough information yet (page count or page-match probe still pending);
+  // call again when more state arrives.
+  | { kind: "wait" }
+  // Honour the current view.
+  | { kind: "keep" }
+  // Switch to this view.
+  | { kind: "set"; view: string };
+
+/**
+ * Decide which view a paged document should open in.
+ *
+ * Background (issues #733 / #760): Elasticsearch has no concept of the
+ * "Combined" view — it is assembled in the frontend from the page index. So
+ * search picks the document field with the most highlights (e.g. `text`,
+ * `ocr.english`) and forces that view via `?view=…`, which then suppresses the
+ * Combined default and lands the user in flat text/OCR even when Combined would
+ * show the same match in the view we actually want people to use.
+ *
+ * This resolves that: for a paged document we prefer Combined whenever the
+ * search query is also reachable there (`searchMatchesInPages`), and only fall
+ * back to the search-forced flat view when it is not — e.g. lossy Tesseract OCR,
+ * cross-field matches, or future translation matches that don't exist in the
+ * page index. A document opened without a search query, or with an explicit
+ * non-text view, is left untouched.
+ *
+ * The caller applies this once per document load so that a user manually
+ * switching to the Text/OCR tab afterwards is respected.
+ */
+export function resolveInitialPagedView({
+  totalPages,
+  currentView,
+  hasSearchQuery,
+  searchMatchesInPages,
+}: {
+  totalPages: number | null;
+  currentView: string | undefined;
+  hasSearchQuery: boolean;
+  // null = the page-match probe has not resolved yet.
+  searchMatchesInPages: boolean | null;
+}): ViewResolution {
+  // Wait until we know whether the document is paged.
+  if (totalPages === null) {
+    return { kind: "wait" };
+  }
+
+  // No pages means there is no Combined view to prefer.
+  if (totalPages <= 0) {
+    return { kind: "keep" };
+  }
+
+  // Paged document with no view yet → default to Combined (existing behaviour,
+  // e.g. opening from an ingestion or workspace).
+  if (!currentView) {
+    return { kind: "set", view: COMBINED_VIEW };
+  }
+
+  // Search forced a text-like view. Prefer Combined when the match is reachable
+  // there; otherwise honour the forced view so the user still lands on a real
+  // match.
+  if (hasSearchQuery && isTextLikeView(currentView)) {
+    if (searchMatchesInPages === null) {
+      return { kind: "wait" };
+    }
+    return searchMatchesInPages
+      ? { kind: "set", view: COMBINED_VIEW }
+      : { kind: "keep" };
+  }
+
+  // Any other explicit view (Combined, preview, table, transcript, or a
+  // text-like view opened without a search query) → honour it.
+  return { kind: "keep" };
+}

--- a/frontend/src/js/components/PageViewer/resolveInitialPagedView.ts
+++ b/frontend/src/js/components/PageViewer/resolveInitialPagedView.ts
@@ -14,17 +14,10 @@ export function isTextLikeView(view: string): boolean {
   return view === "text" || view.startsWith("ocr");
 }
 
-type ViewResolution =
-  // Not enough information yet (page count or page-match probe still pending);
-  // call again when more state arrives.
-  | { kind: "wait" }
-  // Honour the current view.
-  | { kind: "keep" }
-  // Switch to this view.
-  | { kind: "set"; view: string };
-
 /**
- * Decide which view a paged document should open in.
+ * Decide which view a paged document should open in, given its pageCount
+ * response (which also answers whether the search query matches in the page
+ * index — see getPageCount).
  *
  * Background (issues #733 / #760): Elasticsearch has no concept of the
  * "Combined" view — it is assembled in the frontend from the page index. So
@@ -33,57 +26,53 @@ type ViewResolution =
  * Combined default and lands the user in flat text/OCR even when Combined would
  * show the same match in the view we actually want people to use.
  *
- * This resolves that: for a paged document we prefer Combined whenever the
- * search query is also reachable there (`searchMatchesInPages`), and only fall
- * back to the search-forced flat view when it is not — e.g. lossy Tesseract OCR,
+ * This resolves that: prefer Combined whenever the search query is also
+ * reachable there (`searchMatchesInPages`), and only fall back to the
+ * search-forced flat view when it is not — e.g. lossy Tesseract OCR,
  * cross-field matches, or future translation matches that don't exist in the
  * page index. A document opened without a search query, or with an explicit
  * non-text view, is left untouched.
  *
- * The caller applies this once per document load so that a user manually
- * switching to the Text/OCR tab afterwards is respected.
+ * Returns the view to switch to, or undefined to leave the current view alone.
+ * The caller runs this once per pageCount response, so a user manually
+ * switching tabs afterwards is never overridden.
  */
 export function resolveInitialPagedView({
-  totalPages,
+  pageCount,
   currentView,
   hasSearchQuery,
   searchMatchesInPages,
 }: {
-  totalPages: number | null;
+  pageCount: number;
   currentView: string | undefined;
   hasSearchQuery: boolean;
-  // null = the page-match probe has not resolved yet.
-  searchMatchesInPages: boolean | null;
-}): ViewResolution {
-  // Wait until we know whether the document is paged.
-  if (totalPages === null) {
-    return { kind: "wait" };
-  }
-
+  // true/false from the backend when a query was sent; null or undefined when
+  // no query was sent, or from a backend that predates the parameter.
+  searchMatchesInPages: boolean | null | undefined;
+}): string | undefined {
   // No pages means there is no Combined view to prefer.
-  if (totalPages <= 0) {
-    return { kind: "keep" };
+  if (pageCount <= 0) {
+    return undefined;
   }
 
   // Paged document with no view yet → default to Combined (existing behaviour,
   // e.g. opening from an ingestion or workspace).
   if (!currentView) {
-    return { kind: "set", view: COMBINED_VIEW };
+    return COMBINED_VIEW;
   }
 
-  // Search forced a text-like view. Prefer Combined when the match is reachable
-  // there; otherwise honour the forced view so the user still lands on a real
-  // match.
-  if (hasSearchQuery && isTextLikeView(currentView)) {
-    if (searchMatchesInPages === null) {
-      return { kind: "wait" };
-    }
-    return searchMatchesInPages
-      ? { kind: "set", view: COMBINED_VIEW }
-      : { kind: "keep" };
+  // Search forced a text-like view: prefer Combined when the match is known to
+  // be reachable there; otherwise honour the forced view so the user still
+  // lands on a real match.
+  if (
+    hasSearchQuery &&
+    isTextLikeView(currentView) &&
+    searchMatchesInPages === true
+  ) {
+    return COMBINED_VIEW;
   }
 
-  // Any other explicit view (Combined, preview, table, transcript, or a
-  // text-like view opened without a search query) → honour it.
-  return { kind: "keep" };
+  // Honour any other explicit view (Combined, preview, table, transcript, or a
+  // text-like view without a search query or without a page match).
+  return undefined;
 }

--- a/frontend/src/js/components/PageViewer/useHighlightNavigation.ts
+++ b/frontend/src/js/components/PageViewer/useHighlightNavigation.ts
@@ -48,13 +48,19 @@ export function useHighlightNavigation(
 
       setQuery(q);
       setIsPending(true);
-      // TODO: handle error
       return authFetch(`/api/pages2/${uri}/${endpoint}?${params.toString()}`)
         .then((res) => res.json())
         .then((results: HighlightForSearchNavigation[]) => {
           setIsPending(false);
           setHighlights(results);
           setFocusedIndex(results.length > 0 ? 0 : null);
+        })
+        .catch(() => {
+          // e.g. the document has no page index; treat as no highlights rather
+          // than letting the rejection surface as an uncaught runtime error.
+          setIsPending(false);
+          setHighlights([]);
+          setFocusedIndex(null);
         });
     },
     [uri, endpoint],

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useRef, useState } from "react";
+import React, { FC, useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import authFetch from "../util/auth/authFetch";
 import { useParams } from "react-router-dom";
@@ -33,7 +33,6 @@ import { useWorkspaceNavigation } from "../util/workspaceNavigation";
 import { removeLastUnmatchedQuote } from "../util/stringUtils";
 import {
   COMBINED_VIEW,
-  isTextLikeView,
   resolveInitialPagedView,
 } from "./PageViewer/resolveInitialPagedView";
 
@@ -133,6 +132,10 @@ const PageViewerContent: FC<{
 type PageCountResponse = {
   pageCount: number;
   dimensions: PageDimensions | null;
+  // Whether the search query (if one was sent) matches in the page index —
+  // i.e. whether the Combined view can show it. null when no query was sent;
+  // absent from backends that predate the parameter.
+  searchMatchesInPages?: boolean | null;
 };
 
 const SearchStepperOverlay: FC<{
@@ -228,12 +231,66 @@ export const PageViewerOrFallback: FC<{}> = () => {
   );
   const dispatch = useDispatch();
 
+  const searchQuery = searchParams.get("q") ?? undefined;
+
   useEffect(() => {
-    authFetch(`/api/pages2/${uri}/pageCount`)
+    let cancelled = false;
+
+    // Sending the search query along with the pageCount request lets the
+    // backend also tell us whether the query matches in the page index — i.e.
+    // whether the Combined view could show it. Elasticsearch can't answer that
+    // during search itself because it has no notion of the Combined view
+    // (issues #733 / #760).
+    const params = new URLSearchParams();
+    if (searchQuery) {
+      // The backend will respect quotes and do an exact search, but if quotes
+      // are unbalanced elasticsearch will error
+      params.set("q", removeLastUnmatchedQuote(searchQuery));
+    }
+    const queryString = params.toString();
+    const suffix = queryString ? `?${queryString}` : "";
+
+    authFetch(`/api/pages2/${uri}/pageCount${suffix}`)
       .then((res) => res.json())
-      .then((obj: PageCountResponse) => setResponse({ ...obj, uri }))
-      .catch(() => setResponse({ pageCount: 0, dimensions: null, uri }));
-  }, [uri]);
+      .then((obj: PageCountResponse) => {
+        if (cancelled) {
+          return;
+        }
+
+        // Decide the initial view once per document load, right as its data
+        // arrives, so a user manually switching tabs afterwards is never
+        // overridden (see resolveInitialPagedView). The current view is read
+        // from the URL, which the middleware keeps in sync with the store.
+        const currentView =
+          new URLSearchParams(window.location.search).get("view") ?? undefined;
+        const target = resolveInitialPagedView({
+          pageCount: obj.pageCount,
+          currentView,
+          hasSearchQuery: Boolean(searchQuery),
+          searchMatchesInPages: obj.searchMatchesInPages,
+        });
+
+        // Dispatch before setResponse so the viewer never renders a frame in
+        // the view we are about to leave.
+        if (target && target !== currentView) {
+          dispatch(setResourceView(target));
+        }
+        setResponse({ ...obj, uri });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResponse({ pageCount: 0, dimensions: null, uri });
+        }
+      });
+
+    // Discard responses from a superseded request so an out-of-order arrival
+    // (e.g. when stepping quickly between results) can't replace the current
+    // document's data — or dispatch a view change after this document has been
+    // left.
+    return () => {
+      cancelled = true;
+    };
+  }, [uri, searchQuery, dispatch]);
 
   // This component is not remounted when the :uri route param changes, so until
   // the new document's count arrives `response` still holds the previous one's.
@@ -241,84 +298,6 @@ export const PageViewerOrFallback: FC<{}> = () => {
   // rather than wrongly imposing the Combined view on the next document.
   const pageData = response && response.uri === uri ? response : null;
   const totalPages = pageData ? pageData.pageCount : null;
-
-  const searchQuery = searchParams.get("q") ?? undefined;
-
-  // We resolve the initial view once per document load so that a user manually
-  // switching tabs afterwards is respected (see resolveInitialPagedView).
-  const decidedForUri = useRef<string | null>(null);
-  // null = the page-match probe has not resolved (or wasn't needed) yet.
-  const [searchMatchesInPages, setSearchMatchesInPages] = useState<
-    boolean | null
-  >(null);
-
-  useEffect(() => {
-    decidedForUri.current = null;
-    setSearchMatchesInPages(null);
-  }, [uri]);
-
-  // When search has forced a text-like view on a paged document, probe the page
-  // index to find out whether the query is also reachable in the Combined view.
-  // Elasticsearch can't tell us this up front because it has no notion of the
-  // Combined view (issues #733 / #760). Mirrors the request the PageViewer's
-  // Controls make once Combined is active.
-  useEffect(() => {
-    if (
-      decidedForUri.current === uri ||
-      !searchQuery ||
-      !totalPages ||
-      totalPages <= 0 ||
-      !view ||
-      !isTextLikeView(view)
-    ) {
-      return;
-    }
-
-    let cancelled = false;
-    const params = new URLSearchParams();
-    params.set("q", removeLastUnmatchedQuote(searchQuery));
-
-    authFetch(`/api/pages2/${uri}/search?${params.toString()}`)
-      .then((res) => res.json())
-      .then((results: unknown) => {
-        if (!cancelled) {
-          setSearchMatchesInPages(Array.isArray(results) && results.length > 0);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          // If we can't confirm a page match, honour the search-forced view so
-          // the user still lands on a real match.
-          setSearchMatchesInPages(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [uri, searchQuery, totalPages, view]);
-
-  useEffect(() => {
-    if (decidedForUri.current === uri) {
-      return;
-    }
-
-    const resolution = resolveInitialPagedView({
-      totalPages,
-      currentView: view,
-      hasSearchQuery: Boolean(searchQuery),
-      searchMatchesInPages,
-    });
-
-    if (resolution.kind === "wait") {
-      return;
-    }
-
-    decidedForUri.current = uri;
-    if (resolution.kind === "set" && resolution.view !== view) {
-      dispatch(setResourceView(resolution.view));
-    }
-  }, [uri, totalPages, view, searchQuery, searchMatchesInPages, dispatch]);
 
   if (totalPages === null) {
     return null;

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useState } from "react";
+import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import authFetch from "../util/auth/authFetch";
 import { useParams } from "react-router-dom";
@@ -30,8 +30,12 @@ import { keyboardShortcuts } from "../util/keyboardShortcuts";
 import { KeyboardShortcut } from "./UtilComponents/KeyboardShortcut";
 import history from "../util/history";
 import { useWorkspaceNavigation } from "../util/workspaceNavigation";
-
-const COMBINED_VIEW = "combined";
+import { removeLastUnmatchedQuote } from "../util/stringUtils";
+import {
+  COMBINED_VIEW,
+  isTextLikeView,
+  resolveInitialPagedView,
+} from "./PageViewer/resolveInitialPagedView";
 
 function isCombinedOrUnset(view: string | undefined): boolean {
   return !view || view === COMBINED_VIEW;
@@ -231,12 +235,83 @@ export const PageViewerOrFallback: FC<{}> = () => {
 
   const totalPages = response?.pageCount ?? null;
 
-  // Default to "combined" when we have pages and no view is set.
+  const searchQuery = searchParams.get("q") ?? undefined;
+
+  // We resolve the initial view once per document load so that a user manually
+  // switching tabs afterwards is respected (see resolveInitialPagedView).
+  const decidedForUri = useRef<string | null>(null);
+  // null = the page-match probe has not resolved (or wasn't needed) yet.
+  const [searchMatchesInPages, setSearchMatchesInPages] = useState<
+    boolean | null
+  >(null);
+
   useEffect(() => {
-    if (totalPages && totalPages > 0 && !view) {
-      dispatch(setResourceView(COMBINED_VIEW));
+    decidedForUri.current = null;
+    setSearchMatchesInPages(null);
+  }, [uri]);
+
+  // When search has forced a text-like view on a paged document, probe the page
+  // index to find out whether the query is also reachable in the Combined view.
+  // Elasticsearch can't tell us this up front because it has no notion of the
+  // Combined view (issues #733 / #760). Mirrors the request the PageViewer's
+  // Controls make once Combined is active.
+  useEffect(() => {
+    if (
+      decidedForUri.current === uri ||
+      !searchQuery ||
+      !totalPages ||
+      totalPages <= 0 ||
+      !view ||
+      !isTextLikeView(view)
+    ) {
+      return;
     }
-  }, [totalPages, view, dispatch]);
+
+    let cancelled = false;
+    const params = new URLSearchParams();
+    params.set("q", removeLastUnmatchedQuote(searchQuery));
+
+    authFetch(`/api/pages2/${uri}/search?${params.toString()}`)
+      .then((res) => res.json())
+      .then((results: unknown) => {
+        if (!cancelled) {
+          setSearchMatchesInPages(Array.isArray(results) && results.length > 0);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          // If we can't confirm a page match, honour the search-forced view so
+          // the user still lands on a real match.
+          setSearchMatchesInPages(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [uri, searchQuery, totalPages, view]);
+
+  useEffect(() => {
+    if (decidedForUri.current === uri) {
+      return;
+    }
+
+    const resolution = resolveInitialPagedView({
+      totalPages,
+      currentView: view,
+      hasSearchQuery: Boolean(searchQuery),
+      searchMatchesInPages,
+    });
+
+    if (resolution.kind === "wait") {
+      return;
+    }
+
+    decidedForUri.current = uri;
+    if (resolution.kind === "set" && resolution.view !== view) {
+      dispatch(setResourceView(resolution.view));
+    }
+  }, [uri, totalPages, view, searchQuery, searchMatchesInPages, dispatch]);
 
   if (response === null) {
     return null;

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -227,6 +227,11 @@ export const PageViewerOrFallback: FC<{}> = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    // Clear the previous document's page count while we fetch the new one.
+    // Otherwise, because this component is not remounted when the :uri route
+    // param changes, a stale count would make us briefly treat the new
+    // document as paged (and wrongly impose the Combined view on it).
+    setResponse(null);
     authFetch(`/api/pages2/${uri}/pageCount`)
       .then((res) => res.json())
       .then((obj: PageCountResponse) => setResponse(obj))

--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -217,7 +217,9 @@ export const PageViewerOrFallback: FC<{}> = () => {
     }
   }, [highlightStepper.currentHighlight, highlightStepper.totalHighlights]);
 
-  const [response, setResponse] = useState<PageCountResponse | null>(null);
+  const [response, setResponse] = useState<
+    (PageCountResponse & { uri: string }) | null
+  >(null);
   const view = useSelector<GiantState, string | undefined>(
     (state) => state.urlParams.view,
   );
@@ -227,18 +229,18 @@ export const PageViewerOrFallback: FC<{}> = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    // Clear the previous document's page count while we fetch the new one.
-    // Otherwise, because this component is not remounted when the :uri route
-    // param changes, a stale count would make us briefly treat the new
-    // document as paged (and wrongly impose the Combined view on it).
-    setResponse(null);
     authFetch(`/api/pages2/${uri}/pageCount`)
       .then((res) => res.json())
-      .then((obj: PageCountResponse) => setResponse(obj))
-      .catch(() => setResponse({ pageCount: 0, dimensions: null }));
+      .then((obj: PageCountResponse) => setResponse({ ...obj, uri }))
+      .catch(() => setResponse({ pageCount: 0, dimensions: null, uri }));
   }, [uri]);
 
-  const totalPages = response?.pageCount ?? null;
+  // This component is not remounted when the :uri route param changes, so until
+  // the new document's count arrives `response` still holds the previous one's.
+  // Tagging it with its uri lets us treat a stale count as "not yet known"
+  // rather than wrongly imposing the Combined view on the next document.
+  const pageData = response && response.uri === uri ? response : null;
+  const totalPages = pageData ? pageData.pageCount : null;
 
   const searchQuery = searchParams.get("q") ?? undefined;
 
@@ -318,9 +320,9 @@ export const PageViewerOrFallback: FC<{}> = () => {
     }
   }, [uri, totalPages, view, searchQuery, searchMatchesInPages, dispatch]);
 
-  if (response === null) {
+  if (totalPages === null) {
     return null;
-  } else if (response.pageCount === 0) {
+  } else if (totalPages === 0) {
     return (
       <div className="document__viewer-fallback">
         <SearchStepperOverlay highlightStepper={highlightStepper} />
@@ -337,8 +339,8 @@ export const PageViewerOrFallback: FC<{}> = () => {
       <PageViewerContent
         key={uri}
         uri={uri}
-        totalPages={response.pageCount}
-        firstPageDimensions={response.dimensions ?? undefined}
+        totalPages={totalPages}
+        firstPageDimensions={pageData?.dimensions ?? undefined}
         view={view}
         findQuery={pageFind.findQuery}
         findHighlightsState={pageFind.highlightsState}
@@ -365,7 +367,7 @@ export const PageViewerOrFallback: FC<{}> = () => {
           <DocumentFooter
             uri={uri}
             workspaceNav={workspaceNav}
-            totalPages={response.pageCount}
+            totalPages={totalPages}
             pageFind={isCombinedOrUnset(view) ? pageFind : undefined}
             pageViewControls={
               isCombinedOrUnset(view) ? pageViewControls : undefined


### PR DESCRIPTION
**This change means that when you click a Giant search result for a paged document, it opens in the Combined view with the match highlighted — provided the match is actually reachable in Combined.** Previously all search results took users to the Text or OCR view even when Combined was available. 

Fixes #760. Background discussion in #733. Most of the the 350 lines are tests and comments rather than actual code changes. 

### Why

Elasticsearch has no concept of the "Combined" view — it's assembled in the frontend from the page index. Search picks the document field with the most highlights (`text`, `ocr.english`, etc) and forces that view via `?view=`, which suppressed the Combined default and dropped users into flat text/OCR even when Combined would show the same match in the view we actually want people to use.

### How

The viewer needs to know, before choosing a view, whether the search query is reachable in the page index. Elasticsearch can't say during search itself, so the answer is folded into a request the viewer already makes:

**Backend.** `GET /api/pages2/:uri/pageCount` accepts an optional `q` and returns `searchMatchesInPages` alongside the count — `true`/`false` when a query was sent, `null` otherwise. It is answered by `Pages2.hasSearchMatch`: a single Elasticsearch count query built with the same query builder as the page highlighters, so quoting and stemming semantics match exactly what the Combined view will highlight. A failed or unparseable query recovers to "no match" — opening a document can never break because of `q`. (Deliberately *not* answered via the existing `/pages2/:uri/search` endpoint, which fans out per hit page — permission check, ES multi-search, S3 PDF download, PDFBox geometry extraction — far too heavy to use as a boolean.)

**Frontend.** All decision inputs arrive in that one response, so the view is decided exactly once, inside the pageCount fetch callback, by a pure unit-tested helper (`resolveInitialPagedView`):

- paged document, no view → Combined (the existing default, e.g. opening from a workspace)
- paged document, search-forced text/OCR view, match reachable in the pages → Combined
- anything else → honour the current view

Nothing re-fires when the view changes, so a user switching to the Text/OCR tab afterwards is never overridden. The switch is dispatched before the page count is stored, so no frame ever renders in the view being left. It goes through `setResourceView`, which the middleware syncs to the URL via `replace` — no back-button trap; after a search click the URL settles on `?view=combined&q=…`.

The match-driven rule self-heals the cases where page text is *not* a superset of the document fields — lossy Tesseract-era OCR, cross-field matches, any future translation view: those answer "no match", so the search-forced flat view is kept and the user still lands on a real match.

### Behaviour

| Open via | Result |
|---|---|
| Search hit in body of a **paged** PDF (`?view=text`/`ocr`) | **Combined**, match highlighted |
| Search hit only reachable outside the pages (lossy OCR / cross-field / future translation) | forced flat view, as before |
| Search hit in a **non-paged** doc (email, plain text, image-only) | forced view, as before |
| Opened from workspace/dataset (no `?view=`) | Combined default, as before |
| User clicks Text tab after landing on Combined | stays on Text |

### Robustness

- `PageViewerOrFallback` is **not remounted** when the `/viewer/:uri` route param changes, so the cached page count is tagged with the uri it was fetched for and a mismatched count reads as "not yet known". Without this, stepping to the next/previous result imposed Combined on a non-paged document using the *previous* document's count, and 404'd.
- The pageCount fetch has a cancellation guard: a late response from a superseded request (stepping quickly between results) can neither replace the current document's data nor dispatch a view change after the document has been left.
- `useHighlightNavigation` catches fetch failures, so a pages 404 can never surface as an uncaught runtime error.
- Deploy skew: a backend without the parameter simply omits the field, which resolves to keeping the search-forced view — the pre-existing behaviour.

### A note on shared URLs

A shared `?view=text` with no query is honoured. A shared `?view=text&q=…` resolves by match reachability — it's indistinguishable from a fresh search click. This is an accepted trade-off: a `view+q` URL never preserved the sharer's intent anyway (search navigation always focuses the *first* match, so it lands on match number 1 in any view). Directing a colleague to a specific passage is better addressed by snippet/selection sharing, which encodes an anchor rather than re-running a query.

### OCR engines

Under the **OcrMyPdf** engine, page text retains the born-digital layer and adds OCR, so a `text`/`ocr` match is almost always also in the pages → answer "yes". Under the **Tesseract** engine, page text is a lossy OCR re-derivation, so a born-digital `text` match can be missing from the pages → answer "no" → the forced flat view is kept. The fix is correct under either engine; the per-document answer is what makes it robust.

### Testing

- `resolveInitialPagedView`: 11 unit tests, green.
- `ElasticsearchPagesITest`: 10/10 green, including 5 new `hasSearchMatch` cases (match, no match, quoted phrases, cross-document isolation, no pages). Local caveat: this branch predates the #755 testcontainers bump, so against Docker Engine 29+ the suite only runs with that bump applied (verified that way locally); CI runs it as-is.
- Full frontend suite 222/222; `CI=true npm run build` typechecks clean.
- Before removing WIP: a browser-level end-to-end pass of the final wiring (search click → Combined; stepping across paged/non-paged results).

### Follow-up (out of scope)

Stepping next/previous between search results navigates without a `?view=` (deliberately dropped by `buildLink`), so it always lands on the Combined default without consulting match reachability. Unifying it with the click path would mean passing the stepped-to result's `fieldWithMostHighlights` (already available on `state.search.currentResults`) through `DocumentFooter`.
