### PR TITLE
If a PDF page contains a massive vector, rasterize it with ghostscript

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,2 @@
 nodejs 24.15.0
 java corretto-21.0.10.7.1
-sbt 1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 nodejs 24.15.0
 java corretto-21.0.10.7.1
+sbt 1

--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -54,22 +54,21 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
 
     try {
       pdDocuments = params.languages.map { lang =>
-        // A single pdfbox parse of the original file, used both for the page count and to spot pages with
-        // pathologically large content streams
-        val inspection = Using(PDDocument.load(file)) { doc =>
+
+        val docInspection: Try[(Int, Boolean)] = Using(PDDocument.load(file)) { doc =>
           (doc.getNumberOfPages, Ocr.hasLargeVectorContent(file, doc))
         }
-        inspection.failed.foreach(e => logger.warn(s"Failed to inspect ${blob.uri} with pdfbox", e))
+        docInspection.failed.foreach(e => logger.warn(s"Failed to inspect ${blob.uri} with pdfbox", e))
 
-        val pages = inspection.map(_._1).toOption
-        val largeVectors = inspection.map(_._2).getOrElse(false)
+        val pages = docInspection.map(_._1).toOption
+        val largeVectors = docInspection.map(_._2).getOrElse(false)
 
         val biggerThanA1 = Ocr.hasPagesBiggerThanA1(file.toPath, stdErrLogger)
         val preProcessPdf = Ocr.preProcessPdf(file.toPath, tmpDir, stdErrLogger, biggerThanA1, largeVectors)
-        val pdfPath = Ocr.invokeOcrMyPdf(lang.ocr, preProcessPdf.getOrElse(file.toPath), None, stdErrLogger, tmpDir, pages, ocrMyPdfFlag)
-        val pdfDoc = PDDocument.load(pdfPath.toFile)
+        val outputPdfPath = Ocr.invokeOcrMyPdf(lang.ocr, preProcessPdf.getOrElse(file.toPath), None, stdErrLogger, tmpDir, pages, ocrMyPdfFlag)
+        val outputPdfDoc = PDDocument.load(outputPdfPath.toFile)
 
-        lang -> (pdfPath, pdfDoc)
+        lang -> (outputPdfPath, outputPdfDoc)
       }.toMap
 
       // All docs have the same number of pages with the same dimensions, just different text from the OCR run per language

--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -54,9 +54,11 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
 
     try {
       pdDocuments = params.languages.map { lang =>
-        val pages = Using(PDDocument.load(file))(_.getNumberOfPages).toOption
+        val pdfBoxDocument = PDDocument.load(file)
+        val pages = Using(pdfBoxDocument)(_.getNumberOfPages).toOption
         val biggerThanA1 = Ocr.hasPagesBiggerThanA1(file.toPath, stdErrLogger)
-        val preProcessPdf = Ocr.preProcessPdf(file.toPath, tmpDir, stdErrLogger, biggerThanA1)
+        val pathologicalVectors = Ocr.hasLargeVectorContent(file, pdfBoxDocument)
+        val preProcessPdf = Ocr.preProcessPdf(file.toPath, tmpDir, stdErrLogger, biggerThanA1, pathologicalVectors)
         val pdfPath = Ocr.invokeOcrMyPdf(lang.ocr, preProcessPdf.getOrElse(file.toPath), None, stdErrLogger, tmpDir, pages, ocrMyPdfFlag)
         val pdfDoc = PDDocument.load(pdfPath.toFile)
 

--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.nio.file.{Files, Path}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.{Try, Using}
+import scala.util.{Failure, Success, Try, Using}
 
 class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages, previewStorage: ObjectStorage,
   ingestionServices: IngestionServices)(implicit ec: ExecutionContext) extends BaseOcrExtractor(scratch, index) with Logging {
@@ -55,17 +55,18 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
     try {
       pdDocuments = params.languages.map { lang =>
 
-        val docInspection: Try[(Int, Boolean)] = Using(PDDocument.load(file)) { doc =>
+        val (numPages, largeVectors) = Using(PDDocument.load(file)) { doc =>
           (doc.getNumberOfPages, Ocr.hasLargeVectorContent(file, doc))
+        } match {
+          case Success((numPages, largeVectors)) =>(Some(numPages), largeVectors)
+          case Failure(exception) =>
+            logger.warn(s"Failed to inspect ${blob.uri} with pdfbox", exception)
+            (None, false)
         }
-        docInspection.failed.foreach(e => logger.warn(s"Failed to inspect ${blob.uri} with pdfbox", e))
-
-        val pages = docInspection.map(_._1).toOption
-        val largeVectors = docInspection.map(_._2).getOrElse(false)
 
         val biggerThanA1 = Ocr.hasPagesBiggerThanA1(file.toPath, stdErrLogger)
         val preProcessPdf = Ocr.preProcessPdf(file.toPath, tmpDir, stdErrLogger, biggerThanA1, largeVectors)
-        val outputPdfPath = Ocr.invokeOcrMyPdf(lang.ocr, preProcessPdf.getOrElse(file.toPath), None, stdErrLogger, tmpDir, pages, ocrMyPdfFlag)
+        val outputPdfPath = Ocr.invokeOcrMyPdf(lang.ocr, preProcessPdf.getOrElse(file.toPath), None, stdErrLogger, tmpDir, numPages, ocrMyPdfFlag)
         val outputPdfDoc = PDDocument.load(outputPdfPath.toFile)
 
         lang -> (outputPdfPath, outputPdfDoc)

--- a/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
+++ b/backend/app/extraction/ocr/OcrMyPdfExtractor.scala
@@ -54,11 +54,18 @@ class OcrMyPdfExtractor(scratch: ScratchSpace, index: Index, pageService: Pages,
 
     try {
       pdDocuments = params.languages.map { lang =>
-        val pdfBoxDocument = PDDocument.load(file)
-        val pages = Using(pdfBoxDocument)(_.getNumberOfPages).toOption
+        // A single pdfbox parse of the original file, used both for the page count and to spot pages with
+        // pathologically large content streams
+        val inspection = Using(PDDocument.load(file)) { doc =>
+          (doc.getNumberOfPages, Ocr.hasLargeVectorContent(file, doc))
+        }
+        inspection.failed.foreach(e => logger.warn(s"Failed to inspect ${blob.uri} with pdfbox", e))
+
+        val pages = inspection.map(_._1).toOption
+        val largeVectors = inspection.map(_._2).getOrElse(false)
+
         val biggerThanA1 = Ocr.hasPagesBiggerThanA1(file.toPath, stdErrLogger)
-        val pathologicalVectors = Ocr.hasLargeVectorContent(file, pdfBoxDocument)
-        val preProcessPdf = Ocr.preProcessPdf(file.toPath, tmpDir, stdErrLogger, biggerThanA1, pathologicalVectors)
+        val preProcessPdf = Ocr.preProcessPdf(file.toPath, tmpDir, stdErrLogger, biggerThanA1, largeVectors)
         val pdfPath = Ocr.invokeOcrMyPdf(lang.ocr, preProcessPdf.getOrElse(file.toPath), None, stdErrLogger, tmpDir, pages, ocrMyPdfFlag)
         val pdfDoc = PDDocument.load(pdfPath.toFile)
 

--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -16,7 +16,7 @@ import scala.concurrent.{Await, Future, TimeoutException, blocking, duration}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
 import scala.sys.process._
-import scala.util.Using
+import scala.util.{Try, Using}
 
 
 
@@ -140,9 +140,10 @@ object Ocr extends Logging {
   // to run tesseract over it anyway.
   private val MAX_PAGE_CONTENT_STREAM_BYTES = 50L * 1024 * 1024 //50mb
 
+  // The caller owns pdfboxDocument and is responsible for closing it
   def hasLargeVectorContent(file: File, pdfboxDocument: PDDocument): Boolean = {
-    val result = Using(pdfboxDocument) { doc =>
-      doc.getPages.asScala.zipWithIndex.exists { case (page, index) =>
+    val result = Try {
+      pdfboxDocument.getPages.asScala.zipWithIndex.exists { case (page, index) =>
         val tooBig = contentStreamExceeds(page, MAX_PAGE_CONTENT_STREAM_BYTES)
         if (tooBig) {
           logger.info(s"Page ${index + 1} of ${file.getName} has a content stream larger than " +

--- a/backend/app/utils/Ocr.scala
+++ b/backend/app/utils/Ocr.scala
@@ -4,15 +4,19 @@ import model.ingestion
 import model.ingestion.{OcrMyPdfFlag, RedoOcr, SkipText}
 
 import java.nio.file.{Files, Path}
+import org.apache.pdfbox.pdmodel.{PDDocument, PDPage}
 import services.TesseractOcrConfig
 import utils.attempt.Failure
 
+import java.io.File
 import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.{Await, Future, TimeoutException, blocking, duration}
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
 import scala.sys.process._
+import scala.util.Using
 
 
 
@@ -88,17 +92,25 @@ object Ocr extends Logging {
   // Also, optionally downsize large pages to a1 - this is important as we use the --redo-ocr setting with ocrmypdf
   // which will cause it to rasterise the whole page at 300dpi - if the page is too big then we will end up with a massive
   // rasterised image that will use too much memory/cpu to process.
-  def preProcessPdf(inputFilePath: Path, tmpDir: Path, stderr: OcrStderrLogger, fitToA1: Boolean): Option[Path] = {
+  // Finally, optionally flatten the pdf to a raster image - see hasPathologicalVectorContent for why.
+  def preProcessPdf(inputFilePath: Path, tmpDir: Path, stderr: OcrStderrLogger, fitToA1: Boolean, rasterise: Boolean): Option[Path] = {
     val tempDownSampledFile = tmpDir.resolve(s"${inputFilePath.getFileName}.downsampled.pdf")
+    val stdout = mutable.Buffer.empty[String]
 
     val cmd = new StringBuilder("gs ")
-    cmd.append("-sDEVICE=pdfwrite ")
-    cmd.append("-dDownsampleColorImages=true ")
-    cmd.append("-dDownsampleGrayImages=true ")
-    cmd.append("-dDownsampleMonoImages=true ")
-    cmd.append("-dColorImageResolution=300 ")
-    cmd.append("-dGrayImageResolution=300 ")
-    cmd.append("-dMonoImageResolution=300 ")
+    if (rasterise) {
+      // Renders every page to a 300dpi image, discarding the vector content entirely
+      cmd.append("-sDEVICE=pdfimage24 ")
+      cmd.append("-r300 ")
+    } else {
+      cmd.append("-sDEVICE=pdfwrite ")
+      cmd.append("-dDownsampleColorImages=true ")
+      cmd.append("-dDownsampleGrayImages=true ")
+      cmd.append("-dDownsampleMonoImages=true ")
+      cmd.append("-dColorImageResolution=300 ")
+      cmd.append("-dGrayImageResolution=300 ")
+      cmd.append("-dMonoImageResolution=300 ")
+    }
     if (fitToA1) {
       cmd.append("-dPDFFitPage ")
       cmd.append("-sPAPERSIZE=a1 ")
@@ -114,6 +126,55 @@ object Ocr extends Logging {
       case _ =>
         logger.warn(s"Failed to down sample the file ${inputFilePath.getFileName}. exit code ${exitCode} .")
         None
+    }
+  }
+
+  // ocrmypdf's --redo-ocr strips any pre-existing invisible text from a page, which it does by parsing the
+  // whole page content stream into memory (as a list of python objects, one per operator). A page containing a
+  // large vector graphic can have a content stream of hundreds of MB - we've seen a single A3 page with 18.7
+  // million lineto operators in a ~300MB content stream, which caused ocrmypdf to consume 7.5GB of memory and
+  // OOM the worker.
+  //
+  // Ghostscript itself copes with these pages fine, so we spot them up front and flatten the pdf to a raster
+  // image before handing it to ocrmypdf. There is no loss of OCR quality because ocrmypdf rasterises the page
+  // to run tesseract over it anyway.
+  private val MAX_PAGE_CONTENT_STREAM_BYTES = 50L * 1024 * 1024 //50mb
+
+  def hasLargeVectorContent(file: File, pdfboxDocument: PDDocument): Boolean = {
+    val result = Using(pdfboxDocument) { doc =>
+      doc.getPages.asScala.zipWithIndex.exists { case (page, index) =>
+        val tooBig = contentStreamExceeds(page, MAX_PAGE_CONTENT_STREAM_BYTES)
+        if (tooBig) {
+          logger.info(s"Page ${index + 1} of ${file.getName} has a content stream larger than " +
+            s"$MAX_PAGE_CONTENT_STREAM_BYTES bytes - the pdf will be flattened to a raster image before OCR")
+        }
+        tooBig
+      }
+    }
+
+    result.failed.foreach { e =>
+      logger.warn(s"Failed to check the content stream size of ${file.getName}", e)
+    }
+
+    result.getOrElse(false)
+  }
+
+  // Streams through the (decompressed) content stream counting bytes, stopping as soon as we exceed the limit
+  // so that we never hold a pathologically large content stream in memory ourselves.
+  private def contentStreamExceeds(page: PDPage, limit: Long): Boolean = {
+    Option(page.getContents).exists { contents =>
+      Using(contents) { in =>
+        val buffer = new Array[Byte](64 * 1024)
+        var total = 0L
+        var read = in.read(buffer)
+
+        while (read != -1 && total <= limit) {
+          total += read
+          read = in.read(buffer)
+        }
+
+        total > limit
+      }.getOrElse(false)
     }
   }
 


### PR DESCRIPTION
## What does this change?

Giant, specifically ocrmypdf, has a problem with PDF files containing massive vector images. (e.g this one https://drive.google.com/drive/u/0/folders/15YG293eQRWbueWXS0Ps4xZlT_FoV_hKD) 

Here we use PDFBox to detect pages with such a massive image and use ghostscript to rasterize the document at 300 DPI, deliberately discarding vector content. Note that the default ocrmypdf behaviour does rasterize at 400DPI but it preserves vector content (flag png16m vs pdfimage24)

A downside of this approach is that it rasterizes the whole PDF even if there's just one page with a giant vector in it. It's definitely possible to just rasterize the page with the vector in it, but it adds quite a bit of complexity - you have to split the PDF and then re-merge it back together I think. I think we can accept the reduced quality because:
 - a document with a vector in it is almost definitely a digital PDF rather than a scan, so the machine readable text will suffice without OCR for most of the text
 - OCR will still be run on the rasterized text so it should be searchable
  - we are hoping to improve our ocr engine anyway, at which points these pre process steps will probably change

Given that we are possibly going to replace ocrmypdf entirely, I think this might be ok for now (though I'm sure Visual OCR will provide a new host of problems...)

## How has this change been tested?
 - [x] Tested locally
 - [x] Tested on playground
 - [x] Tested in prod 😨 

