### PR TITLE
Fix presigned urls when using garage locally

### DIFF
--- a/backend/app/AppComponents.scala
+++ b/backend/app/AppComponents.scala
@@ -95,10 +95,10 @@ class AppComponents(context: Context, config: Config)
     else
       SnsClient.builder().region(config.sqs.regionV2).build()
 
-    val s3Presigner = S3Presigner.builder()
-      .region(config.sqs.regionV2)
-      .credentialsProvider(credentialsProvider)
-      .build()
+    val s3Presigner = if (config.s3.endpoint.isDefined)
+      S3Presigner.builder().endpointOverride(URI.create(config.s3.endpoint.get)).region(config.s3.regionV2).credentialsProvider(s3Client.credentials).build()
+    else
+      S3Presigner.builder().region(config.sqs.regionV2).credentialsProvider(s3Client.credentials).build()
 
     val workerName = config.worker.name.getOrElse(InetAddress.getLocalHost.getHostName)
 

--- a/backend/app/services/Config.scala
+++ b/backend/app/services/Config.scala
@@ -165,7 +165,9 @@ case class S3Config(
   secretKey: Option[String],
   // These settings are just for AWS
   sseAlgorithm: Option[String]
-)
+) {
+  val regionV2: Region = Region.of(region)
+}
 
 case class SQSConfig(
                     region: String,


### PR DESCRIPTION
## What does this change?
In https://github.com/guardian/giant/pull/748 we forgot to test presigned urls locally (only used for transcription/translation).

This makes sure we can generate presigned urls when using garage.

## How has this change been tested?
 - [x] Tested locally
 - [ ] Tested on playground
