### PR TITLE
Fix reprocess  following Neo4j upgrade

### DIFF
--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -984,7 +984,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
         |  // We SET them afterwards, because we want to copy properties from the PROCESSED
         |  // https://neo4j.com/docs/developer-manual/3.3/cypher/clauses/set/#set-copying-properties-between-nodes-and-relationships.
         |  CREATE (blob)<-[todoForRedoingPreviousSuccess :TODO]-(extractor)
-        |  SET todoForRedoingPreviousSuccess = processedRelation
+        |  SET todoForRedoingPreviousSuccess = properties(processedRelation)
         |  SET todoForRedoingPreviousSuccess.attempts = 0
         |  SET todoForRedoingPreviousSuccess.priority = extractor.priority
         |  SET todoForRedoingPreviousSuccess.cost = extractor.cost
@@ -1087,7 +1087,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
         |MATCH (blob :Blob:Resource {uri: $uri})<-[failure :EXTRACTION_FAILURE]-(failedExtractor :Extractor {external: true})
         |MATCH (blob)<-[processing_externally :PROCESSING_EXTERNALLY]-(failedExtractor)
         |MERGE (blob)<-[todo:TODO]-(failedExtractor)
-        |ON CREATE SET todo = processing_externally, todo.attempts = 0
+        |ON CREATE SET todo = properties(processing_externally), todo.attempts = 0
         |DELETE processing_externally
       """.stripMargin,
       parameters(


### PR DESCRIPTION
## What does this change?
There are various problems with reprocessing but right now it appears to be completely broken. I think this was probably caused by the neo4j upgrade, but because reprocessing is so flaky anyway we might have ignored failures during testing.

This change fixes the top level error. There are other reprocessing related problems which will need a bit more work.

The error this fixes looks like this - neo4j even tells us how to fix it:

```
Caused by: org.neo4j.driver.exceptions.Neo4jException: 22N27: Invalid input 'RELATIONSHIP' for processedRelation. Expected to be MAP. Hint: use properties(...) on the right-hand side.
```

## How has this change been tested?
 - [x] Tested locally
 - [ ] Tested on playground
