### PR TITLE
workspace level progress bar show overall amount processed

### DIFF
--- a/backend/app/model/annotations/Workspace.scala
+++ b/backend/app/model/annotations/Workspace.scala
@@ -64,6 +64,7 @@ case class WorkspaceNode(
   descendantsLeafCount: Long,
   descendantsNodeCount: Long,
   descendantsProcessingTaskCount: Long,
+  descendantsProcessingLeafCount: Long,
   descendantsFailedCount: Long
 ) extends WorkspaceEntry
 
@@ -127,6 +128,7 @@ object WorkspaceEntry {
           descendantsLeafCount = 0,
           descendantsNodeCount = 0,
           descendantsProcessingTaskCount = 0,
+          descendantsProcessingLeafCount = 0,
           descendantsFailedCount = 0,
         ),
         children = List.empty

--- a/backend/app/model/ingestion/RemoteIngest.scala
+++ b/backend/app/model/ingestion/RemoteIngest.scala
@@ -128,6 +128,7 @@ case class RemoteIngest(
           descendantsLeafCount = 0,
           descendantsNodeCount = 0,
           descendantsProcessingTaskCount = 0,
+          descendantsProcessingLeafCount = 0,
           descendantsFailedCount = 0
         ),
         // confusingly we return an empty list here - the folder structure is built later

--- a/backend/app/services/annotations/Neo4jAnnotations.scala
+++ b/backend/app/services/annotations/Neo4jAnnotations.scala
@@ -161,6 +161,7 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
             node.copy(
               children = children,
               data = node.data match {
+                // TODO this probably ought to be achieved single pass of the children list rather than multiple children.map calls (probably a reduce)
                 case wNode: WorkspaceNode => wNode.copy(
                   descendantsLeafCount = children.map {
                     case TreeNode(_, _, childNode: WorkspaceNode, _) => childNode.descendantsLeafCount
@@ -177,6 +178,17 @@ class Neo4jAnnotations(driver: Driver, executionContext: ExecutionContext, query
                     case leaf: TreeLeaf[WorkspaceEntry] => leaf.data match {
                       case wl: WorkspaceLeaf => wl.processingStage match {
                         case ProcessingStage.Processing(tasksRemaining, _) => tasksRemaining
+                        case _ => 0
+                      }
+                      case _ => 0
+                    }
+                    case _ => 0
+                  }.sum,
+                  descendantsProcessingLeafCount = children.map {
+                    case TreeNode(_, _, childNode: WorkspaceNode, _) => childNode.descendantsProcessingTaskCount
+                    case leaf: TreeLeaf[WorkspaceEntry] => leaf.data match {
+                      case wl: WorkspaceLeaf => wl.processingStage match {
+                        case ProcessingStage.Processing(_, _) => 1
                         case _ => 0
                       }
                       case _ => 0

--- a/backend/test/model/frontend/TreeEntryTest.scala
+++ b/backend/test/model/frontend/TreeEntryTest.scala
@@ -77,6 +77,7 @@ class TreeEntryTest extends AnyFreeSpec with Matchers {
         descendantsLeafCount = 0,
         descendantsNodeCount = 0,
         descendantsProcessingTaskCount = 0,
+        descendantsProcessingLeafCount = 0,
         descendantsFailedCount = 0
       ),
       children = children

--- a/frontend/src/js/components/workspace/Workspaces.tsx
+++ b/frontend/src/js/components/workspace/Workspaces.tsx
@@ -1200,6 +1200,26 @@ class WorkspacesUnconnected extends React.Component<Props, State> {
                 size="s"
               />
             )}
+            {this.props.currentWorkspace &&
+              isWorkspaceNode(this.props.currentWorkspace.rootNode.data) &&
+              this.props.currentWorkspace.rootNode.data
+                .descendantsProcessingLeafCount > 0 && (
+                <EuiProgress
+                  label="Processing:"
+                  valueText={`${(this.props.currentWorkspace.rootNode.data.descendantsLeafCount - this.props.currentWorkspace.rootNode.data.descendantsProcessingLeafCount).toLocaleString()} of ${this.props.currentWorkspace.rootNode.data.descendantsLeafCount.toLocaleString()}`}
+                  value={
+                    this.props.currentWorkspace.rootNode.data
+                      .descendantsLeafCount -
+                    this.props.currentWorkspace.rootNode.data
+                      .descendantsProcessingLeafCount
+                  }
+                  max={
+                    this.props.currentWorkspace.rootNode.data
+                      .descendantsLeafCount
+                  }
+                  size="s"
+                />
+              )}
           </div>
           <div className="workspace__tree-actions" style={{ gap: "2px" }}>
             <EuiText

--- a/frontend/src/js/types/Workspaces.ts
+++ b/frontend/src/js/types/Workspaces.ts
@@ -13,6 +13,7 @@ export interface WorkspaceNode extends BaseWorkspaceEntry {
   descendantsLeafCount: number;
   descendantsNodeCount: number;
   descendantsProcessingTaskCount: number;
+  descendantsProcessingLeafCount: number;
   descendantsFailedCount: number;
 }
 

--- a/frontend/src/js/util/workspaceNavigation.spec.ts
+++ b/frontend/src/js/util/workspaceNavigation.spec.ts
@@ -11,6 +11,7 @@ const nodeData: WorkspaceNode = {
   descendantsNodeCount: 0,
   descendantsLeafCount: 0,
   descendantsProcessingTaskCount: 0,
+  descendantsProcessingLeafCount: 0,
   descendantsFailedCount: 0,
 };
 

--- a/frontend/src/js/util/workspaceUtils.fixtures.ts
+++ b/frontend/src/js/util/workspaceUtils.fixtures.ts
@@ -5,6 +5,7 @@ const standardWorkspaceNodeData: WorkspaceNode = {
   descendantsNodeCount: 0,
   descendantsLeafCount: 0,
   descendantsProcessingTaskCount: 0,
+  descendantsProcessingLeafCount: 0,
   descendantsFailedCount: 0,
 };
 


### PR DESCRIPTION
I recently had need to wait for processing to complete on a workspace with a few thousand items (all top level) and it was a bit annoying having to scroll up/down and eyeball roughly how many were processed to see roughly how close/long it would be until I could do something (which needed everything to be processed), this would be actually be near impossible on a much bigger workspace.

Seemed straight-forward to add a small progress bar (like was added for moving files - see #460) to display this, needed an additional server-side computed field to count the actual files in processing state (as we only had the task count, which can be more than one per file), but this was simple to add.

<img width="478" height="130" alt="image" src="https://github.com/user-attachments/assets/83a9259f-6ad4-4e81-be1e-dc3c0264bfca" />

