### PR TITLE
Use AMIs tagged with Encrypted=true rather than Encrypted=investigations

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,7 +14,6 @@ deployments:
       amiTags:
         Recipe: investigations-giant-app-arm
         AmigoStage: PROD
-        Encrypted: investigations
 
   pfi-neo4j-ami-update:
     type: ami-cloudformation-parameter
@@ -24,7 +23,6 @@ deployments:
       amiTags:
         Recipe: investigations-neo4j-2026-jammy-java25
         AmigoStage: PROD
-        Encrypted: true
 
   pfi-elasticsearch-ami-update:
     type: ami-cloudformation-parameter
@@ -34,7 +32,6 @@ deployments:
       amiTags:
         Recipe: investigations-elasticsearch-8-arm64
         AmigoStage: PROD
-        Encrypted: investigations
 
   pfi:
     type: autoscaling


### PR DESCRIPTION
## What does this change?
This tweaks the giant deploy process so that we use AMIs built by the amigo image copier that is deployed via a stack set and maintained by DevX rather than a copy of that that was deployed to our account years ago.

This is a follow up of https://github.com/guardian/giant/pull/522 - but means we're now following the same pattern as all the other accounts at the guardian

Note that when you set `amiEncrypted=true` it automatically sets `Encrypted: true`, so we don't need that override parameter anymore

## How has this change been tested?
The AMI generation code is the same so I'm quite confident this will work. There should be no change other than the AMI id really.
