### PR TITLE
Bump bouncycastle 1.71 -> 1.84

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,11 +116,11 @@ lazy val backend = (project in file("backend"))
     libraryDependencies ++= Seq(
       ws,
       "commons-codec" % "commons-codec" % "1.11",
-      "org.bouncycastle" % "bcprov-jdk18on" % "1.71",
+      "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
       // required by tikka, used to be part of bcprov-jdk15on, pulled out into a separate library from 1.69 onwards
       // see https://github.com/guardian/giant/pull/92 for details - may be removable if it gets added as an explicit
       // dependency to tikka or another library
-      "org.bouncycastle" % "bcutil-jdk18on" % "1.71",
+      "org.bouncycastle" % "bcutil-jdk18on" % "1.84",
       "commons-io" % "commons-io" % "2.6",
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % "8.11.4",
       "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % "8.6.2",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Upgrade bouncycastle to fix a CVE https://github.com/guardian/giant/security/dependabot/333

## How has this change been tested?
 - [x] Tested on playground by logging in and processing a file
