### PR TITLE
[infra] use SSM param for the postgres VPC

### DIFF
--- a/infra/cdk/bin/__snapshots__/cdk.test.ts.snap
+++ b/infra/cdk/bin/__snapshots__/cdk.test.ts.snap
@@ -57,7 +57,7 @@ exports[`Giant's stacks should match the snapshots 1`] = `
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
     "VpcId": {
-      "Default": "/account/vpc/primary/id",
+      "Default": "/account/vpc/giant/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
@@ -249,9 +249,7 @@ exports[`Giant's stacks should match the snapshots 1`] = `
             "Value": "CODE",
           },
         ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
+        "VpcId": "VpcId",
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
@@ -336,9 +334,7 @@ exports[`Giant's stacks should match the snapshots 1`] = `
             "Value": "CODE",
           },
         ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
+        "VpcId": "VpcId",
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
@@ -455,7 +451,7 @@ exports[`Giant's stacks should match the snapshots 2`] = `
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
     "VpcId": {
-      "Default": "/account/vpc/primary/id",
+      "Default": "/account/vpc/giant/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
@@ -647,9 +643,7 @@ exports[`Giant's stacks should match the snapshots 2`] = `
             "Value": "PROD",
           },
         ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
+        "VpcId": "VpcId",
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
@@ -734,9 +728,7 @@ exports[`Giant's stacks should match the snapshots 2`] = `
             "Value": "PROD",
           },
         ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
+        "VpcId": "VpcId",
       },
       "Type": "AWS::EC2::SecurityGroup",
     },

--- a/infra/cdk/lib/constructs/GuStackWithGiantVPC.ts
+++ b/infra/cdk/lib/constructs/GuStackWithGiantVPC.ts
@@ -1,0 +1,21 @@
+import {VPC_SSM_PARAMETER_PREFIX} from "@guardian/cdk/lib/constants/ssm-parameter-paths";
+import {
+	GuStack,
+	type GuStackProps,
+	GuVpcParameter,
+} from '@guardian/cdk/lib/constructs/core';
+import { GuVpc } from '@guardian/cdk/lib/constructs/ec2/vpc';
+import { type App } from 'aws-cdk-lib';
+import type { IVpc } from 'aws-cdk-lib/aws-ec2';
+
+export class GuStackWithGiantVPC extends GuStack {
+	readonly vpc: IVpc;
+
+	constructor(scope: App, id: string, props: GuStackProps) {
+		super(scope, id, props);
+
+		const vpcParameter = GuVpcParameter.getInstance(this);
+		vpcParameter.default = `${VPC_SSM_PARAMETER_PREFIX}/giant/id`;
+		this.vpc = GuVpc.fromId(this, 'GiantVPC', { vpcId: vpcParameter.id });
+	}
+}

--- a/infra/cdk/lib/postgres.ts
+++ b/infra/cdk/lib/postgres.ts
@@ -1,5 +1,4 @@
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuVpc, SubnetType } from '@guardian/cdk/lib/constructs/ec2/vpc';
 import type { App } from 'aws-cdk-lib';
 import { CfnOutput, Duration, Tags } from 'aws-cdk-lib';
@@ -17,12 +16,11 @@ import {
 	PostgresEngineVersion,
 	StorageType,
 } from 'aws-cdk-lib/aws-rds';
+import { GuStackWithGiantVPC } from './constructs/GuStackWithGiantVPC';
 
-export class Postgres extends GuStack {
+export class Postgres extends GuStackWithGiantVPC {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
-
-		const vpc = GuVpc.fromIdParameter(this, 'GiantVPC');
 
 		const dbStorage = 20;
 
@@ -33,12 +31,12 @@ export class Postgres extends GuStack {
 			this,
 			'DatabaseSecurityGroup',
 			{
-				vpc: vpc,
+				vpc: this.vpc,
 			},
 		);
 
 		const database = new DatabaseInstance(this, 'Database', {
-			vpc: vpc,
+			vpc: this.vpc,
 			vpcSubnets: {
 				subnets: GuVpc.subnetsFromParameter(this, {
 					type: SubnetType.PRIVATE,
@@ -77,7 +75,7 @@ export class Postgres extends GuStack {
 		Tags.of(database).add('devx-backup-enabled', 'true');
 
 		const dbAccessSecurityGroup = new SecurityGroup(this, 'db-access', {
-			vpc: vpc,
+			vpc: this.vpc,
 			allowAllOutbound: false,
 		});
 		dbAccessSecurityGroup.addEgressRule(


### PR DESCRIPTION
corrects a long standing mistake/oversight in the default value for the `VpcId` CFN parameter on the stack. This is a fairly academic change since it would only apply to any 'new' postgres stacks created, given the CODE & PROD ones appear to have had their SSM path updated (presumably for a long time) 
<img width="530" height="84" alt="image" src="https://github.com/user-attachments/assets/fafd3918-6dad-461f-a129-7cd36a1af914" />

... but its better to get this right!

NOTE how this is abstracted into `GuStackWithGiantVPC`, which may seem premature but is in anticipation of migrating further infra definitions into CDK here