### PR TITLE
FIXes viewer sidebar getting stale when stepping through search results

### DIFF
--- a/frontend/src/js/components/viewer/ViewerSidebar.js
+++ b/frontend/src/js/components/viewer/ViewerSidebar.js
@@ -35,18 +35,14 @@ class ViewerSidebar extends React.Component {
   };
 
   UNSAFE_componentWillReceiveProps(props) {
-    if (
-      !this.props.isLoadingResource &&
-      props.match.params.uri !== this.props.match.params.uri
-    ) {
+    if (props.match.params.uri !== this.props.match.params.uri) {
       this.props.getResource(props.match.params.uri, props.urlParams.q);
     }
   }
 
   UNSAFE_componentWillMount() {
-    // <Viewer> may have fetched the resource first, so avoid duplicate requests which race each other.
     // Ultimately we'd like the resource fetch to be triggered from a common parent of this and <Viewer>
-    if (!this.props.isLoadingResource && !this.props.resource) {
+    if (!this.props.resource) {
       this.props.getResource(
         this.props.match.params.uri,
         this.props.urlParams.q,


### PR DESCRIPTION
When trying to download an original file, having stepped through a number of search results, it offered a download of the first search result I'd clicked on, I then noticed all the other sidebar content was stale too. 

The fix is simple, the guard (if check) around the fetch for the right information checking the OLD state of `props.isLoadingResource` rather than the new, but regardless this check is a bit pointless since the URI check is sufficient, so I've simplified.

Fixes https://github.com/guardian/giant/issues/799