### PR TITLE
Migrate PreviewSwitcher to a functional typescript component

### DIFF
--- a/frontend/src/js/components/viewer/PreviewSwitcher.tsx
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
 import { Resource } from "../../types/Resource";
 import _ from "lodash";
 
@@ -29,10 +29,17 @@ type PreviewSwitcherProps = {
   setResourceView: typeof setResourceView;
 };
 
-class PreviewSwitcher extends React.Component<PreviewSwitcherProps> {
-  currentViewModeIsValid(resource: Resource): boolean {
-    const { view, totalPages } = this.props;
+function canPreview(previewStatus?: string): boolean {
+  return previewStatus !== "disabled";
+}
 
+const PreviewSwitcher: FC<PreviewSwitcherProps> = ({
+  resource,
+  view,
+  totalPages,
+  setResourceView,
+}) => {
+  const currentViewModeIsValid = (): boolean => {
     if (!view) {
       return false;
     }
@@ -60,183 +67,150 @@ class PreviewSwitcher extends React.Component<PreviewSwitcherProps> {
       return false;
     }
 
-    if (view === "preview" && !this.canPreview(resource.previewStatus)) {
+    if (view === "preview" && !canPreview(resource.previewStatus)) {
       return false;
     }
 
     return true;
-  }
+  };
 
-  canPreview(previewStatus?: string): boolean {
-    return previewStatus !== "disabled";
-  }
+  const previewLabel = (): string =>
+    previewLabelForMimeTypes(resource?.mimeTypes ?? []);
 
-  previewLabel(): string {
-    return previewLabelForMimeTypes(this.props.resource?.mimeTypes ?? []);
-  }
-
-  componentDidUpdateOrMount() {
-    if (
-      this.props.resource &&
-      this.props.view &&
-      !this.currentViewModeIsValid(this.props.resource)
-    ) {
-      const fallback = getDefaultView(this.props.resource);
+  useEffect(() => {
+    if (resource && view && !currentViewModeIsValid()) {
+      const fallback = getDefaultView(resource);
       if (fallback) {
-        this.props.setResourceView(fallback);
+        setResourceView(fallback);
       }
     }
-  }
+    // Mirrors the previous componentDidMount/componentDidUpdate behaviour by
+    // re-running whenever the relevant props change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  });
 
-  componentDidMount() {
-    this.componentDidUpdateOrMount();
-  }
-
-  componentDidUpdate() {
-    this.componentDidUpdateOrMount();
-  }
-
-  showText = () => {
-    this.props.setResourceView("text");
+  const showText = () => {
+    setResourceView("text");
   };
 
-  showCombined = () => {
+  const showCombined = () => {
     // Combined view is only available when the document has been ingested as pages (e.g. PDF).
-    if ((this.props.totalPages ?? 0) > 0) {
-      this.props.setResourceView("combined");
+    if ((totalPages ?? 0) > 0) {
+      setResourceView("combined");
     }
   };
 
-  showPreview = () => {
-    if (this.canPreview(this.props.resource?.previewStatus)) {
-      this.props.setResourceView("preview");
+  const showPreview = () => {
+    if (canPreview(resource?.previewStatus)) {
+      setResourceView("preview");
     }
   };
 
-  showOcr = () => {
-    const resource = this.props.resource;
+  const showOcr = () => {
     if (resource?.transcript) {
       const languages = Object.keys(resource.transcript);
       if (languages.length > 0) {
-        this.props.setResourceView(`transcript.${languages[0]}`);
+        setResourceView(`transcript.${languages[0]}`);
       }
     } else if (resource?.ocr) {
       const languages = Object.keys(resource.ocr);
       if (languages.length > 0) {
-        this.props.setResourceView(`ocr.${languages[0]}`);
+        setResourceView(`ocr.${languages[0]}`);
       }
     }
   };
 
-  showTable = () => {
-    this.props.setResourceView("table");
-  };
-
-  renderMultiLangLinks(
+  const renderMultiLangLinks = (
     current: string,
-    view: string,
+    langView: string,
     textPrefix?: string,
-  ): JSX.Element[] | false {
-    if (_.get(this.props.resource, view)) {
-      const languages = Object.keys(_.get(this.props.resource, view));
+  ): JSX.Element[] | false => {
+    if (_.get(resource, langView)) {
+      const languages = Object.keys(_.get(resource, langView));
       if (languages.length > 0) {
         return languages.map((l) => (
           <PreviewLink
             key={l}
             current={current}
-            to={`${view}.${l}`}
+            to={`${langView}.${l}`}
             text={`${textPrefix || ""} (${_.startCase(l)})`}
-            navigate={this.props.setResourceView}
+            navigate={setResourceView}
           />
         ));
       }
     }
     return false;
-  }
+  };
 
-  render() {
-    const current = this.props.view
-      ? this.props.view
-      : this.props.resource.transcript
-        ? "transcript"
-        : "text";
+  const current = view ? view : resource.transcript ? "transcript" : "text";
 
-    const { parents } = this.props.resource;
+  const { parents } = resource;
 
-    return (
-      <nav className="preview__links">
-        <KeyboardShortcut
-          shortcut={keyboardShortcuts.showText}
-          func={this.showText}
+  return (
+    <nav className="preview__links">
+      <KeyboardShortcut shortcut={keyboardShortcuts.showText} func={showText} />
+      <KeyboardShortcut
+        shortcut={keyboardShortcuts.showCombined}
+        func={showCombined}
+      />
+      <KeyboardShortcut
+        shortcut={keyboardShortcuts.showPreview}
+        func={showPreview}
+      />
+      <KeyboardShortcut shortcut={keyboardShortcuts.showOcr} func={showOcr} />
+      {(totalPages ?? 0) > 0 && (
+        <PreviewLink
+          current={current}
+          text="Combined"
+          to="combined"
+          navigate={setResourceView}
         />
-        <KeyboardShortcut
-          shortcut={keyboardShortcuts.showCombined}
-          func={this.showCombined}
+      )}
+      {hasTextContent(resource) && !resource.transcript ? (
+        <PreviewLink
+          current={current}
+          text="Text"
+          to="text"
+          navigate={setResourceView}
         />
-        <KeyboardShortcut
-          shortcut={keyboardShortcuts.showPreview}
-          func={this.showPreview}
+      ) : (
+        false
+      )}
+      {resource.transcript
+        ? renderMultiLangLinks(current, "transcript", "Transcript")
+        : false}
+      {resource.vttTranscript
+        ? renderMultiLangLinks(
+            current,
+            "vttTranscript",
+            "Transcript time codes",
+          )
+        : false}
+      {!resource.transcript && renderMultiLangLinks(current, "ocr", "OCR")}
+      {canPreview(resource.previewStatus) ? (
+        <PreviewLink
+          current={current}
+          text={previewLabel()}
+          to="preview"
+          navigate={setResourceView}
         />
-        <KeyboardShortcut
-          shortcut={keyboardShortcuts.showOcr}
-          func={this.showOcr}
-        />
-        {(this.props.totalPages ?? 0) > 0 && (
+      ) : (
+        false
+      )}
+      {parents &&
+        parents.some(
+          (m) => m.uri.endsWith("csv") || m.uri.endsWith("tsv"),
+        ) && (
           <PreviewLink
             current={current}
-            text="Combined"
-            to="combined"
-            navigate={this.props.setResourceView}
+            text="Table"
+            to="table"
+            navigate={setResourceView}
           />
         )}
-        {hasTextContent(this.props.resource) &&
-        !this.props.resource.transcript ? (
-          <PreviewLink
-            current={current}
-            text="Text"
-            to="text"
-            navigate={this.props.setResourceView}
-          />
-        ) : (
-          false
-        )}
-        {this.props.resource.transcript
-          ? this.renderMultiLangLinks(current, "transcript", "Transcript")
-          : false}
-        {this.props.resource.vttTranscript
-          ? this.renderMultiLangLinks(
-              current,
-              "vttTranscript",
-              "Transcript time codes",
-            )
-          : false}
-        {!this.props.resource.transcript &&
-          this.renderMultiLangLinks(current, "ocr", "OCR")}
-        {this.canPreview(this.props.resource.previewStatus) ? (
-          <PreviewLink
-            current={current}
-            text={this.previewLabel()}
-            to="preview"
-            navigate={this.props.setResourceView}
-          />
-        ) : (
-          false
-        )}
-        {parents &&
-          parents.some(
-            (m) => m.uri.endsWith("csv") || m.uri.endsWith("tsv"),
-          ) && (
-            <PreviewLink
-              current={current}
-              text="Table"
-              to="table"
-              navigate={this.props.setResourceView}
-            />
-          )}
-      </nav>
-    );
-  }
-}
+    </nav>
+  );
+};
 
 type PreviewLinkProps = {
   current: string;

--- a/frontend/src/js/components/viewer/PreviewSwitcher.tsx
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.tsx
@@ -1,6 +1,5 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { resourcePropType } from "../../types/Resource";
+import React, { FC } from "react";
+import { Resource } from "../../types/Resource";
 import _ from "lodash";
 
 import { hasTextContent, getDefaultView } from "../../util/resourceUtils";
@@ -11,9 +10,9 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 
 import { setResourceView } from "../../actions/urlParams/setViews";
+import { GiantDispatch } from "../../types/redux/GiantDispatch";
 
-/** @param {string[]} mimeTypes @returns {string} */
-export function previewLabelForMimeTypes(mimeTypes) {
+export function previewLabelForMimeTypes(mimeTypes: string[]): string {
   if (mimeTypes.some((m) => m.startsWith("video/"))) {
     return "Video";
   }
@@ -23,25 +22,27 @@ export function previewLabelForMimeTypes(mimeTypes) {
   return "Preview";
 }
 
-class PreviewSwitcher extends React.Component {
-  static propTypes = {
-    resource: resourcePropType,
-    view: PropTypes.string,
-    totalPages: PropTypes.number,
-    setResourceView: PropTypes.func.isRequired,
-  };
+type PreviewSwitcherProps = {
+  resource: Resource;
+  view?: string;
+  totalPages?: number;
+  setResourceView: typeof setResourceView;
+};
 
-  currentViewModeIsValid(resource) {
-    if (!this.props.view) {
+class PreviewSwitcher extends React.Component<PreviewSwitcherProps> {
+  currentViewModeIsValid(resource: Resource): boolean {
+    const { view, totalPages } = this.props;
+
+    if (!view) {
       return false;
     }
 
-    if (this.props.view === "combined" && this.props.totalPages > 0) {
+    if (view === "combined" && (totalPages ?? 0) > 0) {
       return true;
     }
 
     if (
-      this.props.view === "table" &&
+      view === "table" &&
       (!resource.parents ||
         !resource.parents.some(
           (m) => m.uri.endsWith("csv") || m.uri.endsWith("tsv"),
@@ -51,32 +52,26 @@ class PreviewSwitcher extends React.Component {
       return false;
     }
 
-    if (this.props.view === "text" && !hasTextContent(resource)) {
+    if (view === "text" && !hasTextContent(resource)) {
       return false;
     }
 
-    if (
-      this.props.view.startsWith("ocr") &&
-      !_.get(resource, this.props.view)
-    ) {
+    if (view.startsWith("ocr") && !_.get(resource, view)) {
       return false;
     }
 
-    if (
-      this.props.view === "preview" &&
-      !this.canPreview(resource.previewStatus)
-    ) {
+    if (view === "preview" && !this.canPreview(resource.previewStatus)) {
       return false;
     }
 
     return true;
   }
 
-  canPreview(previewStatus) {
+  canPreview(previewStatus?: string): boolean {
     return previewStatus !== "disabled";
   }
 
-  previewLabel() {
+  previewLabel(): string {
     return previewLabelForMimeTypes(this.props.resource?.mimeTypes ?? []);
   }
 
@@ -107,7 +102,7 @@ class PreviewSwitcher extends React.Component {
 
   showCombined = () => {
     // Combined view is only available when the document has been ingested as pages (e.g. PDF).
-    if (this.props.totalPages > 0) {
+    if ((this.props.totalPages ?? 0) > 0) {
       this.props.setResourceView("combined");
     }
   };
@@ -137,7 +132,11 @@ class PreviewSwitcher extends React.Component {
     this.props.setResourceView("table");
   };
 
-  renderMultiLangLinks(current, view, textPrefix) {
+  renderMultiLangLinks(
+    current: string,
+    view: string,
+    textPrefix?: string,
+  ): JSX.Element[] | false {
     if (_.get(this.props.resource, view)) {
       const languages = Object.keys(_.get(this.props.resource, view));
       if (languages.length > 0) {
@@ -182,7 +181,7 @@ class PreviewSwitcher extends React.Component {
           shortcut={keyboardShortcuts.showOcr}
           func={this.showOcr}
         />
-        {this.props.totalPages > 0 && (
+        {(this.props.totalPages ?? 0) > 0 && (
           <PreviewLink
             current={current}
             text="Combined"
@@ -198,9 +197,7 @@ class PreviewSwitcher extends React.Component {
             to="text"
             navigate={this.props.setResourceView}
           />
-        ) : (
-          false
-        )}
+        ) : false}
         {this.props.resource.transcript
           ? this.renderMultiLangLinks(current, "transcript", "Transcript")
           : false}
@@ -220,9 +217,7 @@ class PreviewSwitcher extends React.Component {
             to="preview"
             navigate={this.props.setResourceView}
           />
-        ) : (
-          false
-        )}
+        ) : false}
         {parents &&
           parents.some(
             (m) => m.uri.endsWith("csv") || m.uri.endsWith("tsv"),
@@ -239,37 +234,38 @@ class PreviewSwitcher extends React.Component {
   }
 }
 
-function PreviewLink({ current, text, to, navigate }) {
+type PreviewLinkProps = {
+  current: string;
+  text: string;
+  to: string;
+  navigate: (view: string) => void;
+};
+
+const PreviewLink: FC<PreviewLinkProps> = ({ current, text, to, navigate }) => {
   const active = current.toLowerCase() === to.toLowerCase();
   const clazz = `btn-link preview__link ${active ? "preview__link--active" : ""}`;
 
-  const onClick = (e) => {
+  const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     navigate(to);
   };
 
   return (
-    <button href="#" className={clazz} onClick={onClick}>
+    <button className={clazz} onClick={onClick}>
       {text}
     </button>
   );
-}
-
-PreviewLink.propTypes = {
-  current: PropTypes.string.isRequired,
-  to: PropTypes.string.isRequired,
-  text: PropTypes.string.isRequired,
-  navigate: PropTypes.func.isRequired,
 };
 
 function mapStateToProps() {
   return {};
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch: GiantDispatch) {
   return {
     setResourceView: bindActionCreators(setResourceView, dispatch),
   };
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(PreviewSwitcher);
+

--- a/frontend/src/js/components/viewer/PreviewSwitcher.tsx
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.tsx
@@ -198,9 +198,7 @@ const PreviewSwitcher: FC<PreviewSwitcherProps> = ({
         false
       )}
       {parents &&
-        parents.some(
-          (m) => m.uri.endsWith("csv") || m.uri.endsWith("tsv"),
-        ) && (
+        parents.some((m) => m.uri.endsWith("csv") || m.uri.endsWith("tsv")) && (
           <PreviewLink
             current={current}
             text="Table"

--- a/frontend/src/js/components/viewer/PreviewSwitcher.tsx
+++ b/frontend/src/js/components/viewer/PreviewSwitcher.tsx
@@ -197,7 +197,9 @@ class PreviewSwitcher extends React.Component<PreviewSwitcherProps> {
             to="text"
             navigate={this.props.setResourceView}
           />
-        ) : false}
+        ) : (
+          false
+        )}
         {this.props.resource.transcript
           ? this.renderMultiLangLinks(current, "transcript", "Transcript")
           : false}
@@ -217,7 +219,9 @@ class PreviewSwitcher extends React.Component<PreviewSwitcherProps> {
             to="preview"
             navigate={this.props.setResourceView}
           />
-        ) : false}
+        ) : (
+          false
+        )}
         {parents &&
           parents.some(
             (m) => m.uri.endsWith("csv") || m.uri.endsWith("tsv"),
@@ -268,4 +272,3 @@ function mapDispatchToProps(dispatch: GiantDispatch) {
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(PreviewSwitcher);
-


### PR DESCRIPTION
## What does this change?
Whilst working on the UI to show translated text it was getting annoying that this file was still in javascript. This Pr is best reviewed as two separate commits

This PR:
 - Migrates it to typescript in https://github.com/guardian/giant/commit/e4f2002a92af176f502483aaec0a171c61ca7e0b
 - Migrates to a functional component in https://github.com/guardian/giant/commit/d0f0eeb3bee6f6aabe4acd3c0b786c0fce3fdfe9

Replaces https://github.com/guardian/giant/pull/783

I did this entirely with copilot but have tested locally/on playground, seems to move us to a better position

## How has this change been tested?
 - [x] Tested locally
 - [x] Tested on playground
