### PR TITLE
also include transcribed text in the 'download workspace as text files' feature

### DIFF
--- a/backend/app/services/index/ElasticsearchResources.scala
+++ b/backend/app/services/index/ElasticsearchResources.scala
@@ -529,7 +529,8 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
           .initScript(Script("state.total = 0L").lang("painless"))
           .mapScript(Script("""
                               |if (params._source != null) {
-                              |  Map text = params._source.ocr != null ? params._source.ocr : params._source.text;
+                              |  Map text = params._source.ocr != null ? params._source.ocr :
+                              |     (params._source.text != null ? params._source.text : params._source.transcript);
                               |  if (text != null) {
                               |    for (entry in text.entrySet()) {
                               |      if (entry.getValue() != null && entry.getValue().length() > 0) {
@@ -561,13 +562,17 @@ class ElasticsearchResources(override val client: ElasticClient, indexName: Stri
       )
       .sourceInclude(
         "text.*",
-        "ocr.*"
+        "ocr.*",
+        "transcript.*"
       )
       .size(blobUris.size)
 
     execute(query).map { response =>
       response.hits.hits.flatMap { hit =>
-        hit.sourceAsMap.get(IndexFields.ocr).orElse(hit.sourceAsMap.get(IndexFields.text)).map(text => hit.id -> text.asInstanceOf[Map[String, String]])
+        hit.sourceAsMap.get(IndexFields.ocr)
+          .orElse(hit.sourceAsMap.get(IndexFields.text))
+          .orElse(hit.sourceAsMap.get(IndexFields.transcript))
+          .map(text => hit.id -> text.asInstanceOf[Map[String, String]])
       }.toMap
     }
   }


### PR DESCRIPTION
https://github.com/guardian/giant/pull/691 introduced a new (admin only) option to download all the text of a workspace, but it didn't included transcribed text... this PR fixes that.

There are quite a few other fields it should probably include... but they need more thought and I'd like get this improvement released.

It would also be nice to have links to giant in the resulting text files, for easier navigation back to the original, but again that can follow.