### PR TITLE
Fix: delete using path/segment boundaries rather than stems

### DIFF
--- a/backend/app/services/manifest/Neo4jManifest.scala
+++ b/backend/app/services/manifest/Neo4jManifest.scala
@@ -1292,7 +1292,7 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
       |OPTIONAL MATCH (w: WorkspaceNode { uri: $uri})
       |OPTIONAL MATCH (b: Blob:Resource { uri: $uri})-[:PARENT]->(f: File)
       |OPTIONAL MATCH (descendant :Resource)
-      |  WHERE descendant.uri STARTS WITH $uri
+      |  WHERE descendant.uri STARTS WITH $uri + '/'
       |DETACH DELETE b, f, w, descendant
       """.stripMargin,
     // Always consider the deletion a success.
@@ -1310,9 +1310,12 @@ class Neo4jManifest(driver: Driver, executionContext: ExecutionContext, queryLog
   // at which point the URL pattern starts again.
   def deleteResourceAndDescendants(uri: Uri): Attempt[Unit] = attemptTransaction { tx =>
     tx.run(
+      // Match the resource itself or descendants below it on a path-segment boundary.
+      // A raw string prefix would also match siblings whose names share the spelling:
+      // deleting ingestion 'coll/batch' must not take 'coll/batch2' with it.
       """
         |MATCH (r: Resource)
-        |WHERE r.uri STARTS WITH $uri
+        |WHERE r.uri = $uri OR r.uri STARTS WITH $uri + '/'
         |DETACH DELETE r
       """.stripMargin,
       parameters(

--- a/backend/test/services/manifest/Neo4JManifestITest.scala
+++ b/backend/test/services/manifest/Neo4JManifestITest.scala
@@ -102,6 +102,55 @@ class Neo4JManifestITest extends AnyFreeSpec
       ingestion.uri shouldBe "test-collection/test-ingestion"
     }
 
+    "Deletion respects path-segment boundaries" - {
+      def fileBlob(fileUri: String, blobUri: String, ingestion: String): Manifest.InsertBlob = {
+        val uri = Uri(fileUri)
+        Manifest.InsertBlob(
+          IngestionFile(uri, Uri(uri.value.split("/").dropRight(1).mkString("/")), 1024L, None, None, None, true),
+          Uri(blobUri),
+          parentBlobs = List.empty,
+          MimeType("application/test"),
+          ingestion,
+          List(English.key),
+          extractors = List.empty,
+          workspace = None,
+          isFastLane = false
+        )
+      }
+
+      "deleting an ingestion does not delete a sibling sharing its name prefix" in {
+        manifest.insertCollection("boundary_test", "boundary_test", "test").eitherValue.isRight shouldBe true
+        insertIngestion(Uri("boundary_test"), Some(Uri("boundary_test/batch"))).eitherValue.isRight shouldBe true
+        insertIngestion(Uri("boundary_test"), Some(Uri("boundary_test/batch2"))).eitherValue.isRight shouldBe true
+
+        manifest.insert(List(fileBlob("boundary_test/batch/a.txt", "boundary-blob-a", "boundary_test/batch")), Uri("boundary_test/batch")).isRight shouldBe true
+        manifest.insert(List(fileBlob("boundary_test/batch2/b.txt", "boundary-blob-b", "boundary_test/batch2")), Uri("boundary_test/batch2")).isRight shouldBe true
+
+        manifest.deleteResourceAndDescendants(Uri("boundary_test/batch")).eitherValue.isRight shouldBe true
+
+        // The deleted ingestion and its file are gone
+        manifest.getIngestion(Uri("boundary_test/batch")).eitherValue.isLeft shouldBe true
+        manifest.getBlobsForFiles(List("boundary_test/batch/a.txt")).toOption.get shouldBe empty
+
+        // The sibling whose name shares the prefix is untouched
+        manifest.getIngestion(Uri("boundary_test/batch2")).eitherValue.isRight shouldBe true
+        manifest.getBlobsForFiles(List("boundary_test/batch2/b.txt")).toOption.get.keySet shouldBe Set("boundary_test/batch2/b.txt")
+      }
+
+      "deleting a collection does not delete a sibling sharing its name prefix" in {
+        manifest.insertCollection("boundco", "boundco", "test").eitherValue.isRight shouldBe true
+        manifest.insertCollection("boundco2", "boundco2", "test").eitherValue.isRight shouldBe true
+        insertIngestion(Uri("boundco"), Some(Uri("boundco/in"))).eitherValue.isRight shouldBe true
+        insertIngestion(Uri("boundco2"), Some(Uri("boundco2/in"))).eitherValue.isRight shouldBe true
+
+        manifest.deleteResourceAndDescendants(Uri("boundco")).eitherValue.isRight shouldBe true
+
+        manifest.getCollection(Uri("boundco")).eitherValue.isLeft shouldBe true
+        manifest.getCollection(Uri("boundco2")).eitherValue.isRight shouldBe true
+        manifest.getIngestion(Uri("boundco2/in")).eitherValue.isRight shouldBe true
+      }
+    }
+
     "Emails" - {
       val person1 = model.Recipient(Some("Bob"), "bob@example.com")
       val person2 = model.Recipient(Some("Alice"), "alice@example.com")


### PR DESCRIPTION
This is actually a two-line change but I also added a test

There's a bug that we should definitely fix before letting anyone else use CLI. Incidentally, the bug is present in the backend generally - it's not in the CLI per se - but mercifully we currently have no UI to delete ingestions.

`deleteResourceAndDescendants` matched resources with `uri STARTS WITH $uri` — a raw string prefix. This means that if I attempted to delete ingestion `collection/batch1`, I would also inadvertently  delete every resource of any sibling whose name shares the spelling - e.g. `collection/batch10`, `collection/batch11` etc - and all the files therein. Likewise, deleting collection `luke` would destroy `luke_2`. 

The match now requires either the exact URI or a `/` immediately after the prefix, so a deletion can never leak into a sibling.

`deleteBlob`'s descendant clause used the same raw prefix. It was safe in practice only because blob URIs are fixed-length hashes (one can never be a strict prefix of another); it now uses the same explicit boundary rather than relying on that property.

Two new integration tests in `Neo4JManifestITest` (ingestion-sibling and collection-sibling cases). Both **fail against the previous query** — the sibling really is destroyed — and pass with the fix. Backend unit suite unaffected.

There are no index implications: the query still anchors on `uri` prefix matching, which uses the existing Resource uri index the same way.