### PR TITLE
Add 'Download folder as text' to the workspace tree context menu

### DIFF
--- a/backend/app/controllers/api/Workspaces.scala
+++ b/backend/app/controllers/api/Workspaces.scala
@@ -187,6 +187,14 @@ class Workspaces(
     } yield Ok(Json.toJson(totalWordCount))
   }
 
+  def getWordCount(workspaceId: String) = ApiAction.attempt(parse.json) { req =>
+    for {
+      _ <- annotation.getWorkspaceMetadata(req.user.username, workspaceId) // check workspace exists and user has access
+      blobUris <- req.body.validate[List[String]].toAttempt
+      wordCount <- index.getWordCountForBlobs(workspaceId, blobUris)
+    } yield Ok(Json.toJson(wordCount))
+  }
+
   def getText(workspaceId: String) = ApiAction.attempt(parse.json) { req =>
     for {
       _ <- annotation.getWorkspaceMetadata(req.user.username, workspaceId) // check workspace exists and user has access

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -617,9 +617,10 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     )
   }
 
-  // Counts whitespace-separated words across the text (or, where present, OCR) of every language for
-  // every document matched by the query. Shared by the workspace- and folder-scoped word counts so they
-  // always use the same counting method (only the set of matched documents differs).
+  // Counts whitespace-separated words in every language of a single field per document, picked in
+  // precedence order: OCR where present, otherwise extracted text, otherwise the transcript (so
+  // audio/video documents are counted too). Shared by the workspace- and folder-scoped word counts so
+  // they always use the same counting method (only the set of matched documents differs).
   private val wordCountAggregation =
     scriptedMetricAggregation("workspaceWordCount")
       .initScript(Script("state.total = 0L").lang("painless"))

--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -7,6 +7,7 @@ import com.sksamuel.elastic4s.requests.common.FetchSourceContext
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
+import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import com.sksamuel.elastic4s.requests.update.UpdateByQueryRequest
 import extraction.{EnrichedMetadata}
@@ -616,36 +617,51 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
     )
   }
 
-  override def getTotalWordCountForWorkspace(workspaceId: String): Attempt[Long] = {
-    val query = search(indexName)
-      .query(
-        buildWorkspaceIdFilter(workspaceId)
-      )
-      .aggregations(
-        scriptedMetricAggregation("workspaceWordCount")
-          .initScript(Script("state.total = 0L").lang("painless"))
-          .mapScript(Script("""
-                              |if (params._source != null) {
-                              |  Map text = params._source.ocr != null ? params._source.ocr :
-                              |     (params._source.text != null ? params._source.text : params._source.transcript);
-                              |  if (text != null) {
-                              |    for (entry in text.entrySet()) {
-                              |      if (entry.getValue() != null && entry.getValue().length() > 0) {
-                              |        state.total += /\s+/.split(entry.getValue()).length;
-                              |      }
-                              |    }
-                              |  }
-                              |}
-          """.stripMargin.trim).lang("painless"))
-          .combineScript(Script("return state.total").lang("painless"))
-          .reduceScript(Script("long total = 0; for (s in states) { total += s } return total").lang("painless"))
-      )
+  // Counts whitespace-separated words across the text (or, where present, OCR) of every language for
+  // every document matched by the query. Shared by the workspace- and folder-scoped word counts so they
+  // always use the same counting method (only the set of matched documents differs).
+  private val wordCountAggregation =
+    scriptedMetricAggregation("workspaceWordCount")
+      .initScript(Script("state.total = 0L").lang("painless"))
+      .mapScript(Script("""
+                          |if (params._source != null) {
+                          |  Map text = params._source.ocr != null ? params._source.ocr :
+                          |     (params._source.text != null ? params._source.text : params._source.transcript);
+                          |  if (text != null) {
+                          |    for (entry in text.entrySet()) {
+                          |      if (entry.getValue() != null && entry.getValue().length() > 0) {
+                          |        state.total += /\s+/.split(entry.getValue()).length;
+                          |      }
+                          |    }
+                          |  }
+                          |}
+      """.stripMargin.trim).lang("painless"))
+      .combineScript(Script("return state.total").lang("painless"))
+      .reduceScript(Script("long total = 0; for (s in states) { total += s } return total").lang("painless"))
+
+  private def wordCountForQuery(query: Query): Attempt[Long] = {
+    val searchDefinition = search(indexName)
+      .query(query)
+      .aggregations(wordCountAggregation)
       .size(0)
 
-    execute(query).map { response =>
+    execute(searchDefinition).map { response =>
       response.aggregations.data("workspaceWordCount").asInstanceOf[Map[String, Number]]("value").longValue()
     }
   }
+
+  override def getTotalWordCountForWorkspace(workspaceId: String): Attempt[Long] =
+    wordCountForQuery(buildWorkspaceIdFilter(workspaceId))
+
+  override def getWordCountForBlobs(workspaceId: String, blobUris: List[String]): Attempt[Long] =
+    wordCountForQuery(
+      must(
+        idsQuery(blobUris),
+        // mirror getTextForBlobs: restrict to blobs that are actually in this workspace, so this can't be
+        // used to probe for or count text in blobs the user has no access to
+        buildWorkspaceIdFilter(workspaceId)
+      )
+    )
 
   override def getTextForBlobs(workspaceId: String, blobUris: List[String]): Attempt[Map[String, Map[String, String]]] = {
     val query = search(indexName)

--- a/backend/app/services/index/Index.scala
+++ b/backend/app/services/index/Index.scala
@@ -51,6 +51,8 @@ trait Index {
 
   def getTotalWordCountForWorkspace(workspaceId: String): Attempt[Long]
 
+  def getWordCountForBlobs(workspaceId: String, blobUris: List[String]): Attempt[Long]
+
   def getTextForBlobs(workspaceId: String, blobUris: List[String]): Attempt[Map[String, Map[String, String]]]
 
   def addTranslationToLanguageData(uri: Uri, fieldName: String, translation: String): Attempt[Unit]

--- a/backend/conf/routes
+++ b/backend/conf/routes
@@ -65,6 +65,7 @@ PUT           /api/workspaces/:workspaceId/name                             cont
 GET           /api/workspaces/:workspaceId                                  controllers.api.Workspaces.get(workspaceId: String)
 GET           /api/workspaces/:workspaceId/nodes                            controllers.api.Workspaces.getContents(workspaceId: String)
 GET           /api/workspaces/:workspaceId/totalWordCount                   controllers.api.Workspaces.getTotalWordCount(workspaceId: String)
+POST          /api/workspaces/:workspaceId/wordCount                        controllers.api.Workspaces.getWordCount(workspaceId: String)
 POST          /api/workspaces/:workspaceId/text                             controllers.api.Workspaces.getText(workspaceId: String)
 PUT           /api/workspaces/:workspaceId/owner                            controllers.api.Workspaces.updateWorkspaceOwner(workspaceId: String)
 POST          /api/workspaces/:workspaceId/reprocess                        controllers.api.Workspaces.reprocess(workspaceId: String, rerunSuccessful: Option[Boolean], rerunFailed: Option[Boolean])

--- a/backend/test/services/index/ElasticsearchResourcesITest.scala
+++ b/backend/test/services/index/ElasticsearchResourcesITest.scala
@@ -629,6 +629,44 @@ class ElasticsearchResourcesITest extends AnyFreeSpec with Matchers with BeforeA
       }
     }
 
+    "getWordCountForBlobs" - {
+      "counts whitespace-separated words for blobs in the workspace" in {
+        val workspaceId = "word-count-workspace-id"
+        val docUri = indexTestHelpers.addTestDocument(catCollection, "word_count_text", maybeText = Map(
+          English -> "one two three four five")
+        ).await()
+        elasticsearchTestService.elasticResources.addResourceToWorkspace(docUri, workspaceId, "word-count-node").await()
+
+        val count = elasticsearchTestService.elasticResources.getWordCountForBlobs(workspaceId, List(docUri.value)).await()
+        count shouldBe 5L
+
+        elasticsearchTestService.elasticResources.removeResourceFromWorkspace(docUri, workspaceId, "word-count-node").await()
+      }
+
+      "returns zero for blobs that are not in the given workspace (no cross-workspace probing)" in {
+        val docUri = indexTestHelpers.addTestDocument(catCollection, "word_count_not_in_workspace", maybeText = Map(
+          English -> "one two three")
+        ).await()
+
+        val count = elasticsearchTestService.elasticResources.getWordCountForBlobs("some-other-workspace-id", List(docUri.value)).await()
+        count shouldBe 0L
+      }
+
+      "prefers OCR text over extracted text when both are present" in {
+        val workspaceId = "word-count-ocr-workspace-id"
+        val docUri = indexTestHelpers.addTestDocument(catCollection, "word_count_ocr",
+          maybeText = Map(English -> "one two three"),
+          maybeOcrText = Map(English -> "alpha beta gamma delta")
+        ).await()
+        elasticsearchTestService.elasticResources.addResourceToWorkspace(docUri, workspaceId, "word-count-ocr-node").await()
+
+        val count = elasticsearchTestService.elasticResources.getWordCountForBlobs(workspaceId, List(docUri.value)).await()
+        count shouldBe 4L
+
+        elasticsearchTestService.elasticResources.removeResourceFromWorkspace(docUri, workspaceId, "word-count-ocr-node").await()
+      }
+    }
+
     // TODO MRB: add test to properly cover the painless update scripts
     // TODO MRB: add some tests for duplicate removal in fileUris, email recipients, collections and ingestions etc
   }

--- a/frontend/src/js/components/workspace/DownloadTextModal.tsx
+++ b/frontend/src/js/components/workspace/DownloadTextModal.tsx
@@ -211,8 +211,8 @@ export const DownloadTextModal = ({
         <p>
           This will download the text for all the{" "}
           <strong>{allBlobUris.length.toLocaleString()}</strong> files in this{" "}
-          {scopeNoun}, with each file's text separated by a header indicating the
-          file path and language.
+          {scopeNoun}, with each file's text separated by a header indicating
+          the file path and language.
         </p>
         <p>
           <label>

--- a/frontend/src/js/components/workspace/DownloadTextModal.tsx
+++ b/frontend/src/js/components/workspace/DownloadTextModal.tsx
@@ -6,6 +6,7 @@ import {
 import Modal from "../UtilComponents/Modal";
 import { isTreeNode, TreeEntry } from "../../types/Tree";
 import {
+  getWordCountForBlobs,
   getWorkspaceText,
   getWorkspaceTotalWordCount,
 } from "../../services/WorkspaceApi";
@@ -21,6 +22,10 @@ interface DownloadTextModalProps {
   isOpen: boolean;
   dismiss: () => void;
   workspace: Workspace;
+  // When supplied, the download is scoped to this folder's subtree rather than the whole workspace.
+  // `label` is used for the modal heading and the downloaded filename.
+  rootEntry?: TreeEntry<WorkspaceEntry>;
+  label?: string;
 }
 
 const getFileBlobUriMap = (
@@ -49,23 +54,42 @@ export const DownloadTextModal = ({
   isOpen,
   dismiss,
   workspace,
+  rootEntry,
+  label,
 }: DownloadTextModalProps) => {
-  const [workspaceWordCount, setWorkspaceWordCount] = useState<number | null>(
-    null,
-  );
-  useEffect(() => {
-    getWorkspaceTotalWordCount(workspace.id).then(setWorkspaceWordCount);
-  }, [workspace.id]);
+  const isFolderDownload = rootEntry !== undefined;
+  const downloadName = label ?? workspace.name;
+  const scopeNoun = isFolderDownload ? "folder" : "workspace";
 
-  const blobUriToWorkspacePath = useMemo(
-    () => getFileBlobUriMap(workspace.rootNode),
-    [workspace.rootNode],
-  );
+  // Always build full, workspace-root-relative paths (for provenance in the file headers), then restrict
+  // to the chosen subtree's blobs when scoped to a folder.
+  const blobUriToWorkspacePath = useMemo(() => {
+    const fullMap = getFileBlobUriMap(workspace.rootNode);
+    if (!rootEntry) {
+      return fullMap;
+    }
+    const scopeUris = new Set(Object.keys(getFileBlobUriMap(rootEntry)));
+    return Object.fromEntries(
+      Object.entries(fullMap).filter(([uri]) => scopeUris.has(uri)),
+    );
+  }, [workspace.rootNode, rootEntry]);
 
   const allBlobUris = useMemo(
     () => Object.keys(blobUriToWorkspacePath),
     [blobUriToWorkspacePath],
   );
+
+  const [totalWordCount, setTotalWordCount] = useState<number | null>(null);
+  useEffect(() => {
+    // Folder counts go via the blob-scoped endpoint; the whole-workspace count keeps its dedicated
+    // (cheaper, tag-filtered) endpoint. Both use the same Elasticsearch aggregation, so the figures
+    // are computed identically and reconcile.
+    if (rootEntry) {
+      getWordCountForBlobs(workspace.id, allBlobUris).then(setTotalWordCount);
+    } else {
+      getWorkspaceTotalWordCount(workspace.id).then(setTotalWordCount);
+    }
+  }, [workspace.id, rootEntry, allBlobUris]);
 
   const [targetNumOfResultFiles, setTargetNumOfResultFiles] = useState(
     Math.min(allBlobUris.length, 250),
@@ -76,7 +100,7 @@ export const DownloadTextModal = ({
   const downloadAllText = async () => {
     setProgress(0.01);
 
-    const fetchTextBatchSize = Math.min(1000, workspaceWordCount! / 15_000);
+    const fetchTextBatchSize = Math.min(1000, totalWordCount! / 15_000);
 
     let buffer: {
       [blobUri: string]: {
@@ -91,7 +115,7 @@ export const DownloadTextModal = ({
     };
 
     const dumpToFile = async () => {
-      const filename = `${workspace.name} (${workspace.id}).${currentOutputFile.number}.txt`;
+      const filename = `${downloadName} (${workspace.id}).${currentOutputFile.number}.txt`;
       const myBlob = new Blob([currentOutputFile.text.trim()], {
         type: "text/plain",
       });
@@ -168,27 +192,26 @@ export const DownloadTextModal = ({
   };
 
   const wordsPerFile =
-    workspaceWordCount &&
-    Math.ceil(workspaceWordCount / targetNumOfResultFiles);
+    totalWordCount && Math.ceil(totalWordCount / targetNumOfResultFiles);
 
   return (
     <Modal isOpen={isOpen} dismiss={dismiss}>
       <div style={{ padding: "10px" }}>
-        <h2>Download Workspace as Text</h2>
+        <h2>Download {isFolderDownload ? "Folder" : "Workspace"} as Text</h2>
         <p>
-          {workspaceWordCount === null ? (
+          {totalWordCount === null ? (
             <span>
-              <EuiLoadingSpinner size="s" /> Calculating total word count for
-              workspace...
+              <EuiLoadingSpinner size="s" /> Calculating total word count for{" "}
+              {scopeNoun}...
             </span>
           ) : (
-            `This workspace has a total of ${workspaceWordCount.toLocaleString()} words across all files and languages.`
+            `This ${scopeNoun} has a total of ${totalWordCount.toLocaleString()} words across all files and languages.`
           )}
         </p>
         <p>
           This will download the text for all the{" "}
-          <strong>{allBlobUris.length.toLocaleString()}</strong> files in this
-          workspace, with each file's text separated by a header indicating the
+          <strong>{allBlobUris.length.toLocaleString()}</strong> files in this{" "}
+          {scopeNoun}, with each file's text separated by a header indicating the
           file path and language.
         </p>
         <p>
@@ -225,7 +248,7 @@ export const DownloadTextModal = ({
         ) : (
           <EuiButton
             onClick={downloadAllText}
-            disabled={!workspaceWordCount || allBlobUris.length === 0}
+            disabled={!totalWordCount || allBlobUris.length === 0}
           >
             Start Download
           </EuiButton>

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -70,6 +70,7 @@ import {
   RemoveFromWorkspaceModal,
 } from "./ConfirmModal";
 import { ReprocessFolderModal } from "./ReprocessFolderModal";
+import { DownloadTextModal } from "./DownloadTextModal";
 import { PartialUser } from "../../types/User";
 import { getMyPermissions } from "../../actions/users/getMyPermissions";
 import buildLink from "../../util/buildLink";
@@ -117,6 +118,7 @@ type State = {
     status: ModalStatus;
   };
   reprocessFolderModalEntry: null | TreeEntry<WorkspaceEntry>;
+  downloadFolderEntry: null | TreeEntry<WorkspaceEntry>;
   itemsBeingMoved: number;
   itemsWithMoveSettled: number;
   /** Files dropped from the file system via drag-and-drop */
@@ -428,6 +430,7 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
       status: "unconfirmed",
     },
     reprocessFolderModalEntry: null,
+    downloadFolderEntry: null,
     itemsBeingMoved: 0,
     itemsWithMoveSettled: 0,
     droppedFiles: undefined,
@@ -959,6 +962,11 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
         content: "Reprocess folder contents\u2026",
         icon: "redo",
       });
+      items.push({
+        key: "downloadFolderAsText",
+        content: "Download folder as text",
+        icon: "file alternate outline",
+      });
     }
 
     if (isWorkspaceFolder && !isRemoteIngest) {
@@ -1063,6 +1071,13 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
               isWorkspaceFolder
             ) {
               this.setState({ reprocessFolderModalEntry: entry });
+            }
+
+            if (
+              menuItemProps.content === "Download folder as text" &&
+              isWorkspaceFolder
+            ) {
+              this.setState({ downloadFolderEntry: entry });
             }
 
             if (menuItemProps.content === "Search in folder") {
@@ -1406,6 +1421,16 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
               onCancel={() =>
                 this.setState({ reprocessFolderModalEntry: null })
               }
+            />
+          )}
+        {this.state.downloadFolderEntry &&
+          isWorkspaceNode(this.state.downloadFolderEntry.data) && (
+            <DownloadTextModal
+              isOpen={true}
+              dismiss={() => this.setState({ downloadFolderEntry: null })}
+              workspace={this.props.currentWorkspace}
+              rootEntry={this.state.downloadFolderEntry}
+              label={this.state.downloadFolderEntry.name}
             />
           )}
       </div>

--- a/frontend/src/js/services/WorkspaceApi.ts
+++ b/frontend/src/js/services/WorkspaceApi.ts
@@ -65,6 +65,17 @@ export function getWorkspaceTotalWordCount(id: string): Promise<number> {
   );
 }
 
+export function getWordCountForBlobs(
+  id: string,
+  blobUris: string[],
+): Promise<number> {
+  return authFetch(`/api/workspaces/${id}/wordCount`, {
+    method: "POST",
+    headers: new Headers({ "Content-Type": "application/json" }),
+    body: JSON.stringify(blobUris),
+  }).then((res) => res.json());
+}
+
 export function getWorkspaceText(
   id: string,
   blobUris: string[],


### PR DESCRIPTION
## What & why

Builds on the new feature https://github.com/guardian/giant/pull/691 that allows us to take a LLM-friendly compiled text export of the content of a workspace - and, potentially, integrate that with our own LLM services. 

Adds an admin-only **"Download folder as text"** action to the workspace-tree context menu, scoped to a selected folder and its tree descendants. It's the first stage of generalising the existing workspace-wide "Download all text" to folders, reusing that feature's machinery plus the word-count aggregation already used for workspaces.

This is **Stage 1 (tree nodes only)** — self-contained and shippable, with **no behaviour change to the existing workspace download**.

## How it works

- **Frontend** — `DownloadTextModal` now takes an optional `rootEntry`/`label`, so it can be scoped to a folder subtree. It builds full workspace-root-relative paths (for provenance in the `----- START OF … -----` headers) and restricts them to the folder's blobs. A new context-menu item (gated on `isAdmin && isWorkspaceFolder && !isRemoteIngest`, alongside "Reprocess folder contents…") opens the modal scoped to the folder.
- **Backend** — folder word counts go via a new `POST /api/workspaces/:id/wordCount` (`getWordCountForBlobs`), which reuses the **same** Elasticsearch word-count aggregation as the whole-workspace figure, swapping the workspace-tag filter for an ids filter (plus the workspace filter, mirroring `getTextForBlobs`'s security property). The aggregation is extracted into a shared helper so the two counts are computed identically and therefore reconcile.

## Consistency note

The only divergence risk was the displayed word count. Because folder and workspace counts now use the identical aggregation, the sum of top-level folder counts ≈ the workspace total (modulo any ES-tag↔tree drift). The thing that *would* break reconciliation — attachment/archive sub-documents (`parentBlobs`) — is deliberately out of scope here.

## Deferred to Stage 2 (rides the lazy-loading work)

Bundled because both need server-side URI derivation:
- Move folder **and** workspace URI derivation server-side via `getBlobUrisInWorkspaceFolder` (fixes lazy-loading fragility for both).
- Include `parentBlobs` sub-documents using folder-search's `buildWorkspaceBlobFilter` authorisation model.
- Re-point the workspace count/download to the same derivation so reconciliation holds with attachments included. **Heads-up for that PR:** the existing "Download all text" will then start including attachment/archive text it currently omits.

## Testing

- New ITests for `getWordCountForBlobs`: counts words for in-workspace blobs, returns 0 for blobs outside the workspace (no cross-workspace probing), and prefers OCR over extracted text. (ITests run in CI.)
- `react-scripts build`, backend `compile`, and `Test/compile` all green.
- **Manually verified** in the running app as admin: folder menu item appears; modal scopes to the folder with a count from the new endpoint; downloads contain only the folder's files; existing workspace-wide download unchanged.
