### PR TITLE
Don't return an error in translation extractor if nothing to translate

### DIFF
--- a/backend/app/extraction/DocumentBodyExtractor.scala
+++ b/backend/app/extraction/DocumentBodyExtractor.scala
@@ -53,7 +53,7 @@ class DocumentBodyExtractor(tika: Tika, index: Index, ingestionServices: Ingesti
         val rawMetadata = metadata.names().map(name => name -> metadata.getValues(name).toSeq).toMap
         val documentBodyDetectedLanguage = ingestionServices.detectLanguage(blob.uri.value, body.trim()).flatMap(_.certainLanguage)
         // if we managed to detect the language and it's not english then add a translation extractor TODO
-        if (documentBodyDetectedLanguage.exists(_ != "en")) {
+        if (documentBodyDetectedLanguage.exists(_ != "en") && body.trim().length > IngestionServices.TRANSLATION_MINIMUM_LENGTH) {
           ingestionServices.addTranslationTodo(blob.uri, params, classOf[ExternalDocumentTranslationExtractor].getSimpleName)
         }
         val enrichedMetadata = MetadataEnrichment.enrich(rawMetadata)

--- a/backend/app/extraction/ExternalTranslationExtractor.scala
+++ b/backend/app/extraction/ExternalTranslationExtractor.scala
@@ -57,7 +57,8 @@ abstract class ExternalTranslationExtractor(manifest: Manifest, index: Index, tr
       if (translationTask.isEmpty) {
         logger.info(s"No non-English text found to translate in blob ${blob.uri.value}")
         ExternalTranscriptionWorker.markExternalExtractorAsComplete(manifest, blob.uri.value, name)
-        Left(NoTextToTranslateFailure(s"No non-English text found to translate in blob ${blob.uri.value}"))
+        // no work to do isn't really a failure so just return a Right here
+        Right()
       } else {
         val job = for {
           languageDataJson <- translationTask.map(task => Right(Json.stringify(Json.toJson(task)))).getOrElse(Left(NoTextToTranslateFailure(s"No non-English text found to translate in blob ${blob.uri.value}")))

--- a/backend/app/extraction/ocr/BaseOcrExtractor.scala
+++ b/backend/app/extraction/ocr/BaseOcrExtractor.scala
@@ -89,7 +89,7 @@ object BaseOcrExtractor extends Logging {
       index.addDocumentOcrTranslationData(uri, lang, lang.iso6391Code).awaitEither(10.second)
     }
     // if the best language is not english, add translation extractor TODO
-    bestLanguage.filter(lang => isNotEnglish(lang.iso6391Code))
+    bestLanguage.filter(lang => isNotEnglish(lang.iso6391Code) && textByLanguage.get(lang).exists(_.length > IngestionServices.TRANSLATION_MINIMUM_LENGTH))
       .foreach { lang =>
         logger.info(s"Selected ${lang.key} OCR of ${uri.value} for translation")
         ingestionServices.addTranslationTodo(uri, params, classOf[ExternalOcrTranslationExtractor].getSimpleName)

--- a/backend/app/services/ingestion/IngestionServices.scala
+++ b/backend/app/services/ingestion/IngestionServices.scala
@@ -67,6 +67,8 @@ trait IngestionServices {
 
 object IngestionServices extends Logging {
 
+  val TRANSLATION_MINIMUM_LENGTH = 10
+
   def isNotEnglish(languageCode: String): Boolean = {
     languageCode.toLowerCase != English.iso6391Code.toLowerCase()
   }


### PR DESCRIPTION
## What does this change?
I noticed a lot of errors in giant related to translation failing because there wasn't anything to translate. I don't think this is an error case, so I've stopped failing the extractor in this situation.

I've also added a minimum length at which text will be translated of 10 characters - could potentially increase this for text and ocr fields but keep it short for emailSubject, but let's see how this goes for now

## How has this change been tested?
 - [ ] Tested locally
 - [x] Tested on playground
