### PR TITLE
Viewer: fetch and render the resource only when it matches the route uri

### DIFF
--- a/frontend/src/js/components/PageViewerOrFallback.tsx
+++ b/frontend/src/js/components/PageViewerOrFallback.tsx
@@ -35,6 +35,7 @@ import {
   COMBINED_VIEW,
   resolveInitialPagedView,
 } from "./PageViewer/resolveInitialPagedView";
+import { isResourceForUri } from "../util/resourceUtils";
 
 function isCombinedOrUnset(view: string | undefined): boolean {
   return !view || view === COMBINED_VIEW;
@@ -78,9 +79,12 @@ const PageViewerContent: FC<{
   onVisiblePageChange,
 }) => {
   const dispatch = useDispatch();
-  const resource = useSelector<GiantState, Resource | null>(
+  const storeResource = useSelector<GiantState, Resource | null>(
     (state) => state.resource,
   );
+  // The store can hold a resource left over from a previously viewed
+  // document while this one is being fetched — don't render it (#799)
+  const resource = isResourceForUri(storeResource, uri) ? storeResource : null;
   const auth = useSelector((state: GiantState) => state.auth);
   const preferences = useSelector((state: GiantState) => state.app.preferences);
 
@@ -256,9 +260,13 @@ export const PageViewerOrFallback: FC<{}> = () => {
   const view = useSelector<GiantState, string | undefined>(
     (state) => state.urlParams.view,
   );
-  const resource = useSelector<GiantState, Resource | null>(
+  const storeResource = useSelector<GiantState, Resource | null>(
     (state) => state.resource,
   );
+  // The store can hold a resource left over from a previously viewed document
+  // while this one is being fetched. Treat it as absent so the footer (and
+  // its download button) can never act on the wrong document (#799).
+  const resource = isResourceForUri(storeResource, uri) ? storeResource : null;
   const dispatch = useDispatch();
 
   const searchQuery = searchParams.get("q") ?? undefined;

--- a/frontend/src/js/components/viewer/Viewer.tsx
+++ b/frontend/src/js/components/viewer/Viewer.tsx
@@ -35,7 +35,7 @@ import {
 import { Auth } from "../../types/Auth";
 import { GiantDispatch } from "../../types/redux/GiantDispatch";
 import LazyTreeBrowser from "./LazyTreeBrowser";
-import { getDefaultView } from "../../util/resourceUtils";
+import { getDefaultView, isResourceForUri } from "../../util/resourceUtils";
 import DownloadButton from "./DownloadButton";
 import { WorkspaceNavigation } from "../../util/workspaceNavigation";
 
@@ -102,7 +102,13 @@ class Viewer extends React.Component<Props, State> {
 
     // <ViewerSidebar> may have fetched the resource first, so avoid duplicate requests which race each other.
     // Ultimately we'd like the resource fetch to be triggered from a common parent of this and <ViewerSidebar>
-    if (!this.props.isLoadingResource && !this.props.resource) {
+    // The store can also hold a resource left over from a previously viewed
+    // document (#799), which must not suppress the fetch — so check the
+    // resource is actually the one for this route, not merely present.
+    if (
+      !this.props.isLoadingResource &&
+      !isResourceForUri(this.props.resource, this.props.match.params.uri)
+    ) {
       this.props.getResource(
         this.props.match.params.uri,
         this.props.urlParams.q,
@@ -337,7 +343,12 @@ class Viewer extends React.Component<Props, State> {
   }
 
   render() {
-    if (!this.props.resource) {
+    // Render nothing rather than a leftover resource from a previously
+    // viewed document while the right one is being fetched (#799)
+    if (
+      !this.props.resource ||
+      !isResourceForUri(this.props.resource, this.props.match.params.uri)
+    ) {
       return false;
     }
 

--- a/frontend/src/js/components/viewer/ViewerSidebar.js
+++ b/frontend/src/js/components/viewer/ViewerSidebar.js
@@ -15,6 +15,7 @@ import PreviousIcon from "react-icons/lib/md/navigate-before";
 import { getResource } from "../../actions/resources/getResource";
 import { permissionsPropType } from "../../types/User";
 import { getMyPermissions } from "../../actions/users/getMyPermissions";
+import { isResourceForUri } from "../../util/resourceUtils";
 
 class ViewerSidebar extends React.Component {
   static propTypes = {
@@ -35,10 +36,10 @@ class ViewerSidebar extends React.Component {
   };
 
   UNSAFE_componentWillReceiveProps(props) {
-    if (
-      !this.props.isLoadingResource &&
-      props.match.params.uri !== this.props.match.params.uri
-    ) {
+    // Not guarded by isLoadingResource: if the user moves on while a fetch is
+    // still in flight we must fetch the new document regardless, else the
+    // in-flight response would be displayed for the wrong route.
+    if (props.match.params.uri !== this.props.match.params.uri) {
       this.props.getResource(props.match.params.uri, props.urlParams.q);
     }
   }
@@ -46,7 +47,13 @@ class ViewerSidebar extends React.Component {
   UNSAFE_componentWillMount() {
     // <Viewer> may have fetched the resource first, so avoid duplicate requests which race each other.
     // Ultimately we'd like the resource fetch to be triggered from a common parent of this and <Viewer>
-    if (!this.props.isLoadingResource && !this.props.resource) {
+    // The store can also hold a resource left over from a previously viewed
+    // document (#799), which must not suppress the fetch — so check the
+    // resource is actually the one for this route, not merely present.
+    if (
+      !this.props.isLoadingResource &&
+      !isResourceForUri(this.props.resource, this.props.match.params.uri)
+    ) {
       this.props.getResource(
         this.props.match.params.uri,
         this.props.urlParams.q,
@@ -56,7 +63,16 @@ class ViewerSidebar extends React.Component {
   }
 
   render() {
-    if (this.props.resource) {
+    // Render nothing rather than a leftover resource from a previously
+    // viewed document while the right one is being fetched (#799)
+    const resource = isResourceForUri(
+      this.props.resource,
+      this.props.match.params.uri,
+    )
+      ? this.props.resource
+      : null;
+
+    if (resource) {
       return (
         <div
           className={`sidebar ${this.state.collapsed ? "sidebar--collapsed" : ""} viewer__sidebar`}
@@ -71,9 +87,9 @@ class ViewerSidebar extends React.Component {
               {this.state.collapsed ? <NextIcon /> : <PreviousIcon />}
             </button>
           </div>
-          {this.props.resource.type === "blob" ? (
+          {resource.type === "blob" ? (
             <DocumentMetadata
-              resource={this.props.resource}
+              resource={resource}
               config={this.props.config}
               myPermissions={this.props.myPermissions}
               currentView={this.props.urlParams && this.props.urlParams.view}
@@ -81,7 +97,7 @@ class ViewerSidebar extends React.Component {
             />
           ) : (
             <EmailMetadata
-              resource={this.props.resource}
+              resource={resource}
               config={this.props.config}
               isAdmin={this.props.myPermissions.includes(
                 "CanPerformAdminOperations",

--- a/frontend/src/js/util/resourceUtils.spec.ts
+++ b/frontend/src/js/util/resourceUtils.spec.ts
@@ -1,5 +1,9 @@
 import { Resource, HighlightableText } from "../types/Resource";
-import { getDefaultView, hasTextContent } from "./resourceUtils";
+import {
+  getDefaultView,
+  hasTextContent,
+  isResourceForUri,
+} from "./resourceUtils";
 
 function makeHighlightableText(contents: string): HighlightableText {
   return { contents, highlights: [] };
@@ -132,5 +136,37 @@ describe("getDefaultView", () => {
       text: undefined,
     });
     expect(getDefaultView(resource)).toBeUndefined();
+  });
+});
+
+describe("isResourceForUri", () => {
+  test("returns false when there is no resource", () => {
+    expect(isResourceForUri(null, "test/doc.pdf")).toBe(false);
+  });
+
+  test("returns true when the resource uri matches the route uri exactly", () => {
+    const resource = makeResource({ uri: "test/doc.pdf" });
+    expect(isResourceForUri(resource, "test/doc.pdf")).toBe(true);
+  });
+
+  test("returns false when the resource belongs to a different document", () => {
+    const resource = makeResource({ uri: "test/other-doc.pdf" });
+    expect(isResourceForUri(resource, "test/doc.pdf")).toBe(false);
+  });
+
+  test("matches an encoded resource uri against a decoded route uri", () => {
+    const resource = makeResource({ uri: "test/a%20doc.pdf" });
+    expect(isResourceForUri(resource, "test/a doc.pdf")).toBe(true);
+  });
+
+  test("matches a decoded resource uri against an encoded route uri", () => {
+    const resource = makeResource({ uri: "test/a doc.pdf" });
+    expect(isResourceForUri(resource, "test/a%20doc.pdf")).toBe(true);
+  });
+
+  test("copes with a uri that is not valid percent-encoding", () => {
+    const resource = makeResource({ uri: "test/100%.pdf" });
+    expect(isResourceForUri(resource, "test/100%.pdf")).toBe(true);
+    expect(isResourceForUri(resource, "test/other.pdf")).toBe(false);
   });
 });

--- a/frontend/src/js/util/resourceUtils.ts
+++ b/frontend/src/js/util/resourceUtils.ts
@@ -77,6 +77,27 @@ export function getCurrentResource(prefix: string): string {
   return window.location.pathname.split("/").slice(2).join("/");
 }
 
+function safeDecode(uri: string): string {
+  try {
+    return decodeURIComponent(uri);
+  } catch (e) {
+    // Not a valid encoding (e.g. a raw % in a filename) — compare as-is
+    return uri;
+  }
+}
+
+// The uri field of a resource holds the encoded form (see getCurrentResource
+// above) whereas a route param may reach us encoded or decoded depending on
+// how the link was built, so normalise both sides before comparing. Used to
+// detect when the resource in the store belongs to a previously viewed
+// document rather than the one the route points at (#799).
+export function isResourceForUri(
+  resource: { uri: string } | null,
+  routeUri: string,
+): boolean {
+  return resource !== null && safeDecode(resource.uri) === safeDecode(routeUri);
+}
+
 export function hasTextContent(resource: Resource): boolean {
   return !!resource.text && resource.text.contents.trim() !== "";
 }


### PR DESCRIPTION
Re: #799 


`state.resource` in redux can outlive the document it belongs to, and nothing on the paged-document path clears or revalidates it:

1. Opening a **paged** document renders `PageViewer`, which fetches pages by the route uri directly — the legacy `<Viewer>` (whose unmount is what resets the resource) is never mounted. `<ViewerSidebar>` fetches the resource and the store holds it.
2. Hitting **back** to search reuses the cached query and results, so `Search` skips `resetResource()` (it only resets when it actually re-runs a search). The stale resource survives.
3. Opening a **different** result remounts `<ViewerSidebar>`, whose guard was `if (!this.props.resource)` — the stale resource is truthy, so **no fetch happens**. The sidebar, location breadcrumb and the footer's `DownloadButton` (which reads `state.resource`, not the route uri) all act on the previous document, while the main pane correctly fetches the new document's pages by uri.

## Fix

Replace "is a resource present?" with "is the resource **the one for this route**?" via a new `isResourceForUri` helper. It normalises percent-encoding on both sides, since `resource.uri` holds the encoded form while route params can arrive either way (see the long-standing comment on `getCurrentResource`).

- `<ViewerSidebar>` and the legacy `<Viewer>` fetch on mount whenever the stored resource doesn't match the route, and render nothing rather than a stale resource while the right one loads.
- `<PageViewerOrFallback>` treats a non-matching resource as absent, so the footer — and its download button — can never act on the wrong document. This mirrors the uri-tagging pattern already used there for the `pageCount` response.
- The sidebar's uri-change fetch no longer skips while a previous fetch is in flight, which could otherwise pin the in-flight document to the wrong route when stepping quickly between results.

A uri-match check was chosen over dispatching `resetResource()` on unmount because it also covers a stale resource written by the `getBasicResource` paths (`Directory`, `CurrentCollection`), and is immune to an in-flight response landing after a reset.
