### PR TITLE
use fetch work test manifest across entire test

### DIFF
--- a/backend/test/services/manifest/Neo4JManifestITest.scala
+++ b/backend/test/services/manifest/Neo4JManifestITest.scala
@@ -447,7 +447,7 @@ class Neo4JManifestITest extends AnyFreeSpec
         executor.submit(new Runnable {
           def run(): Unit = {
             barrier.await() // wait for both threads to be ready
-            workerOneResults = manifest
+            workerOneResults = fetchWorkTestManifest
               .fetchWork("concurrentWorkerOne", maxBatchSize = 10, maxCost = 10000, workerCount = 2, workerIndex = 0).toOption.get
             latch.countDown()
           }
@@ -455,7 +455,7 @@ class Neo4JManifestITest extends AnyFreeSpec
         executor.submit(new Runnable {
           def run(): Unit = {
             barrier.await() // wait for both threads to be ready
-            workerTwoResults = manifest.fetchWork("concurrentWorkerTwo", maxBatchSize = 10, maxCost = 10000, workerCount = 2, workerIndex = 1).toOption.get
+            workerTwoResults = fetchWorkTestManifest.fetchWork("concurrentWorkerTwo", maxBatchSize = 10, maxCost = 10000, workerCount = 2, workerIndex = 1).toOption.get
             latch.countDown()
           }
         })


### PR DESCRIPTION
## What does this change?
The fetchWork test is still randomly failing. I'm hoping this change - missed off https://github.com/guardian/giant/pull/712 by accident - might fix the problem - we weren't actually using the new manifest created to separate the fetchWork test when fetching work. Why the test was passing at all I'm not totally sure about! But maybe all the other bits of work created by other tests tend to add up to 5 bits when they are fetched. 

## How has this change been tested?
Tested in CI, the tests passed once, hopefully they will do every time now 
